### PR TITLE
Initial integration of Spotless on only a few files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,41 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.37.0</version>
+                <configuration>
+                    <java>
+                        <includes>
+                            <include>src/main/java/tfw/math/**/*.java</include>
+                            <include>src/main/java/tfw/plot/demo/**/*.java</include>
+                        </includes>
+                        <excludes>
+                            <exclude>src/main/java/tfw/math/BigDecimal.java</exclude>
+                            <exclude>src/main/java/tfw/math/BigInteger.java</exclude>
+                            <exclude>src/main/java/tfw/math/BitSieve.java</exclude>
+                            <exclude>src/main/java/tfw/math/DoubleConsts.java</exclude>
+                            <exclude>src/main/java/tfw/math/FloatConsts.java</exclude>
+                            <exclude>src/main/java/tfw/math/MathContext.java</exclude>
+                            <exclude>src/main/java/tfw/math/MutableBigInteger.java</exclude>
+                            <exclude>src/main/java/tfw/math/RoundingMode.java</exclude>
+                            <exclude>src/main/java/tfw/math/SignedMutableBigInteger.java</exclude>
+                        </excludes>
+                        <palantirJavaFormat>
+                            <version>2.32.0</version>
+                            <style>PALANTIR</style>
+                        </palantirJavaFormat>
+                    </java>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.1.0</version>

