### PR TITLE
Add Sonar exclusions for tfw/math JDK classes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,15 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.exclusions>src/main/java/tfw/math/BigDecimal.java,
+            src/main/java/tfw/math/BigInteger.java,
+            src/main/java/tfw/math/BitSieve.java,
+            src/main/java/tfw/math/DoubleConsts.java,
+            src/main/java/tfw/math/FloatConsts.java,
+            src/main/java/tfw/math/MathContext.java,
+            src/main/java/tfw/math/MutableBigInteger.java,
+            src/main/java/tfw/math/RoundingMode.java,
+            src/main/java/tfw/math/SignedMutableBigInteger.java</sonar.exclusions>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>tfw-org</sonar.organization>
     </properties>


### PR DESCRIPTION
This PR adds Sonar exclusions to the pom.xml file to stop analyzing the tfw/math JDK classes.