### PR TITLE
Add Maven compiler plugin with full lint options.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,16 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Xlint:all,-options,-path</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>3.1.0</version>
             </plugin>


### PR DESCRIPTION
This PR added the Maven compiler plugin to the pom.xml file in order to turn on full linting and output all of the relevant information.