--- a/src/main/java/tfw/math/SMBigInteger.java
+++ b/src/main/java/tfw/math/SMBigInteger.java
@@ -1,158 +1,154 @@
 package tfw.math;
 
 public class SMBigInteger extends SignedMutableBigInteger {
-	private static final SMBigInteger TWO_SMBIGINTEGER = new SMBigInteger();
-	
-	static {
-		TWO_SMBIGINTEGER.setValue(2);
-	}
-	
-	// Based on private constructor BigInteger(long).
-	public void setValue(long value) {
-		if (value < 0) {
-			sign = -1;
-			value = -value;
-		}
-		else {
-			sign = 1;
-		}
-		ensureCapacity(2);
-		
-		int highWord = (int)(value >>> 32);
-		
-		if (highWord == 0) {
-			this.value[0] = (int)value;
-			this.intLen = 1;
-		}
-		else {
-			this.value[0] = highWord;
-			this.value[1] = (int)value;
-			this.intLen = 2;
-		}
-		
-		this.offset = 0;
-	}
-	
-	// Based on BigInteger.longValue().
-	public long longValue() {
-		long result = 0;
-		
-		for (int i=offset+intLen-1,p=0 ; i >= offset ; i--,p++) {
-			result += (this.value[i] & BigInteger.LONG_MASK) << 32 * p;
-		}
-		
-		return result;
-	}
-	
-	public long boundedLongValue() {
-		long longValue = longValue();
-		
-		if (intLen > 2) {
-			if (sign == 1) {
-				return Long.MAX_VALUE;
-			}
-			else {
-				return Long.MIN_VALUE;
-			}
-		}
-		else if (intLen == 2) {
-			boolean unsignedLongCompare = (longValue + Long.MIN_VALUE) > (Long.MAX_VALUE+Long.MIN_VALUE);
-			
-			if (sign == 1 && unsignedLongCompare) {
-				return Long.MAX_VALUE;
-			}
-			else if (sign == -1 && unsignedLongCompare) {
-				return Long.MIN_VALUE;
-			}
-		}
-		
-		return sign * longValue;
-	}
-	
-	public void signedDivide(SMBigInteger divisor, SMBigInteger quotient, SMBigInteger remainder) {
-		if (divisor.boundedLongValue() == 0) {
-			throw new ArithmeticException("/ by zero");
-		}
-		
-		quotient.sign = sign * divisor.sign;
-		
-		MutableBigInteger mbi = divide(divisor, quotient, remainder != null);
-		
-		if (remainder != null) {
-			remainder.sign = quotient.sign;
-			remainder.copyValue(mbi);
-		}
-	}
-	
-	public void signedDivide(SMBigInteger divisor, SMBigInteger quotient, RoundingMode roundingMode) {
-		final SMBigInteger buffer1 = new SMBigInteger();
-		final SMBigInteger buffer2 = new SMBigInteger();
-		
-		signedDivide(divisor, quotient, buffer1);
-		
-		if (buffer1.isZero()) {
-			return;
-		}
-		
-		switch (roundingMode) {
-			case UNNECESSARY: return;
-			case DOWN: return;
-			case UP:
-				if (quotient.sign == 1) {
-					quotient.setValue(quotient.boundedLongValue()+1);
-				}
-				else {
-					quotient.setValue(quotient.boundedLongValue()-1);
-				}
-				return;
-			case CEILING:
-				if (quotient.sign == 1) {
-					quotient.setValue(quotient.boundedLongValue()+1);
-				}
-				return;
-			case FLOOR:
-				quotient.setValue(quotient.boundedLongValue()-1);
-				return;
-			case HALF_UP:
-			case HALF_DOWN:
-			case HALF_EVEN:
-			default:
-				break;
-		}
-		
-		buffer1.signedMultiply(TWO_SMBIGINTEGER, buffer2);
-		buffer2.sign = divisor.sign;
-		buffer2.signedSubtract(divisor);
-		
-		switch(roundingMode) {
-		case HALF_DOWN:
-			if (buffer2.sign == 1) {
-				quotient.setValue(quotient.boundedLongValue()+quotient.sign);
-			}
-			break;
-		case HALF_EVEN:
-			if ((buffer2.sign == 1) || (buffer2.sign == 0 && quotient.isOdd())) {
-				quotient.setValue(quotient.boundedLongValue()+quotient.sign);
-			}
-			break;
-		case HALF_UP:
-			if (buffer2.sign != -1) {
-				quotient.setValue(quotient.boundedLongValue()+quotient.sign);
-			}
-			break;
-		case CEILING:
-		case DOWN:
-		case FLOOR:
-		case UNNECESSARY:
-		case UP:
-		default:
-			break;
-		}
-	}
-	
-	public void signedMultiply(SMBigInteger right, SMBigInteger result) {
-		result.sign = sign * right.sign;
-		
-		multiply(right, result);
-	}
+    private static final SMBigInteger TWO_SMBIGINTEGER = new SMBigInteger();
+
+    static {
+        TWO_SMBIGINTEGER.setValue(2);
+    }
+
+    // Based on private constructor BigInteger(long).
+    public void setValue(long value) {
+        if (value < 0) {
+            sign = -1;
+            value = -value;
+        } else {
+            sign = 1;
+        }
+        ensureCapacity(2);
+
+        int highWord = (int) (value >>> 32);
+
+        if (highWord == 0) {
+            this.value[0] = (int) value;
+            this.intLen = 1;
+        } else {
+            this.value[0] = highWord;
+            this.value[1] = (int) value;
+            this.intLen = 2;
+        }
+
+        this.offset = 0;
+    }
+
+    // Based on BigInteger.longValue().
+    public long longValue() {
+        long result = 0;
+
+        for (int i = offset + intLen - 1, p = 0; i >= offset; i--, p++) {
+            result += (this.value[i] & BigInteger.LONG_MASK) << 32 * p;
+        }
+
+        return result;
+    }
+
+    public long boundedLongValue() {
+        long longValue = longValue();
+
+        if (intLen > 2) {
+            if (sign == 1) {
+                return Long.MAX_VALUE;
+            } else {
+                return Long.MIN_VALUE;
+            }
+        } else if (intLen == 2) {
+            boolean unsignedLongCompare = (longValue + Long.MIN_VALUE) > (Long.MAX_VALUE + Long.MIN_VALUE);
+
+            if (sign == 1 && unsignedLongCompare) {
+                return Long.MAX_VALUE;
+            } else if (sign == -1 && unsignedLongCompare) {
+                return Long.MIN_VALUE;
+            }
+        }
+
+        return sign * longValue;
+    }
+
+    public void signedDivide(SMBigInteger divisor, SMBigInteger quotient, SMBigInteger remainder) {
+        if (divisor.boundedLongValue() == 0) {
+            throw new ArithmeticException("/ by zero");
+        }
+
+        quotient.sign = sign * divisor.sign;
+
+        MutableBigInteger mbi = divide(divisor, quotient, remainder != null);
+
+        if (remainder != null) {
+            remainder.sign = quotient.sign;
+            remainder.copyValue(mbi);
+        }
+    }
+
+    public void signedDivide(SMBigInteger divisor, SMBigInteger quotient, RoundingMode roundingMode) {
+        final SMBigInteger buffer1 = new SMBigInteger();
+        final SMBigInteger buffer2 = new SMBigInteger();
+
+        signedDivide(divisor, quotient, buffer1);
+
+        if (buffer1.isZero()) {
+            return;
+        }
+
+        switch (roundingMode) {
+            case UNNECESSARY:
+                return;
+            case DOWN:
+                return;
+            case UP:
+                if (quotient.sign == 1) {
+                    quotient.setValue(quotient.boundedLongValue() + 1);
+                } else {
+                    quotient.setValue(quotient.boundedLongValue() - 1);
+                }
+                return;
+            case CEILING:
+                if (quotient.sign == 1) {
+                    quotient.setValue(quotient.boundedLongValue() + 1);
+                }
+                return;
+            case FLOOR:
+                quotient.setValue(quotient.boundedLongValue() - 1);
+                return;
+            case HALF_UP:
+            case HALF_DOWN:
+            case HALF_EVEN:
+            default:
+                break;
+        }
+
+        buffer1.signedMultiply(TWO_SMBIGINTEGER, buffer2);
+        buffer2.sign = divisor.sign;
+        buffer2.signedSubtract(divisor);
+
+        switch (roundingMode) {
+            case HALF_DOWN:
+                if (buffer2.sign == 1) {
+                    quotient.setValue(quotient.boundedLongValue() + quotient.sign);
+                }
+                break;
+            case HALF_EVEN:
+                if ((buffer2.sign == 1) || (buffer2.sign == 0 && quotient.isOdd())) {
+                    quotient.setValue(quotient.boundedLongValue() + quotient.sign);
+                }
+                break;
+            case HALF_UP:
+                if (buffer2.sign != -1) {
+                    quotient.setValue(quotient.boundedLongValue() + quotient.sign);
+                }
+                break;
+            case CEILING:
+            case DOWN:
+            case FLOOR:
+            case UNNECESSARY:
+            case UP:
+            default:
+                break;
+        }
+    }
+
+    public void signedMultiply(SMBigInteger right, SMBigInteger result) {
+        result.sign = sign * right.sign;
+
+        multiply(right, result);
+    }
 }

