### PR TITLE
Upgrade to JUnit 5 and convert one test class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,15 @@
             <version>2.0.7</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -146,6 +152,14 @@
                         <argument>./src/main/template</argument>
                         <argument>./src/test/template</argument>
                     </arguments>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <argLine>--illegal-access=permit</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/test/java/tfw/math/SMBigIntegerTest.java
+++ b/src/test/java/tfw/math/SMBigIntegerTest.java
@@ -1,11 +1,12 @@
 package tfw.math;
 
-import junit.framework.TestCase;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class SMBigIntegerTest extends TestCase {
+import org.junit.jupiter.api.Test;
+
+class SMBigIntegerTest {
 	@Test
-	public void testSMBigIntegerValue() {
+	void testSMBigIntegerValue() {
 		final SMBigInteger smBigInteger = new SMBigInteger();
 		
 		smBigInteger.setValue(Long.MIN_VALUE);


### PR DESCRIPTION
This PR upgraded from JUnit 4 to JUnit 5. The SMBIntegerTest class was converted to JUnit 5 while all the rest of the tests are run under the vintage JUnit 4.