--- a/src/main/java/tfw/plot/demo/PlotPanelDemo.java
+++ b/src/main/java/tfw/plot/demo/PlotPanelDemo.java
@@ -17,67 +17,55 @@ import tfw.tsm.ecd.IntegerECD;
 import tfw.tsm.ecd.StatelessTriggerECD;
 import tfw.tsm.ecd.ila.ObjectIlaECD;
 
-public final class PlotPanelDemo
-{
-	private PlotPanelDemo() {}
-	
-	public static void main(String[] args)
-	{
-		
-		final ColorECD BACKGROUND_COLOR_ECD =
-			new ColorECD("backgroundColor");
-		final StatelessTriggerECD GENERATE_GRAPHIC_TRIGGER_ECD =
-			new StatelessTriggerECD("generateGraphicTrigger");
-		final GraphicECD GRAPHIC_ECD =
-			new GraphicECD("graphic");
-		final IntegerECD HEIGHT_ECD =
-			new IntegerECD("height");
-		final ImageECD IMAGE_ECD =
-			new ImageECD("image");
-		final ImageObserverECD IMAGE_OBSERVER_ECD =
-			new ImageObserverECD("imageObserver");
-		final IntegerECD IMAGE_X_ECD =
-			new IntegerECD("imageX");
-		final IntegerECD IMAGE_Y_ECD =
-			new IntegerECD("imageY");
-		final ObjectIlaECD MULTI_GRAPHIC_ECD =
-			new ObjectIlaECD("multiGraphic");
-		final IntegerECD WIDTH_ECD =
-			new IntegerECD("width");
+public final class PlotPanelDemo {
+    private PlotPanelDemo() {}
 
-		JFrameBB frame = new JFrameBB("PlotPanelTest");
-		
-		RootFactory rf2 = new RootFactory();
-//		rf2.setLogging(true);
-		rf2.addEventChannel(BACKGROUND_COLOR_ECD, Color.blue);
-		rf2.addEventChannel(GENERATE_GRAPHIC_TRIGGER_ECD);
-		rf2.addEventChannel(HEIGHT_ECD);
-		rf2.addEventChannel(IMAGE_ECD, new BufferedImage(30, 30, BufferedImage.TYPE_INT_RGB));
-		rf2.addEventChannel(IMAGE_OBSERVER_ECD, frame);
-		rf2.addEventChannel(IMAGE_X_ECD, new Integer(10));
-		rf2.addEventChannel(IMAGE_Y_ECD, new Integer(10));
-		rf2.addEventChannel(MULTI_GRAPHIC_ECD);
-		rf2.addEventChannel(WIDTH_ECD);
-		Root root2 = rf2.create("PlotPanelTest", new BasicTransactionQueue());
-		
-		PlotPanel plotPanel = new PlotPanel(root2);
-		plotPanel.addComponentListenerToBoth(new ComponentInitiator(
-			"PlotPanel", null, null, null, WIDTH_ECD, HEIGHT_ECD));
-		
-//		BackgroundGraphicConverter backgroundConverter = new BackgroundGraphicConverter(
-//			"PlotPanel", GENERATE_GRAPHIC_TRIGGER_ECD, BACKGROUND_COLOR_ECD,
-//			WIDTH_ECD, HEIGHT_ECD, GRAPHIC_ECD);
-//		plotPanel.addGraphicProducer(backgroundConverter, 0);
-//		
-//		DrawImageConverter drawImageConverter = new DrawImageConverter(
-//			"PlotPanel", GENERATE_GRAPHIC_TRIGGER_ECD, IMAGE_ECD, IMAGE_X_ECD,
-//			IMAGE_Y_ECD, IMAGE_OBSERVER_ECD, GRAPHIC_ECD);
-//		plotPanel.addGraphicProducer(drawImageConverter, 1);
-		
-		frame.setContentPane(plotPanel);
-		
-		frame.setSize(500, 500);
-		frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-		frame.setVisible(true);
-	}
+    public static void main(String[] args) {
+
+        final ColorECD BACKGROUND_COLOR_ECD = new ColorECD("backgroundColor");
+        final StatelessTriggerECD GENERATE_GRAPHIC_TRIGGER_ECD = new StatelessTriggerECD("generateGraphicTrigger");
+        final GraphicECD GRAPHIC_ECD = new GraphicECD("graphic");
+        final IntegerECD HEIGHT_ECD = new IntegerECD("height");
+        final ImageECD IMAGE_ECD = new ImageECD("image");
+        final ImageObserverECD IMAGE_OBSERVER_ECD = new ImageObserverECD("imageObserver");
+        final IntegerECD IMAGE_X_ECD = new IntegerECD("imageX");
+        final IntegerECD IMAGE_Y_ECD = new IntegerECD("imageY");
+        final ObjectIlaECD MULTI_GRAPHIC_ECD = new ObjectIlaECD("multiGraphic");
+        final IntegerECD WIDTH_ECD = new IntegerECD("width");
+
+        JFrameBB frame = new JFrameBB("PlotPanelTest");
+
+        RootFactory rf2 = new RootFactory();
+        //		rf2.setLogging(true);
+        rf2.addEventChannel(BACKGROUND_COLOR_ECD, Color.blue);
+        rf2.addEventChannel(GENERATE_GRAPHIC_TRIGGER_ECD);
+        rf2.addEventChannel(HEIGHT_ECD);
+        rf2.addEventChannel(IMAGE_ECD, new BufferedImage(30, 30, BufferedImage.TYPE_INT_RGB));
+        rf2.addEventChannel(IMAGE_OBSERVER_ECD, frame);
+        rf2.addEventChannel(IMAGE_X_ECD, new Integer(10));
+        rf2.addEventChannel(IMAGE_Y_ECD, new Integer(10));
+        rf2.addEventChannel(MULTI_GRAPHIC_ECD);
+        rf2.addEventChannel(WIDTH_ECD);
+        Root root2 = rf2.create("PlotPanelTest", new BasicTransactionQueue());
+
+        PlotPanel plotPanel = new PlotPanel(root2);
+        plotPanel.addComponentListenerToBoth(
+                new ComponentInitiator("PlotPanel", null, null, null, WIDTH_ECD, HEIGHT_ECD));
+
+        //		BackgroundGraphicConverter backgroundConverter = new BackgroundGraphicConverter(
+        //			"PlotPanel", GENERATE_GRAPHIC_TRIGGER_ECD, BACKGROUND_COLOR_ECD,
+        //			WIDTH_ECD, HEIGHT_ECD, GRAPHIC_ECD);
+        //		plotPanel.addGraphicProducer(backgroundConverter, 0);
+        //
+        //		DrawImageConverter drawImageConverter = new DrawImageConverter(
+        //			"PlotPanel", GENERATE_GRAPHIC_TRIGGER_ECD, IMAGE_ECD, IMAGE_X_ECD,
+        //			IMAGE_Y_ECD, IMAGE_OBSERVER_ECD, GRAPHIC_ECD);
+        //		plotPanel.addGraphicProducer(drawImageConverter, 1);
+
+        frame.setContentPane(plotPanel);
+
+        frame.setSize(500, 500);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setVisible(true);
+    }
 }


### PR DESCRIPTION
This PR integrates the Spotless maven plugin with the palantirJavaFormat plugin in order to standardize on a Java code format. It is initially only checking two directories in order to test the include/exclude capability. Performing a "mvn clean verify" checks to see if there are any formatting issues. Performing a "mvn spotless:apply" will fix any formatting issues.