### PR TITLE
Move Ila zero arg and two arg toArray() methods to Util class.

### DIFF
--- a/src/main/java/tfw/audio/au/Au.java
+++ b/src/main/java/tfw/audio/au/Au.java
@@ -7,6 +7,7 @@ import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaConcatenate;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 import tfw.immutable.ila.byteila.ByteIlaSegment;
+import tfw.immutable.ila.byteila.ByteIlaUtil;
 
 /**
  * The Au class represents a valid AU formatted set of bytes along with
@@ -122,7 +123,7 @@ public final class Au {
 
         auByteData = byteIla;
 
-        magicNumber = unsignedIntFromBytes(byteIla.toArray(0, 4), 0, SUN_MAGIC_NUMBER);
+        magicNumber = unsignedIntFromBytes(ByteIlaUtil.toArray(byteIla, 0, 4), 0, SUN_MAGIC_NUMBER);
 
         if (magicNumber != SUN_MAGIC_NUMBER
                 && magicNumber != DEC_MAGIC_NUMBER
@@ -131,7 +132,7 @@ public final class Au {
             throw new IOException("Unrecognized AU Magic Number!");
         }
 
-        byte[] header = byteIla.toArray(4, 20);
+        byte[] header = ByteIlaUtil.toArray(byteIla, 4, 20);
 
         offset = unsignedIntFromBytes(header, 0, magicNumber);
 

--- a/src/main/java/tfw/audio/demo/AuDemo.java
+++ b/src/main/java/tfw/audio/demo/AuDemo.java
@@ -7,7 +7,9 @@ import tfw.audio.au.NormalizedDoubleIlaFromAuAudioData;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromFile;
+import tfw.immutable.ila.byteila.ByteIlaUtil;
 import tfw.immutable.ila.doubleila.DoubleIla;
+import tfw.immutable.ila.doubleila.DoubleIlaUtil;
 
 public class AuDemo {
 
@@ -24,7 +26,7 @@ public class AuDemo {
         System.out.println("encoding = " + auFileFormat.encoding);
         System.out.println("sampleRate = " + auFileFormat.sampleRate);
         System.out.println("numberOfChannels = " + auFileFormat.numberOfChannels);
-        System.out.println("annotation = " + new String(auFileFormat.annotation.toArray()));
+        System.out.println("annotation = " + new String(ByteIlaUtil.toArray(auFileFormat.annotation)));
         System.out.println("data.length = " + auFileFormat.audioData.length());
 
         DoubleIla normalizedData = NormalizedDoubleIlaFromAuAudioData.create(
@@ -33,7 +35,7 @@ public class AuDemo {
         System.out.println("normalizedData = " + normalizedData);
 
         if (normalizedData != null) {
-            double[] d = normalizedData.toArray(0, 10);
+            double[] d = DoubleIlaUtil.toArray(normalizedData, 0, 10);
             for (int i = 0; i < d.length; i++) {
                 System.out.println("  nD[" + i + "]=" + d[i]);
             }

--- a/src/main/java/tfw/audio/wave/WaveUtil.java
+++ b/src/main/java/tfw/audio/wave/WaveUtil.java
@@ -7,6 +7,7 @@ import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaSegment;
 import tfw.immutable.ila.byteila.ByteIlaSwap;
+import tfw.immutable.ila.byteila.ByteIlaUtil;
 
 public final class WaveUtil {
     private WaveUtil() {}
@@ -15,7 +16,7 @@ public final class WaveUtil {
         if (swap) {
             byteIla = ByteIlaSwap.create(byteIla, 4);
         }
-        byte[] b = ByteIlaSegment.create(byteIla, offset, 4).toArray();
+        byte[] b = ByteIlaUtil.toArray(ByteIlaSegment.create(byteIla, offset, 4));
         ByteArrayInputStream bais = new ByteArrayInputStream(b);
         DataInputStream dis = new DataInputStream(bais);
 
@@ -28,7 +29,7 @@ public final class WaveUtil {
 
     public static int intFromUnsignedTwoBytes(ByteIla byteIla, long offset) throws DataInvalidException {
         byteIla = ByteIlaSwap.create(byteIla, 2);
-        byte[] b = ByteIlaSegment.create(byteIla, offset, 2).toArray();
+        byte[] b = ByteIlaUtil.toArray(ByteIlaSegment.create(byteIla, offset, 2));
         ByteArrayInputStream bais = new ByteArrayInputStream(b);
         DataInputStream dis = new DataInputStream(bais);
 

--- a/src/main/java/tfw/immutable/ila/booleanila/AbstractBooleanIla.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/AbstractBooleanIla.java
@@ -15,21 +15,6 @@ public abstract class AbstractBooleanIla extends AbstractIla implements BooleanI
         super(length);
     }
 
-    public final boolean[] toArray() throws DataInvalidException {
-        if (length() > (long) Integer.MAX_VALUE)
-            throw new ArrayIndexOutOfBoundsException("Ila too large for native array");
-
-        return toArray((long) 0, (int) length());
-    }
-
-    public final boolean[] toArray(long start, int length) throws DataInvalidException {
-        boolean[] result = new boolean[length];
-
-        toArray(result, 0, start, length);
-
-        return result;
-    }
-
     public final void toArray(boolean[] array, int offset, long start, int length) throws DataInvalidException {
         toArray(array, offset, 1, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIla.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIla.java
@@ -8,10 +8,6 @@ import tfw.immutable.ila.ImmutableLongArray;
  * @immutables.types=all
  */
 public interface BooleanIla extends ImmutableLongArray {
-    public boolean[] toArray() throws DataInvalidException;
-
-    public boolean[] toArray(long start, int length) throws DataInvalidException;
-
     public void toArray(boolean[] array, int offset, long start, int length) throws DataInvalidException;
 
     public void toArray(boolean[] array, int offset, int stride, long start, int length) throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaUtil.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaUtil.java
@@ -1,0 +1,21 @@
+package tfw.immutable.ila.booleanila;
+
+import tfw.immutable.DataInvalidException;
+
+public final class BooleanIlaUtil {
+    private BooleanIlaUtil() {}
+
+    public static final boolean[] toArray(final BooleanIla booleanIla) throws DataInvalidException {
+        return toArray(booleanIla, 0, (int) Math.min(booleanIla.length(), Integer.MAX_VALUE));
+    }
+
+    public static final boolean[] toArray(final BooleanIla booleanIla, final long start, final int length)
+            throws DataInvalidException {
+        boolean[] result = new boolean[length];
+
+        booleanIla.toArray(result, 0, start, length);
+
+        return result;
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ila/byteila/AbstractByteIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/AbstractByteIla.java
@@ -15,21 +15,6 @@ public abstract class AbstractByteIla extends AbstractIla implements ByteIla {
         super(length);
     }
 
-    public final byte[] toArray() throws DataInvalidException {
-        if (length() > (long) Integer.MAX_VALUE)
-            throw new ArrayIndexOutOfBoundsException("Ila too large for native array");
-
-        return toArray((long) 0, (int) length());
-    }
-
-    public final byte[] toArray(long start, int length) throws DataInvalidException {
-        byte[] result = new byte[length];
-
-        toArray(result, 0, start, length);
-
-        return result;
-    }
-
     public final void toArray(byte[] array, int offset, long start, int length) throws DataInvalidException {
         toArray(array, offset, 1, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIla.java
@@ -8,10 +8,6 @@ import tfw.immutable.ila.ImmutableLongArray;
  * @immutables.types=all
  */
 public interface ByteIla extends ImmutableLongArray {
-    public byte[] toArray() throws DataInvalidException;
-
-    public byte[] toArray(long start, int length) throws DataInvalidException;
-
     public void toArray(byte[] array, int offset, long start, int length) throws DataInvalidException;
 
     public void toArray(byte[] array, int offset, int stride, long start, int length) throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaUtil.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaUtil.java
@@ -1,0 +1,21 @@
+package tfw.immutable.ila.byteila;
+
+import tfw.immutable.DataInvalidException;
+
+public final class ByteIlaUtil {
+    private ByteIlaUtil() {}
+
+    public static final byte[] toArray(final ByteIla byteIla) throws DataInvalidException {
+        return toArray(byteIla, 0, (int) Math.min(byteIla.length(), Integer.MAX_VALUE));
+    }
+
+    public static final byte[] toArray(final ByteIla byteIla, final long start, final int length)
+            throws DataInvalidException {
+        byte[] result = new byte[length];
+
+        byteIla.toArray(result, 0, start, length);
+
+        return result;
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ila/charila/AbstractCharIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/AbstractCharIla.java
@@ -15,21 +15,6 @@ public abstract class AbstractCharIla extends AbstractIla implements CharIla {
         super(length);
     }
 
-    public final char[] toArray() throws DataInvalidException {
-        if (length() > (long) Integer.MAX_VALUE)
-            throw new ArrayIndexOutOfBoundsException("Ila too large for native array");
-
-        return toArray((long) 0, (int) length());
-    }
-
-    public final char[] toArray(long start, int length) throws DataInvalidException {
-        char[] result = new char[length];
-
-        toArray(result, 0, start, length);
-
-        return result;
-    }
-
     public final void toArray(char[] array, int offset, long start, int length) throws DataInvalidException {
         toArray(array, offset, 1, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/charila/CharIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIla.java
@@ -8,10 +8,6 @@ import tfw.immutable.ila.ImmutableLongArray;
  * @immutables.types=all
  */
 public interface CharIla extends ImmutableLongArray {
-    public char[] toArray() throws DataInvalidException;
-
-    public char[] toArray(long start, int length) throws DataInvalidException;
-
     public void toArray(char[] array, int offset, long start, int length) throws DataInvalidException;
 
     public void toArray(char[] array, int offset, int stride, long start, int length) throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaUtil.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaUtil.java
@@ -1,0 +1,21 @@
+package tfw.immutable.ila.charila;
+
+import tfw.immutable.DataInvalidException;
+
+public final class CharIlaUtil {
+    private CharIlaUtil() {}
+
+    public static final char[] toArray(final CharIla charIla) throws DataInvalidException {
+        return toArray(charIla, 0, (int) Math.min(charIla.length(), Integer.MAX_VALUE));
+    }
+
+    public static final char[] toArray(final CharIla charIla, final long start, final int length)
+            throws DataInvalidException {
+        char[] result = new char[length];
+
+        charIla.toArray(result, 0, start, length);
+
+        return result;
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ila/doubleila/AbstractDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/AbstractDoubleIla.java
@@ -15,21 +15,6 @@ public abstract class AbstractDoubleIla extends AbstractIla implements DoubleIla
         super(length);
     }
 
-    public final double[] toArray() throws DataInvalidException {
-        if (length() > (long) Integer.MAX_VALUE)
-            throw new ArrayIndexOutOfBoundsException("Ila too large for native array");
-
-        return toArray((long) 0, (int) length());
-    }
-
-    public final double[] toArray(long start, int length) throws DataInvalidException {
-        double[] result = new double[length];
-
-        toArray(result, 0, start, length);
-
-        return result;
-    }
-
     public final void toArray(double[] array, int offset, long start, int length) throws DataInvalidException {
         toArray(array, offset, 1, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIla.java
@@ -8,10 +8,6 @@ import tfw.immutable.ila.ImmutableLongArray;
  * @immutables.types=all
  */
 public interface DoubleIla extends ImmutableLongArray {
-    public double[] toArray() throws DataInvalidException;
-
-    public double[] toArray(long start, int length) throws DataInvalidException;
-
     public void toArray(double[] array, int offset, long start, int length) throws DataInvalidException;
 
     public void toArray(double[] array, int offset, int stride, long start, int length) throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaUtil.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaUtil.java
@@ -1,0 +1,21 @@
+package tfw.immutable.ila.doubleila;
+
+import tfw.immutable.DataInvalidException;
+
+public final class DoubleIlaUtil {
+    private DoubleIlaUtil() {}
+
+    public static final double[] toArray(final DoubleIla doubleIla) throws DataInvalidException {
+        return toArray(doubleIla, 0, (int) Math.min(doubleIla.length(), Integer.MAX_VALUE));
+    }
+
+    public static final double[] toArray(final DoubleIla doubleIla, final long start, final int length)
+            throws DataInvalidException {
+        double[] result = new double[length];
+
+        doubleIla.toArray(result, 0, start, length);
+
+        return result;
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ila/floatila/AbstractFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/AbstractFloatIla.java
@@ -15,21 +15,6 @@ public abstract class AbstractFloatIla extends AbstractIla implements FloatIla {
         super(length);
     }
 
-    public final float[] toArray() throws DataInvalidException {
-        if (length() > (long) Integer.MAX_VALUE)
-            throw new ArrayIndexOutOfBoundsException("Ila too large for native array");
-
-        return toArray((long) 0, (int) length());
-    }
-
-    public final float[] toArray(long start, int length) throws DataInvalidException {
-        float[] result = new float[length];
-
-        toArray(result, 0, start, length);
-
-        return result;
-    }
-
     public final void toArray(float[] array, int offset, long start, int length) throws DataInvalidException {
         toArray(array, offset, 1, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIla.java
@@ -8,10 +8,6 @@ import tfw.immutable.ila.ImmutableLongArray;
  * @immutables.types=all
  */
 public interface FloatIla extends ImmutableLongArray {
-    public float[] toArray() throws DataInvalidException;
-
-    public float[] toArray(long start, int length) throws DataInvalidException;
-
     public void toArray(float[] array, int offset, long start, int length) throws DataInvalidException;
 
     public void toArray(float[] array, int offset, int stride, long start, int length) throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaUtil.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaUtil.java
@@ -1,0 +1,21 @@
+package tfw.immutable.ila.floatila;
+
+import tfw.immutable.DataInvalidException;
+
+public final class FloatIlaUtil {
+    private FloatIlaUtil() {}
+
+    public static final float[] toArray(final FloatIla floatIla) throws DataInvalidException {
+        return toArray(floatIla, 0, (int) Math.min(floatIla.length(), Integer.MAX_VALUE));
+    }
+
+    public static final float[] toArray(final FloatIla floatIla, final long start, final int length)
+            throws DataInvalidException {
+        float[] result = new float[length];
+
+        floatIla.toArray(result, 0, start, length);
+
+        return result;
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ila/intila/AbstractIntIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/AbstractIntIla.java
@@ -15,21 +15,6 @@ public abstract class AbstractIntIla extends AbstractIla implements IntIla {
         super(length);
     }
 
-    public final int[] toArray() throws DataInvalidException {
-        if (length() > (long) Integer.MAX_VALUE)
-            throw new ArrayIndexOutOfBoundsException("Ila too large for native array");
-
-        return toArray((long) 0, (int) length());
-    }
-
-    public final int[] toArray(long start, int length) throws DataInvalidException {
-        int[] result = new int[length];
-
-        toArray(result, 0, start, length);
-
-        return result;
-    }
-
     public final void toArray(int[] array, int offset, long start, int length) throws DataInvalidException {
         toArray(array, offset, 1, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/intila/IntIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIla.java
@@ -8,10 +8,6 @@ import tfw.immutable.ila.ImmutableLongArray;
  * @immutables.types=all
  */
 public interface IntIla extends ImmutableLongArray {
-    public int[] toArray() throws DataInvalidException;
-
-    public int[] toArray(long start, int length) throws DataInvalidException;
-
     public void toArray(int[] array, int offset, long start, int length) throws DataInvalidException;
 
     public void toArray(int[] array, int offset, int stride, long start, int length) throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaUtil.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaUtil.java
@@ -1,0 +1,21 @@
+package tfw.immutable.ila.intila;
+
+import tfw.immutable.DataInvalidException;
+
+public final class IntIlaUtil {
+    private IntIlaUtil() {}
+
+    public static final int[] toArray(final IntIla intIla) throws DataInvalidException {
+        return toArray(intIla, 0, (int) Math.min(intIla.length(), Integer.MAX_VALUE));
+    }
+
+    public static final int[] toArray(final IntIla intIla, final long start, final int length)
+            throws DataInvalidException {
+        int[] result = new int[length];
+
+        intIla.toArray(result, 0, start, length);
+
+        return result;
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ila/longila/AbstractLongIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/AbstractLongIla.java
@@ -15,21 +15,6 @@ public abstract class AbstractLongIla extends AbstractIla implements LongIla {
         super(length);
     }
 
-    public final long[] toArray() throws DataInvalidException {
-        if (length() > (long) Integer.MAX_VALUE)
-            throw new ArrayIndexOutOfBoundsException("Ila too large for native array");
-
-        return toArray((long) 0, (int) length());
-    }
-
-    public final long[] toArray(long start, int length) throws DataInvalidException {
-        long[] result = new long[length];
-
-        toArray(result, 0, start, length);
-
-        return result;
-    }
-
     public final void toArray(long[] array, int offset, long start, int length) throws DataInvalidException {
         toArray(array, offset, 1, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/longila/LongIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIla.java
@@ -8,10 +8,6 @@ import tfw.immutable.ila.ImmutableLongArray;
  * @immutables.types=all
  */
 public interface LongIla extends ImmutableLongArray {
-    public long[] toArray() throws DataInvalidException;
-
-    public long[] toArray(long start, int length) throws DataInvalidException;
-
     public void toArray(long[] array, int offset, long start, int length) throws DataInvalidException;
 
     public void toArray(long[] array, int offset, int stride, long start, int length) throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaUtil.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaUtil.java
@@ -1,0 +1,21 @@
+package tfw.immutable.ila.longila;
+
+import tfw.immutable.DataInvalidException;
+
+public final class LongIlaUtil {
+    private LongIlaUtil() {}
+
+    public static final long[] toArray(final LongIla longIla) throws DataInvalidException {
+        return toArray(longIla, 0, (int) Math.min(longIla.length(), Integer.MAX_VALUE));
+    }
+
+    public static final long[] toArray(final LongIla longIla, final long start, final int length)
+            throws DataInvalidException {
+        long[] result = new long[length];
+
+        longIla.toArray(result, 0, start, length);
+
+        return result;
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ila/objectila/AbstractObjectIla.java
+++ b/src/main/java/tfw/immutable/ila/objectila/AbstractObjectIla.java
@@ -15,21 +15,6 @@ public abstract class AbstractObjectIla extends AbstractIla implements ObjectIla
         super(length);
     }
 
-    public final Object[] toArray() throws DataInvalidException {
-        if (length() > (long) Integer.MAX_VALUE)
-            throw new ArrayIndexOutOfBoundsException("Ila too large for native array");
-
-        return toArray((long) 0, (int) length());
-    }
-
-    public final Object[] toArray(long start, int length) throws DataInvalidException {
-        Object[] result = new Object[length];
-
-        toArray(result, 0, start, length);
-
-        return result;
-    }
-
     public final void toArray(Object[] array, int offset, long start, int length) throws DataInvalidException {
         toArray(array, offset, 1, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIla.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIla.java
@@ -8,10 +8,6 @@ import tfw.immutable.ila.ImmutableLongArray;
  * @immutables.types=all
  */
 public interface ObjectIla extends ImmutableLongArray {
-    public Object[] toArray() throws DataInvalidException;
-
-    public Object[] toArray(long start, int length) throws DataInvalidException;
-
     public void toArray(Object[] array, int offset, long start, int length) throws DataInvalidException;
 
     public void toArray(Object[] array, int offset, int stride, long start, int length) throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/shortila/AbstractShortIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/AbstractShortIla.java
@@ -15,21 +15,6 @@ public abstract class AbstractShortIla extends AbstractIla implements ShortIla {
         super(length);
     }
 
-    public final short[] toArray() throws DataInvalidException {
-        if (length() > (long) Integer.MAX_VALUE)
-            throw new ArrayIndexOutOfBoundsException("Ila too large for native array");
-
-        return toArray((long) 0, (int) length());
-    }
-
-    public final short[] toArray(long start, int length) throws DataInvalidException {
-        short[] result = new short[length];
-
-        toArray(result, 0, start, length);
-
-        return result;
-    }
-
     public final void toArray(short[] array, int offset, long start, int length) throws DataInvalidException {
         toArray(array, offset, 1, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIla.java
@@ -8,10 +8,6 @@ import tfw.immutable.ila.ImmutableLongArray;
  * @immutables.types=all
  */
 public interface ShortIla extends ImmutableLongArray {
-    public short[] toArray() throws DataInvalidException;
-
-    public short[] toArray(long start, int length) throws DataInvalidException;
-
     public void toArray(short[] array, int offset, long start, int length) throws DataInvalidException;
 
     public void toArray(short[] array, int offset, int stride, long start, int length) throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaUtil.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaUtil.java
@@ -1,0 +1,21 @@
+package tfw.immutable.ila.shortila;
+
+import tfw.immutable.DataInvalidException;
+
+public final class ShortIlaUtil {
+    private ShortIlaUtil() {}
+
+    public static final short[] toArray(final ShortIla shortIla) throws DataInvalidException {
+        return toArray(shortIla, 0, (int) Math.min(shortIla.length(), Integer.MAX_VALUE));
+    }
+
+    public static final short[] toArray(final ShortIla shortIla, final long start, final int length)
+            throws DataInvalidException {
+        short[] result = new short[length];
+
+        shortIla.toArray(result, 0, start, length);
+
+        return result;
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/plot/PlotPanel.java
+++ b/src/main/java/tfw/plot/PlotPanel.java
@@ -69,7 +69,9 @@ public class PlotPanel extends JPanel implements BranchBox {
                 return;
             }
             try {
-                mg = multiGraphic.toArray();
+                mg = new Object[(int) multiGraphic.length()];
+
+                multiGraphic.toArray(mg, 0, 0, mg.length);
             } catch (DataInvalidException die) {
                 return;
             }

--- a/src/main/java/tfw/swing/ByteInterleavedImagePanel.java
+++ b/src/main/java/tfw/swing/ByteInterleavedImagePanel.java
@@ -9,6 +9,7 @@ import java.awt.image.WritableRaster;
 import tfw.awt.ecd.ColorModelECD;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.byteila.ByteIla;
+import tfw.immutable.ila.byteila.ByteIlaUtil;
 import tfw.immutable.ilm.byteilm.ByteIlm;
 import tfw.tsm.Branch;
 import tfw.tsm.Commit;
@@ -56,7 +57,7 @@ public class ByteInterleavedImagePanel extends JPanelBB {
             DataBufferByte dbb = null;
 
             try {
-                dbb = new DataBufferByte(byteIla.toArray(), (int) byteIla.length());
+                dbb = new DataBufferByte(ByteIlaUtil.toArray(byteIla), (int) byteIla.length());
             } catch (DataInvalidException die) {
                 return;
             }

--- a/src/main/java/tfw/swing/combobox/SelectionAndListCommit.java
+++ b/src/main/java/tfw/swing/combobox/SelectionAndListCommit.java
@@ -66,7 +66,10 @@ public class SelectionAndListCommit extends Commit {
 
     protected void commit() {
         try {
-            final Object[] list = ((ObjectIla) get(listECD)).toArray();
+            final ObjectIla listIla = (ObjectIla) get(listECD);
+            final Object[] list = new Object[(int) listIla.length()];
+
+            listIla.toArray(list, 0, 0, list.length);
 
             EventQueue.invokeLater(new Runnable() {
                 public void run() {

--- a/src/main/java/tfw/swing/list/SelectionAndListCommit.java
+++ b/src/main/java/tfw/swing/list/SelectionAndListCommit.java
@@ -5,6 +5,7 @@ import javax.swing.DefaultListModel;
 import javax.swing.JList;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.intila.IntIla;
+import tfw.immutable.ila.intila.IntIlaUtil;
 import tfw.immutable.ila.objectila.ObjectIla;
 import tfw.tsm.Commit;
 import tfw.tsm.Initiator;
@@ -40,7 +41,10 @@ public class SelectionAndListCommit extends Commit {
     protected void commit() {
         if (isStateChanged(listECD)) {
             try {
-                final Object[] elements = ((ObjectIla) get(listECD)).toArray();
+                final ObjectIla elementsIla = (ObjectIla) get(listECD);
+                final Object[] elements = new Object[(int) elementsIla.length()];
+
+                elementsIla.toArray(elements, 0, 0, elements.length);
 
                 EventQueue.invokeLater(new Runnable() {
                     public void run() {
@@ -56,7 +60,10 @@ public class SelectionAndListCommit extends Commit {
         }
         if (selectedItemsECD != null) {
             try {
-                final Object[] selectedItems = ((ObjectIla) get(selectedItemsECD)).toArray();
+                final ObjectIla selectedItemsIla = (ObjectIla) get(selectedItemsECD);
+                final Object[] selectedItems = new Object[(int) selectedItemsIla.length()];
+
+                selectedItemsIla.toArray(selectedItems, 0, 0, selectedItems.length);
 
                 EventQueue.invokeLater(new Runnable() {
                     public void run() {
@@ -73,7 +80,7 @@ public class SelectionAndListCommit extends Commit {
         }
         if (selectedIndexesECD != null) {
             try {
-                final int[] selectedIndex = ((IntIla) get(selectedIndexesECD)).toArray();
+                final int[] selectedIndex = IntIlaUtil.toArray((IntIla) get(selectedIndexesECD));
 
                 EventQueue.invokeLater(new Runnable() {
                     public void run() {

--- a/src/main/java/tfw/tsm/ObjectIlaMultiplexerStrategy.java
+++ b/src/main/java/tfw/tsm/ObjectIlaMultiplexerStrategy.java
@@ -27,7 +27,9 @@ public class ObjectIlaMultiplexerStrategy implements MultiplexerStrategy {
 
         MyMultiStateAccessor(ObjectIla ila) {
             try {
-                this.objs = ila.toArray();
+                this.objs = new Object[(int) ila.length()];
+
+                ila.toArray(objs, 0, 0, objs.length);
             } catch (DataInvalidException e) {
                 throw new RuntimeException("Exception occurred accessing multiplexed state:" + e.getMessage(), e);
             }
@@ -54,7 +56,10 @@ public class ObjectIlaMultiplexerStrategy implements MultiplexerStrategy {
             array = new Object[0];
         } else {
             try {
-                array = ((ObjectIla) originalMultiState).toArray();
+                ObjectIla objectIla = (ObjectIla) originalMultiState;
+                array = new Object[(int) objectIla.length()];
+
+                objectIla.toArray(array, 0, 0, array.length);
             } catch (DataInvalidException e) {
                 throw new RuntimeException("Exception occurred accessing multiplexed state:" + e.getMessage(), e);
             }

--- a/src/main/java/tfw/visualizer/ClusterConverter.java
+++ b/src/main/java/tfw/visualizer/ClusterConverter.java
@@ -6,6 +6,7 @@ import java.util.TreeSet;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
+import tfw.immutable.ila.longila.LongIlaUtil;
 import tfw.immutable.ila.objectila.ObjectIlaFromArray;
 import tfw.tsm.Converter;
 import tfw.tsm.ecd.ObjectECD;
@@ -41,8 +42,8 @@ public class ClusterConverter extends Converter {
         long[] nodeTos = null;
 
         try {
-            nodeFroms = ((LongIla) get(nodeFromsECD)).toArray();
-            nodeTos = ((LongIla) get(nodeTosECD)).toArray();
+            nodeFroms = LongIlaUtil.toArray((LongIla) get(nodeFromsECD));
+            nodeTos = LongIlaUtil.toArray((LongIla) get(nodeTosECD));
         } catch (DataInvalidException e) {
             return;
         }

--- a/src/main/java/tfw/visualizer/IndexedEdgesFromNodesAndEdges.java
+++ b/src/main/java/tfw/visualizer/IndexedEdgesFromNodesAndEdges.java
@@ -22,36 +22,24 @@ public class IndexedEdgesFromNodesAndEdges {
             return (edges.length());
         }
 
-        public long[] toArray() throws DataInvalidException {
-            Object[] nodeArray = nodes.toArray();
-            Object[] edgeArray = edges.toArray();
-            long[] indexArray = new long[edgeArray.length];
-
-            createIndexArray(nodeArray, edgeArray, indexArray, 0, 1);
-
-            return (indexArray);
-        }
-
-        public long[] toArray(long start, int length) throws DataInvalidException {
-            Object[] nodeArray = nodes.toArray();
-            Object[] edgeArray = edges.toArray(start, length);
-            long[] indexArray = new long[edgeArray.length];
-
-            createIndexArray(nodeArray, edgeArray, indexArray, 0, 1);
-
-            return (indexArray);
-        }
-
+        @Override
         public void toArray(long[] array, int offset, long start, int length) throws DataInvalidException {
-            Object[] nodeArray = nodes.toArray();
-            Object[] edgeArray = edges.toArray(start, length);
+            final Object[] nodeArray = new Object[(int) nodes.length()];
+            final Object[] edgeArray = new Object[length];
+
+            nodes.toArray(nodeArray, 0, 0, nodeArray.length);
+            edges.toArray(edgeArray, 0, start, edgeArray.length);
 
             createIndexArray(nodeArray, edgeArray, array, offset, 1);
         }
 
+        @Override
         public void toArray(long[] array, int offset, int stride, long start, int length) throws DataInvalidException {
-            Object[] nodeArray = nodes.toArray();
-            Object[] edgeArray = edges.toArray(start, length);
+            final Object[] nodeArray = new Object[(int) nodes.length()];
+            final Object[] edgeArray = new Object[length];
+
+            nodes.toArray(nodeArray, 0, 0, nodeArray.length);
+            edges.toArray(edgeArray, 0, start, edgeArray.length);
 
             createIndexArray(nodeArray, edgeArray, array, offset, stride);
         }

--- a/src/main/java/tfw/visualizer/MoveSelectionConverter.java
+++ b/src/main/java/tfw/visualizer/MoveSelectionConverter.java
@@ -2,6 +2,7 @@ package tfw.visualizer;
 
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.booleanila.BooleanIla;
+import tfw.immutable.ila.booleanila.BooleanIlaUtil;
 import tfw.tsm.Converter;
 import tfw.tsm.ecd.BooleanECD;
 import tfw.tsm.ecd.IntegerECD;
@@ -60,7 +61,7 @@ public class MoveSelectionConverter extends Converter {
             int[] rights = null;
 
             try {
-                selectedNodes = ((BooleanIla) get(selectedNodesECD)).toArray();
+                selectedNodes = BooleanIlaUtil.toArray((BooleanIla) get(selectedNodesECD));
                 //				tlbr = ((IntIlm)get(pixelNodeTLBRECD)).toArray();
 
                 tops = tlbr[0];

--- a/src/main/java/tfw/visualizer/SelectionToGraphicConverter.java
+++ b/src/main/java/tfw/visualizer/SelectionToGraphicConverter.java
@@ -8,6 +8,7 @@ import tfw.awt.graphic.SetColorGraphic;
 import tfw.awt.graphic.SetStrokeGraphic;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.booleanila.BooleanIla;
+import tfw.immutable.ila.booleanila.BooleanIlaUtil;
 import tfw.immutable.ilm.intilm.IntIlm;
 import tfw.tsm.Converter;
 import tfw.tsm.ecd.ObjectECD;
@@ -39,7 +40,7 @@ public class SelectionToGraphicConverter extends Converter {
         Graphic graphic = SetStrokeGraphic.create(SetColorGraphic.create(null, Color.red), new BasicStroke(3.0f));
 
         try {
-            selectedNodes = ((BooleanIla) get(selectedNodesECD)).toArray();
+            selectedNodes = BooleanIlaUtil.toArray((BooleanIla) get(selectedNodesECD));
 
             IntIlm intIlm = (IntIlm) get(pixelNodeTLBRECD);
             tlbr = intIlm.toArray();

--- a/src/main/java/tfw/visualizer/SimpleTreeLayoutConverter.java
+++ b/src/main/java/tfw/visualizer/SimpleTreeLayoutConverter.java
@@ -7,6 +7,7 @@ import java.util.TreeSet;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 import tfw.immutable.ila.longila.LongIla;
+import tfw.immutable.ila.longila.LongIlaUtil;
 import tfw.immutable.ila.objectila.ObjectIla;
 import tfw.immutable.ila.objectila.ObjectIlaFromArray;
 import tfw.tsm.Converter;
@@ -45,9 +46,17 @@ public class SimpleTreeLayoutConverter extends Converter {
         Object[] nodeClusterTos = null;
 
         try {
-            nodeClusters = ((ObjectIla) get(nodeClustersECD)).toArray();
-            nodeClusterFroms = ((ObjectIla) get(nodeClusterFromsECD)).toArray();
-            nodeClusterTos = ((ObjectIla) get(nodeClusterTosECD)).toArray();
+            final ObjectIla nodeClustersIla = (ObjectIla) get(nodeClustersECD);
+            final ObjectIla nodeClusterFromsIla = (ObjectIla) get(nodeClusterFromsECD);
+            final ObjectIla nodeClusterTosIla = (ObjectIla) get(nodeClusterTosECD);
+
+            nodeClusters = new Object[(int) nodeClustersIla.length()];
+            nodeClusterFroms = new Object[(int) nodeClusterFromsIla.length()];
+            nodeClusterTos = new Object[(int) nodeClusterTosIla.length()];
+
+            nodeClustersIla.toArray(nodeClusters, 0, 0, nodeClusters.length);
+            nodeClusterFromsIla.toArray(nodeClusterFroms, 0, 0, nodeClusterFroms.length);
+            nodeClusterTosIla.toArray(nodeClusterTos, 0, 0, nodeClusterTos.length);
         } catch (DataInvalidException e) {
             return;
         }
@@ -61,9 +70,9 @@ public class SimpleTreeLayoutConverter extends Converter {
             long[] nodeFroms = null;
 
             try {
-                nodes = ((LongIla) nodeClusters[i]).toArray();
-                nodeTos = ((LongIla) nodeClusterTos[i]).toArray();
-                nodeFroms = ((LongIla) nodeClusterFroms[i]).toArray();
+                nodes = LongIlaUtil.toArray((LongIla) nodeClusters[i]);
+                nodeTos = LongIlaUtil.toArray((LongIla) nodeClusterTos[i]);
+                nodeFroms = LongIlaUtil.toArray((LongIla) nodeClusterFroms[i]);
             } catch (DataInvalidException e) {
                 return;
             }

--- a/src/main/java/tfw/visualizer/graph/GraphSelectionFilter.java
+++ b/src/main/java/tfw/visualizer/graph/GraphSelectionFilter.java
@@ -3,6 +3,7 @@ package tfw.visualizer.graph;
 import java.util.HashSet;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.booleanila.BooleanIla;
+import tfw.immutable.ila.booleanila.BooleanIlaUtil;
 
 public class GraphSelectionFilter {
     private GraphSelectionFilter() {}
@@ -42,7 +43,7 @@ public class GraphSelectionFilter {
             Object[] allNodes = new Object[(int) graph.nodesLength()];
             Object[] allFroms = new Object[(int) graph.edgesLength()];
             Object[] allTos = new Object[(int) graph.edgesLength()];
-            boolean[] selectedNodesArray = selectedNodes.toArray();
+            boolean[] selectedNodesArray = BooleanIlaUtil.toArray(selectedNodes);
 
             graph.toArray(allNodes, 0, 0, (int) graph.nodesLength(), allFroms, allTos, 0, 0, (int) graph.edgesLength());
 

--- a/src/main/template/tfw/immutable/ila/Abstract__Ila.template
+++ b/src/main/template/tfw/immutable/ila/Abstract__Ila.template
@@ -16,21 +16,6 @@ public abstract class Abstract%%NAME%%Ila extends AbstractIla implements %%NAME%
         super(length);
     }
 
-    public final %%TYPE%%[] toArray() throws DataInvalidException {
-        if (length() > (long) Integer.MAX_VALUE)
-            throw new ArrayIndexOutOfBoundsException("Ila too large for native array");
-
-        return toArray((long) 0, (int) length());
-    }
-
-    public final %%TYPE%%[] toArray(long start, int length) throws DataInvalidException {
-        %%TYPE%%[] result = new %%TYPE%%[length];
-
-        toArray(result, 0, start, length);
-
-        return result;
-    }
-
     public final void toArray(%%TYPE%%[] array, int offset, long start, int length) throws DataInvalidException {
         toArray(array, offset, 1, start, length);
     }

--- a/src/main/template/tfw/immutable/ila/__Ila.template
+++ b/src/main/template/tfw/immutable/ila/__Ila.template
@@ -9,10 +9,6 @@ import tfw.immutable.ila.ImmutableLongArray;
  * @immutables.types=all
  */
 public interface %%NAME%%Ila extends ImmutableLongArray {
-    public %%TYPE%%[] toArray() throws DataInvalidException;
-
-    public %%TYPE%%[] toArray(long start, int length) throws DataInvalidException;
-
     public void toArray(%%TYPE%%[] array, int offset, long start, int length) throws DataInvalidException;
 
     public void toArray(%%TYPE%%[] array, int offset, int stride, long start, int length) throws DataInvalidException;

--- a/src/main/template/tfw/immutable/ila/__IlaUtil.template
+++ b/src/main/template/tfw/immutable/ila/__IlaUtil.template
@@ -1,0 +1,21 @@
+// booleanila,byteila,charila,doubleila,floatila,intila,longila,shortila
+package %%PACKAGE%%;
+
+import tfw.immutable.DataInvalidException;
+
+public final class %%NAME%%IlaUtil {
+    private %%NAME%%IlaUtil() {}
+
+    public static final %%TYPE%%[] toArray(final %%NAME%%Ila %%TYPE%%Ila) throws DataInvalidException {
+        return toArray(%%TYPE%%Ila, 0, (int) Math.min(%%TYPE%%Ila.length(), Integer.MAX_VALUE));
+    }
+
+    public static final %%TYPE%%[] toArray(final %%NAME%%Ila %%TYPE%%Ila, final long start, final int length)
+            throws DataInvalidException {
+        %%TYPE%%[] result = new %%TYPE%%[length];
+
+        %%TYPE%%Ila.toArray(result, 0, start, length);
+
+        return result;
+    }
+}

--- a/src/test/java/tfw/audio/ALawTest.java
+++ b/src/test/java/tfw/audio/ALawTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import tfw.audio.byteila.ALawByteIlaFromLinearShortIla;
 import tfw.audio.shortila.LinearShortIlaFromALawByteIla;
 import tfw.immutable.ila.byteila.ByteIla;
+import tfw.immutable.ila.byteila.ByteIlaUtil;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
@@ -27,8 +28,8 @@ class ALawTest {
 
         ByteIla secondALawIla = ALawByteIlaFromLinearShortIla.create(secondLinearIla);
 
-        byte[] firstALawArray = firstALawIla.toArray();
-        byte[] secondALawArray = secondALawIla.toArray();
+        byte[] firstALawArray = ByteIlaUtil.toArray(firstALawIla);
+        byte[] secondALawArray = ByteIlaUtil.toArray(secondALawIla);
 
         assertTrue(Arrays.equals(firstALawArray, secondALawArray));
     }

--- a/src/test/java/tfw/audio/AuAudioDataTest.java
+++ b/src/test/java/tfw/audio/AuAudioDataTest.java
@@ -9,6 +9,7 @@ import tfw.audio.au.AuAudioDataFromNormalizedDoubleIla;
 import tfw.audio.au.NormalizedDoubleIlaFromAuAudioData;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
+import tfw.immutable.ila.byteila.ByteIlaUtil;
 import tfw.immutable.ila.doubleila.DoubleIla;
 
 class AuAudioDataTest {
@@ -29,7 +30,7 @@ class AuAudioDataTest {
                 NormalizedDoubleIlaFromAuAudioData.create(origByteIla, Au.SUN_MAGIC_NUMBER, Au.ISDN_U_LAW_8_BIT);
         ByteIla byteIla = AuAudioDataFromNormalizedDoubleIla.create(doubleIla, Au.ISDN_U_LAW_8_BIT);
 
-        byte[] b = byteIla.toArray();
+        byte[] b = ByteIlaUtil.toArray(byteIla);
 
         assertTrue(Arrays.equals(finalByteArray, b));
     }
@@ -51,7 +52,7 @@ class AuAudioDataTest {
 
         ByteIla byteIla = AuAudioDataFromNormalizedDoubleIla.create(doubleIla, Au.LINEAR_8_BIT);
 
-        byte[] b = byteIla.toArray();
+        byte[] b = ByteIlaUtil.toArray(byteIla);
 
         assertTrue(Arrays.equals(finalByteArray, b));
     }
@@ -69,7 +70,7 @@ class AuAudioDataTest {
                 NormalizedDoubleIlaFromAuAudioData.create(origByteIla, Au.SUN_MAGIC_NUMBER, Au.ISDN_A_LAW_8_BIT);
         ByteIla byteIla = AuAudioDataFromNormalizedDoubleIla.create(doubleIla, Au.ISDN_A_LAW_8_BIT);
 
-        byte[] b = byteIla.toArray();
+        byte[] b = ByteIlaUtil.toArray(byteIla);
 
         assertTrue(Arrays.equals(origByteArray, b));
     }

--- a/src/test/java/tfw/audio/AuTest.java
+++ b/src/test/java/tfw/audio/AuTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import tfw.audio.au.Au;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
+import tfw.immutable.ila.byteila.ByteIlaUtil;
 
 class AuTest {
     @Test
@@ -23,7 +24,7 @@ class AuTest {
 
         Au au2 = new Au(au1.encoding, au1.sampleRate, au1.numberOfChannels, au1.annotation, au1.audioData);
 
-        byte[] auBytes2 = au2.auByteData.toArray();
+        byte[] auBytes2 = ByteIlaUtil.toArray(au2.auByteData);
 
         assertTrue(Arrays.equals(auBytes1, auBytes2), "auBytes1 != auBytes2");
     }

--- a/src/test/java/tfw/audio/MuLawTest.java
+++ b/src/test/java/tfw/audio/MuLawTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import tfw.audio.byteila.MuLawByteIlaFromLinearShortIla;
 import tfw.audio.shortila.LinearShortIlaFromMuLawByteIla;
 import tfw.immutable.ila.byteila.ByteIla;
+import tfw.immutable.ila.byteila.ByteIlaUtil;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
@@ -27,8 +28,8 @@ class MuLawTest {
 
         ByteIla secondMuLawIla = MuLawByteIlaFromLinearShortIla.create(secondLinearIla);
 
-        byte[] firstMuLawArray = firstMuLawIla.toArray();
-        byte[] secondMuLawArray = secondMuLawIla.toArray();
+        byte[] firstMuLawArray = ByteIlaUtil.toArray(firstMuLawIla);
+        byte[] secondMuLawArray = ByteIlaUtil.toArray(secondMuLawIla);
 
         assertTrue(Arrays.equals(firstMuLawArray, secondMuLawArray));
     }

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java
@@ -14,98 +14,14 @@ public final class BooleanIlaCheck {
     public static void checkAll(
             BooleanIla target, BooleanIla actual, int addlOffsetLength, int maxAbsStride, boolean epsilon)
             throws Exception {
-        checkZeroArgImmutability(actual);
-        checkTwoArgImmutability(actual, epsilon);
-        checkTwoFourEquivalence(actual, epsilon);
+        BooleanIlaUtilCheck.checkAll(actual, epsilon);
         checkFourFiveEquivalence(actual, addlOffsetLength, epsilon);
         checkCorrectness(target, actual, addlOffsetLength, maxAbsStride, epsilon);
     }
 
-    public static void checkWithoutCorrectness(BooleanIla ila, int offsetLength, boolean epsilon) throws Exception {
-        checkZeroArgImmutability(ila);
-        checkTwoArgImmutability(ila, epsilon);
-        checkTwoFourEquivalence(ila, epsilon);
-        checkFourFiveEquivalence(ila, offsetLength, epsilon);
-    }
-
-    public static void checkZeroArgImmutability(BooleanIla ila) throws Exception {
-        final long firstLength = ila.length();
-        final boolean[] firstArray = ila.toArray();
-        final long secondLength = ila.length();
-        final boolean[] secondArray = ila.toArray();
-        final long thirdLength = ila.length();
-        final boolean[] thirdArray = ila.toArray();
-        final long fourthLength = ila.length();
-
-        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
-        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
-        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
-
-        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
-        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
-        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
-
-        final Random random = new Random(0);
-        for (int ii = 0; ii < firstLength; ++ii) {
-            secondArray[ii] = random.nextBoolean();
-        }
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            if (firstArray[ii] != thirdArray[ii])
-                throw new Exception("firstArray[" + ii + "] ("
-                        + firstArray[ii] + ") != thirdArray["
-                        + ii + "] (" + thirdArray[ii] + ")");
-        }
-    }
-
-    // also performs zero-two equivalence
-    public static void checkTwoArgImmutability(BooleanIla ila, boolean epsilon) throws Exception {
-        if (epsilon != false) {
-            throw new IllegalArgumentException("epsilon != " + (false) + " not allowed");
-        } else {
-            final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-            final boolean[] baseline = ila.toArray(0, ilaLength);
-            if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
-            for (int length = 1; length <= ilaLength; ++length) {
-                for (long start = 0; start < ilaLength - length + 1; ++start) {
-                    final boolean[] subset = ila.toArray(start, length);
-                    if (subset.length != length) throw new Exception("subset.length != length");
-                    for (int ii = 0; ii < subset.length; ++ii) {
-                        if (!(baseline[ii + (int) start] == subset[ii]))
-                            throw new Exception("subset[" + ii + "] ("
-                                    + subset[ii] + ") !~ baseline["
-                                    + (ii + start) + "] ("
-                                    + baseline[ii + (int) start]
-                                    + ") {length=" + length
-                                    + ",start=" + start + "}");
-                    }
-                }
-            }
-        }
-    }
-
-    public static void checkTwoFourEquivalence(BooleanIla ila, boolean epsilon) throws Exception {
-        if (epsilon != false) {
-            throw new IllegalArgumentException("epsilon != " + (false) + " not allowed");
-        } else {
-            final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-            final boolean[] four = new boolean[ilaLength];
-            for (int length = 1; length <= ilaLength; ++length) {
-                for (long start = 0; start < ilaLength - length + 1; ++start) {
-                    final boolean[] two = ila.toArray(start, length);
-                    ila.toArray(four, 0, start, length);
-                    for (int ii = 0; ii < length; ++ii) {
-                        if (!(four[ii] == two[ii]))
-                            throw new Exception("four[" + ii + "] ("
-                                    + four[ii] + ") !~ two["
-                                    + ii + "] ("
-                                    + two[ii]
-                                    + ") {length=" + length
-                                    + ",start=" + start + "}");
-                    }
-                }
-            }
-        }
+    public static void checkWithoutCorrectness(BooleanIla actual, int offsetLength, boolean epsilon) throws Exception {
+        BooleanIlaUtilCheck.checkAll(actual, epsilon);
+        checkFourFiveEquivalence(actual, offsetLength, epsilon);
     }
 
     public static void checkFourFiveEquivalence(BooleanIla ila, int offsetLength, boolean epsilon) throws Exception {

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaUtilCheck.java
@@ -1,0 +1,108 @@
+package tfw.immutable.ila.booleanila;
+
+import java.util.Random;
+
+/**
+ *
+ * @immutables.types=nonnumeric
+ */
+public final class BooleanIlaUtilCheck {
+    private BooleanIlaUtilCheck() {
+        // non-instantiable class
+    }
+
+    public static void checkAll(BooleanIla actual, boolean epsilon) throws Exception {
+        checkZeroArgImmutability(actual);
+        checkTwoArgImmutability(actual, epsilon);
+        checkTwoFourEquivalence(actual, epsilon);
+    }
+
+    public static void checkZeroArgImmutability(BooleanIla ila) throws Exception {
+        final long firstLength = ila.length();
+        final boolean[] firstArray = BooleanIlaUtil.toArray(ila);
+        final long secondLength = ila.length();
+        final boolean[] secondArray = BooleanIlaUtil.toArray(ila);
+        final long thirdLength = ila.length();
+        final boolean[] thirdArray = BooleanIlaUtil.toArray(ila);
+        final long fourthLength = ila.length();
+
+        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
+        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
+        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
+
+        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
+        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
+        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
+
+        final Random random = new Random(0);
+        for (int ii = 0; ii < firstLength; ++ii) {
+            secondArray[ii] = random.nextBoolean();
+        }
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            if (firstArray[ii] != thirdArray[ii])
+                throw new Exception("firstArray[" + ii + "] ("
+                        + firstArray[ii] + ") != thirdArray["
+                        + ii + "] (" + thirdArray[ii] + ")");
+        }
+    }
+
+    // also performs zero-two equivalence
+    public static void checkTwoArgImmutability(BooleanIla ila, boolean epsilon) throws Exception {
+        if (epsilon != false) {
+            throw new IllegalArgumentException("epsilon != " + (false) + " not allowed");
+        } else {
+            final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+            final boolean[] baseline = BooleanIlaUtil.toArray(ila, 0, ilaLength);
+            if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
+            for (int length = 1; length <= ilaLength; ++length) {
+                for (long start = 0; start < ilaLength - length + 1; ++start) {
+                    final boolean[] subset = BooleanIlaUtil.toArray(ila, start, length);
+                    if (subset.length != length) throw new Exception("subset.length != length");
+                    for (int ii = 0; ii < subset.length; ++ii) {
+                        if (!(baseline[ii + (int) start] == subset[ii]))
+                            throw new Exception("subset[" + ii + "] ("
+                                    + subset[ii] + ") !~ baseline["
+                                    + (ii + start) + "] ("
+                                    + baseline[ii + (int) start]
+                                    + ") {length=" + length
+                                    + ",start=" + start + "}");
+                    }
+                }
+            }
+        }
+    }
+
+    public static void checkTwoFourEquivalence(BooleanIla ila, boolean epsilon) throws Exception {
+        if (epsilon != false) {
+            throw new IllegalArgumentException("epsilon != " + (false) + " not allowed");
+        } else {
+            final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+            final boolean[] four = new boolean[ilaLength];
+            for (int length = 1; length <= ilaLength; ++length) {
+                for (long start = 0; start < ilaLength - length + 1; ++start) {
+                    final boolean[] two = BooleanIlaUtil.toArray(ila, start, length);
+                    ila.toArray(four, 0, start, length);
+                    for (int ii = 0; ii < length; ++ii) {
+                        if (!(four[ii] == two[ii]))
+                            throw new Exception("four[" + ii + "] ("
+                                    + four[ii] + ") !~ two["
+                                    + ii + "] ("
+                                    + two[ii]
+                                    + ") {length=" + length
+                                    + ",start=" + start + "}");
+                    }
+                }
+            }
+        }
+    }
+
+    public static void dump(String msg, boolean[] array) {
+        System.out.println(msg + ":");
+        for (int ii = 0; ii < array.length; ++ii) {
+            System.out.print(" " + array[ii]);
+        }
+        System.out.println();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaCheck.java
@@ -14,97 +14,14 @@ public final class ByteIlaCheck {
     public static void checkAll(
             final ByteIla target, final ByteIla actual, int addlOffsetLength, int maxAbsStride, byte epsilon)
             throws Exception {
-        checkZeroArgImmutability(actual);
-        checkTwoArgImmutability(actual, epsilon);
-        checkTwoFourEquivalence(actual, epsilon);
+        ByteIlaUtilCheck.checkAll(actual, epsilon);
         checkFourFiveEquivalence(actual, addlOffsetLength, epsilon);
         checkCorrectness(target, actual, addlOffsetLength, maxAbsStride, epsilon);
     }
 
     public static void checkWithoutCorrectness(ByteIla ila, int offsetLength, byte epsilon) throws Exception {
-        checkZeroArgImmutability(ila);
-        checkTwoArgImmutability(ila, epsilon);
-        checkTwoFourEquivalence(ila, epsilon);
+        ByteIlaUtilCheck.checkAll(ila, epsilon);
         checkFourFiveEquivalence(ila, offsetLength, epsilon);
-    }
-
-    public static void checkZeroArgImmutability(ByteIla ila) throws Exception {
-        final long firstLength = ila.length();
-        final byte[] firstArray = ila.toArray();
-        final long secondLength = ila.length();
-        final byte[] secondArray = ila.toArray();
-        final long thirdLength = ila.length();
-        final byte[] thirdArray = ila.toArray();
-        final long fourthLength = ila.length();
-
-        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
-        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
-        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
-
-        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
-        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
-        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
-
-        final Random random = new Random(0);
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            secondArray[ii] = (byte) random.nextInt();
-        }
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            if (firstArray[ii] != thirdArray[ii])
-                throw new Exception("firstArray[" + ii + "] ("
-                        + firstArray[ii] + ") != thirdArray["
-                        + ii + "] (" + thirdArray[ii] + ")");
-        }
-    }
-
-    // also performs zero-two equivalence
-    public static void checkTwoArgImmutability(ByteIla ila, byte epsilon) throws Exception {
-        final byte eps = epsilon < 0.0 ? (byte) -epsilon : epsilon;
-        final byte neps = (byte) -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final byte[] baseline = ila.toArray(0, ilaLength);
-        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final byte[] subset = ila.toArray(start, length);
-                if (subset.length != length) throw new Exception("subset.length != length");
-                for (int ii = 0; ii < subset.length; ++ii) {
-                    byte delta = (byte) (baseline[ii + (int) start] - subset[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("subset[" + ii + "] ("
-                                + subset[ii] + ") !~ baseline["
-                                + (ii + start) + "] ("
-                                + baseline[ii + (int) start]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
-    }
-
-    public static void checkTwoFourEquivalence(ByteIla ila, byte epsilon) throws Exception {
-        final byte eps = epsilon < 0.0 ? (byte) -epsilon : epsilon;
-        final byte neps = (byte) -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final byte[] four = new byte[ilaLength];
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final byte[] two = ila.toArray(start, length);
-                ila.toArray(four, 0, start, length);
-                for (int ii = 0; ii < length; ++ii) {
-                    byte delta = (byte) (four[ii] - two[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("four[" + ii + "] ("
-                                + four[ii] + ") !~ two["
-                                + ii + "] ("
-                                + two[ii]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
     }
 
     public static void checkFourFiveEquivalence(ByteIla ila, int offsetLength, byte epsilon) throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaUtilCheck.java
@@ -1,0 +1,107 @@
+package tfw.immutable.ila.byteila;
+
+import java.util.Random;
+
+/**
+ *
+ * @immutables.types=numeric
+ */
+public final class ByteIlaUtilCheck {
+    private ByteIlaUtilCheck() {
+        // non-instantiable class
+    }
+
+    public static void checkAll(final ByteIla actual, byte epsilon) throws Exception {
+        checkZeroArgImmutability(actual);
+        checkTwoArgImmutability(actual, epsilon);
+        checkTwoFourEquivalence(actual, epsilon);
+    }
+
+    public static void checkZeroArgImmutability(ByteIla ila) throws Exception {
+        final long firstLength = ila.length();
+        final byte[] firstArray = ByteIlaUtil.toArray(ila);
+        final long secondLength = ila.length();
+        final byte[] secondArray = ByteIlaUtil.toArray(ila);
+        final long thirdLength = ila.length();
+        final byte[] thirdArray = ByteIlaUtil.toArray(ila);
+        final long fourthLength = ila.length();
+
+        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
+        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
+        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
+
+        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
+        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
+        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
+
+        final Random random = new Random(0);
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            secondArray[ii] = (byte) random.nextInt();
+        }
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            if (firstArray[ii] != thirdArray[ii])
+                throw new Exception("firstArray[" + ii + "] ("
+                        + firstArray[ii] + ") != thirdArray["
+                        + ii + "] (" + thirdArray[ii] + ")");
+        }
+    }
+
+    // also performs zero-two equivalence
+    public static void checkTwoArgImmutability(ByteIla ila, byte epsilon) throws Exception {
+        final byte eps = epsilon < 0.0 ? (byte) -epsilon : epsilon;
+        final byte neps = (byte) -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final byte[] baseline = ByteIlaUtil.toArray(ila, 0, ilaLength);
+        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final byte[] subset = ByteIlaUtil.toArray(ila, start, length);
+                if (subset.length != length) throw new Exception("subset.length != length");
+                for (int ii = 0; ii < subset.length; ++ii) {
+                    byte delta = (byte) (baseline[ii + (int) start] - subset[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("subset[" + ii + "] ("
+                                + subset[ii] + ") !~ baseline["
+                                + (ii + start) + "] ("
+                                + baseline[ii + (int) start]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void checkTwoFourEquivalence(ByteIla ila, byte epsilon) throws Exception {
+        final byte eps = epsilon < 0.0 ? (byte) -epsilon : epsilon;
+        final byte neps = (byte) -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final byte[] four = new byte[ilaLength];
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final byte[] two = ByteIlaUtil.toArray(ila, start, length);
+                ila.toArray(four, 0, start, length);
+                for (int ii = 0; ii < length; ++ii) {
+                    byte delta = (byte) (four[ii] - two[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("four[" + ii + "] ("
+                                + four[ii] + ") !~ two["
+                                + ii + "] ("
+                                + two[ii]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void dump(String msg, byte[] array) {
+        System.out.println(msg + ":");
+        for (int ii = 0; ii < array.length; ++ii) {
+            System.out.print(" " + array[ii]);
+        }
+        System.out.println();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaCheck.java
@@ -14,97 +14,14 @@ public final class CharIlaCheck {
     public static void checkAll(
             final CharIla target, final CharIla actual, int addlOffsetLength, int maxAbsStride, char epsilon)
             throws Exception {
-        checkZeroArgImmutability(actual);
-        checkTwoArgImmutability(actual, epsilon);
-        checkTwoFourEquivalence(actual, epsilon);
+        CharIlaUtilCheck.checkAll(actual, epsilon);
         checkFourFiveEquivalence(actual, addlOffsetLength, epsilon);
         checkCorrectness(target, actual, addlOffsetLength, maxAbsStride, epsilon);
     }
 
     public static void checkWithoutCorrectness(CharIla ila, int offsetLength, char epsilon) throws Exception {
-        checkZeroArgImmutability(ila);
-        checkTwoArgImmutability(ila, epsilon);
-        checkTwoFourEquivalence(ila, epsilon);
+        CharIlaUtilCheck.checkAll(ila, epsilon);
         checkFourFiveEquivalence(ila, offsetLength, epsilon);
-    }
-
-    public static void checkZeroArgImmutability(CharIla ila) throws Exception {
-        final long firstLength = ila.length();
-        final char[] firstArray = ila.toArray();
-        final long secondLength = ila.length();
-        final char[] secondArray = ila.toArray();
-        final long thirdLength = ila.length();
-        final char[] thirdArray = ila.toArray();
-        final long fourthLength = ila.length();
-
-        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
-        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
-        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
-
-        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
-        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
-        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
-
-        final Random random = new Random(0);
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            secondArray[ii] = (char) random.nextInt();
-        }
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            if (firstArray[ii] != thirdArray[ii])
-                throw new Exception("firstArray[" + ii + "] ("
-                        + firstArray[ii] + ") != thirdArray["
-                        + ii + "] (" + thirdArray[ii] + ")");
-        }
-    }
-
-    // also performs zero-two equivalence
-    public static void checkTwoArgImmutability(CharIla ila, char epsilon) throws Exception {
-        final char eps = epsilon < 0.0 ? (char) -epsilon : epsilon;
-        final char neps = (char) -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final char[] baseline = ila.toArray(0, ilaLength);
-        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final char[] subset = ila.toArray(start, length);
-                if (subset.length != length) throw new Exception("subset.length != length");
-                for (int ii = 0; ii < subset.length; ++ii) {
-                    char delta = (char) (baseline[ii + (int) start] - subset[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("subset[" + ii + "] ("
-                                + subset[ii] + ") !~ baseline["
-                                + (ii + start) + "] ("
-                                + baseline[ii + (int) start]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
-    }
-
-    public static void checkTwoFourEquivalence(CharIla ila, char epsilon) throws Exception {
-        final char eps = epsilon < 0.0 ? (char) -epsilon : epsilon;
-        final char neps = (char) -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final char[] four = new char[ilaLength];
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final char[] two = ila.toArray(start, length);
-                ila.toArray(four, 0, start, length);
-                for (int ii = 0; ii < length; ++ii) {
-                    char delta = (char) (four[ii] - two[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("four[" + ii + "] ("
-                                + four[ii] + ") !~ two["
-                                + ii + "] ("
-                                + two[ii]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
     }
 
     public static void checkFourFiveEquivalence(CharIla ila, int offsetLength, char epsilon) throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaUtilCheck.java
@@ -1,0 +1,107 @@
+package tfw.immutable.ila.charila;
+
+import java.util.Random;
+
+/**
+ *
+ * @immutables.types=numeric
+ */
+public final class CharIlaUtilCheck {
+    private CharIlaUtilCheck() {
+        // non-instantiable class
+    }
+
+    public static void checkAll(final CharIla actual, char epsilon) throws Exception {
+        checkZeroArgImmutability(actual);
+        checkTwoArgImmutability(actual, epsilon);
+        checkTwoFourEquivalence(actual, epsilon);
+    }
+
+    public static void checkZeroArgImmutability(CharIla ila) throws Exception {
+        final long firstLength = ila.length();
+        final char[] firstArray = CharIlaUtil.toArray(ila);
+        final long secondLength = ila.length();
+        final char[] secondArray = CharIlaUtil.toArray(ila);
+        final long thirdLength = ila.length();
+        final char[] thirdArray = CharIlaUtil.toArray(ila);
+        final long fourthLength = ila.length();
+
+        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
+        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
+        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
+
+        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
+        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
+        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
+
+        final Random random = new Random(0);
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            secondArray[ii] = (char) random.nextInt();
+        }
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            if (firstArray[ii] != thirdArray[ii])
+                throw new Exception("firstArray[" + ii + "] ("
+                        + firstArray[ii] + ") != thirdArray["
+                        + ii + "] (" + thirdArray[ii] + ")");
+        }
+    }
+
+    // also performs zero-two equivalence
+    public static void checkTwoArgImmutability(CharIla ila, char epsilon) throws Exception {
+        final char eps = epsilon < 0.0 ? (char) -epsilon : epsilon;
+        final char neps = (char) -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final char[] baseline = CharIlaUtil.toArray(ila, 0, ilaLength);
+        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final char[] subset = CharIlaUtil.toArray(ila, start, length);
+                if (subset.length != length) throw new Exception("subset.length != length");
+                for (int ii = 0; ii < subset.length; ++ii) {
+                    char delta = (char) (baseline[ii + (int) start] - subset[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("subset[" + ii + "] ("
+                                + subset[ii] + ") !~ baseline["
+                                + (ii + start) + "] ("
+                                + baseline[ii + (int) start]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void checkTwoFourEquivalence(CharIla ila, char epsilon) throws Exception {
+        final char eps = epsilon < 0.0 ? (char) -epsilon : epsilon;
+        final char neps = (char) -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final char[] four = new char[ilaLength];
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final char[] two = CharIlaUtil.toArray(ila, start, length);
+                ila.toArray(four, 0, start, length);
+                for (int ii = 0; ii < length; ++ii) {
+                    char delta = (char) (four[ii] - two[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("four[" + ii + "] ("
+                                + four[ii] + ") !~ two["
+                                + ii + "] ("
+                                + two[ii]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void dump(String msg, char[] array) {
+        System.out.println(msg + ":");
+        for (int ii = 0; ii < array.length; ++ii) {
+            System.out.print(" " + array[ii]);
+        }
+        System.out.println();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaCheck.java
@@ -14,97 +14,14 @@ public final class DoubleIlaCheck {
     public static void checkAll(
             final DoubleIla target, final DoubleIla actual, int addlOffsetLength, int maxAbsStride, double epsilon)
             throws Exception {
-        checkZeroArgImmutability(actual);
-        checkTwoArgImmutability(actual, epsilon);
-        checkTwoFourEquivalence(actual, epsilon);
+        DoubleIlaUtilCheck.checkAll(actual, epsilon);
         checkFourFiveEquivalence(actual, addlOffsetLength, epsilon);
         checkCorrectness(target, actual, addlOffsetLength, maxAbsStride, epsilon);
     }
 
     public static void checkWithoutCorrectness(DoubleIla ila, int offsetLength, double epsilon) throws Exception {
-        checkZeroArgImmutability(ila);
-        checkTwoArgImmutability(ila, epsilon);
-        checkTwoFourEquivalence(ila, epsilon);
+        DoubleIlaUtilCheck.checkAll(ila, epsilon);
         checkFourFiveEquivalence(ila, offsetLength, epsilon);
-    }
-
-    public static void checkZeroArgImmutability(DoubleIla ila) throws Exception {
-        final long firstLength = ila.length();
-        final double[] firstArray = ila.toArray();
-        final long secondLength = ila.length();
-        final double[] secondArray = ila.toArray();
-        final long thirdLength = ila.length();
-        final double[] thirdArray = ila.toArray();
-        final long fourthLength = ila.length();
-
-        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
-        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
-        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
-
-        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
-        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
-        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
-
-        final Random random = new Random(0);
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            secondArray[ii] = random.nextDouble();
-        }
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            if (firstArray[ii] != thirdArray[ii])
-                throw new Exception("firstArray[" + ii + "] ("
-                        + firstArray[ii] + ") != thirdArray["
-                        + ii + "] (" + thirdArray[ii] + ")");
-        }
-    }
-
-    // also performs zero-two equivalence
-    public static void checkTwoArgImmutability(DoubleIla ila, double epsilon) throws Exception {
-        final double eps = epsilon < 0.0 ? -epsilon : epsilon;
-        final double neps = -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final double[] baseline = ila.toArray(0, ilaLength);
-        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final double[] subset = ila.toArray(start, length);
-                if (subset.length != length) throw new Exception("subset.length != length");
-                for (int ii = 0; ii < subset.length; ++ii) {
-                    double delta = (baseline[ii + (int) start] - subset[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("subset[" + ii + "] ("
-                                + subset[ii] + ") !~ baseline["
-                                + (ii + start) + "] ("
-                                + baseline[ii + (int) start]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
-    }
-
-    public static void checkTwoFourEquivalence(DoubleIla ila, double epsilon) throws Exception {
-        final double eps = epsilon < 0.0 ? -epsilon : epsilon;
-        final double neps = -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final double[] four = new double[ilaLength];
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final double[] two = ila.toArray(start, length);
-                ila.toArray(four, 0, start, length);
-                for (int ii = 0; ii < length; ++ii) {
-                    double delta = (four[ii] - two[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("four[" + ii + "] ("
-                                + four[ii] + ") !~ two["
-                                + ii + "] ("
-                                + two[ii]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
     }
 
     public static void checkFourFiveEquivalence(DoubleIla ila, int offsetLength, double epsilon) throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaUtilCheck.java
@@ -1,0 +1,107 @@
+package tfw.immutable.ila.doubleila;
+
+import java.util.Random;
+
+/**
+ *
+ * @immutables.types=numeric
+ */
+public final class DoubleIlaUtilCheck {
+    private DoubleIlaUtilCheck() {
+        // non-instantiable class
+    }
+
+    public static void checkAll(final DoubleIla actual, double epsilon) throws Exception {
+        checkZeroArgImmutability(actual);
+        checkTwoArgImmutability(actual, epsilon);
+        checkTwoFourEquivalence(actual, epsilon);
+    }
+
+    public static void checkZeroArgImmutability(DoubleIla ila) throws Exception {
+        final long firstLength = ila.length();
+        final double[] firstArray = DoubleIlaUtil.toArray(ila);
+        final long secondLength = ila.length();
+        final double[] secondArray = DoubleIlaUtil.toArray(ila);
+        final long thirdLength = ila.length();
+        final double[] thirdArray = DoubleIlaUtil.toArray(ila);
+        final long fourthLength = ila.length();
+
+        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
+        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
+        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
+
+        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
+        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
+        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
+
+        final Random random = new Random(0);
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            secondArray[ii] = random.nextDouble();
+        }
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            if (firstArray[ii] != thirdArray[ii])
+                throw new Exception("firstArray[" + ii + "] ("
+                        + firstArray[ii] + ") != thirdArray["
+                        + ii + "] (" + thirdArray[ii] + ")");
+        }
+    }
+
+    // also performs zero-two equivalence
+    public static void checkTwoArgImmutability(DoubleIla ila, double epsilon) throws Exception {
+        final double eps = epsilon < 0.0 ? -epsilon : epsilon;
+        final double neps = -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final double[] baseline = DoubleIlaUtil.toArray(ila, 0, ilaLength);
+        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final double[] subset = DoubleIlaUtil.toArray(ila, start, length);
+                if (subset.length != length) throw new Exception("subset.length != length");
+                for (int ii = 0; ii < subset.length; ++ii) {
+                    double delta = (baseline[ii + (int) start] - subset[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("subset[" + ii + "] ("
+                                + subset[ii] + ") !~ baseline["
+                                + (ii + start) + "] ("
+                                + baseline[ii + (int) start]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void checkTwoFourEquivalence(DoubleIla ila, double epsilon) throws Exception {
+        final double eps = epsilon < 0.0 ? -epsilon : epsilon;
+        final double neps = -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final double[] four = new double[ilaLength];
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final double[] two = DoubleIlaUtil.toArray(ila, start, length);
+                ila.toArray(four, 0, start, length);
+                for (int ii = 0; ii < length; ++ii) {
+                    double delta = (four[ii] - two[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("four[" + ii + "] ("
+                                + four[ii] + ") !~ two["
+                                + ii + "] ("
+                                + two[ii]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void dump(String msg, double[] array) {
+        System.out.println(msg + ":");
+        for (int ii = 0; ii < array.length; ++ii) {
+            System.out.print(" " + array[ii]);
+        }
+        System.out.println();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaCheck.java
@@ -14,97 +14,14 @@ public final class FloatIlaCheck {
     public static void checkAll(
             final FloatIla target, final FloatIla actual, int addlOffsetLength, int maxAbsStride, float epsilon)
             throws Exception {
-        checkZeroArgImmutability(actual);
-        checkTwoArgImmutability(actual, epsilon);
-        checkTwoFourEquivalence(actual, epsilon);
+        FloatIlaUtilCheck.checkAll(actual, epsilon);
         checkFourFiveEquivalence(actual, addlOffsetLength, epsilon);
         checkCorrectness(target, actual, addlOffsetLength, maxAbsStride, epsilon);
     }
 
     public static void checkWithoutCorrectness(FloatIla ila, int offsetLength, float epsilon) throws Exception {
-        checkZeroArgImmutability(ila);
-        checkTwoArgImmutability(ila, epsilon);
-        checkTwoFourEquivalence(ila, epsilon);
+        FloatIlaUtilCheck.checkAll(ila, epsilon);
         checkFourFiveEquivalence(ila, offsetLength, epsilon);
-    }
-
-    public static void checkZeroArgImmutability(FloatIla ila) throws Exception {
-        final long firstLength = ila.length();
-        final float[] firstArray = ila.toArray();
-        final long secondLength = ila.length();
-        final float[] secondArray = ila.toArray();
-        final long thirdLength = ila.length();
-        final float[] thirdArray = ila.toArray();
-        final long fourthLength = ila.length();
-
-        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
-        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
-        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
-
-        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
-        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
-        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
-
-        final Random random = new Random(0);
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            secondArray[ii] = random.nextFloat();
-        }
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            if (firstArray[ii] != thirdArray[ii])
-                throw new Exception("firstArray[" + ii + "] ("
-                        + firstArray[ii] + ") != thirdArray["
-                        + ii + "] (" + thirdArray[ii] + ")");
-        }
-    }
-
-    // also performs zero-two equivalence
-    public static void checkTwoArgImmutability(FloatIla ila, float epsilon) throws Exception {
-        final float eps = epsilon < 0.0 ? -epsilon : epsilon;
-        final float neps = -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final float[] baseline = ila.toArray(0, ilaLength);
-        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final float[] subset = ila.toArray(start, length);
-                if (subset.length != length) throw new Exception("subset.length != length");
-                for (int ii = 0; ii < subset.length; ++ii) {
-                    float delta = (baseline[ii + (int) start] - subset[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("subset[" + ii + "] ("
-                                + subset[ii] + ") !~ baseline["
-                                + (ii + start) + "] ("
-                                + baseline[ii + (int) start]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
-    }
-
-    public static void checkTwoFourEquivalence(FloatIla ila, float epsilon) throws Exception {
-        final float eps = epsilon < 0.0 ? -epsilon : epsilon;
-        final float neps = -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final float[] four = new float[ilaLength];
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final float[] two = ila.toArray(start, length);
-                ila.toArray(four, 0, start, length);
-                for (int ii = 0; ii < length; ++ii) {
-                    float delta = (four[ii] - two[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("four[" + ii + "] ("
-                                + four[ii] + ") !~ two["
-                                + ii + "] ("
-                                + two[ii]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
     }
 
     public static void checkFourFiveEquivalence(FloatIla ila, int offsetLength, float epsilon) throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaUtilCheck.java
@@ -1,0 +1,107 @@
+package tfw.immutable.ila.floatila;
+
+import java.util.Random;
+
+/**
+ *
+ * @immutables.types=numeric
+ */
+public final class FloatIlaUtilCheck {
+    private FloatIlaUtilCheck() {
+        // non-instantiable class
+    }
+
+    public static void checkAll(final FloatIla actual, float epsilon) throws Exception {
+        checkZeroArgImmutability(actual);
+        checkTwoArgImmutability(actual, epsilon);
+        checkTwoFourEquivalence(actual, epsilon);
+    }
+
+    public static void checkZeroArgImmutability(FloatIla ila) throws Exception {
+        final long firstLength = ila.length();
+        final float[] firstArray = FloatIlaUtil.toArray(ila);
+        final long secondLength = ila.length();
+        final float[] secondArray = FloatIlaUtil.toArray(ila);
+        final long thirdLength = ila.length();
+        final float[] thirdArray = FloatIlaUtil.toArray(ila);
+        final long fourthLength = ila.length();
+
+        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
+        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
+        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
+
+        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
+        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
+        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
+
+        final Random random = new Random(0);
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            secondArray[ii] = random.nextFloat();
+        }
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            if (firstArray[ii] != thirdArray[ii])
+                throw new Exception("firstArray[" + ii + "] ("
+                        + firstArray[ii] + ") != thirdArray["
+                        + ii + "] (" + thirdArray[ii] + ")");
+        }
+    }
+
+    // also performs zero-two equivalence
+    public static void checkTwoArgImmutability(FloatIla ila, float epsilon) throws Exception {
+        final float eps = epsilon < 0.0 ? -epsilon : epsilon;
+        final float neps = -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final float[] baseline = FloatIlaUtil.toArray(ila, 0, ilaLength);
+        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final float[] subset = FloatIlaUtil.toArray(ila, start, length);
+                if (subset.length != length) throw new Exception("subset.length != length");
+                for (int ii = 0; ii < subset.length; ++ii) {
+                    float delta = (baseline[ii + (int) start] - subset[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("subset[" + ii + "] ("
+                                + subset[ii] + ") !~ baseline["
+                                + (ii + start) + "] ("
+                                + baseline[ii + (int) start]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void checkTwoFourEquivalence(FloatIla ila, float epsilon) throws Exception {
+        final float eps = epsilon < 0.0 ? -epsilon : epsilon;
+        final float neps = -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final float[] four = new float[ilaLength];
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final float[] two = FloatIlaUtil.toArray(ila, start, length);
+                ila.toArray(four, 0, start, length);
+                for (int ii = 0; ii < length; ++ii) {
+                    float delta = (four[ii] - two[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("four[" + ii + "] ("
+                                + four[ii] + ") !~ two["
+                                + ii + "] ("
+                                + two[ii]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void dump(String msg, float[] array) {
+        System.out.println(msg + ":");
+        for (int ii = 0; ii < array.length; ++ii) {
+            System.out.print(" " + array[ii]);
+        }
+        System.out.println();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaCheck.java
@@ -14,97 +14,14 @@ public final class IntIlaCheck {
     public static void checkAll(
             final IntIla target, final IntIla actual, int addlOffsetLength, int maxAbsStride, int epsilon)
             throws Exception {
-        checkZeroArgImmutability(actual);
-        checkTwoArgImmutability(actual, epsilon);
-        checkTwoFourEquivalence(actual, epsilon);
+        IntIlaUtilCheck.checkAll(actual, epsilon);
         checkFourFiveEquivalence(actual, addlOffsetLength, epsilon);
         checkCorrectness(target, actual, addlOffsetLength, maxAbsStride, epsilon);
     }
 
     public static void checkWithoutCorrectness(IntIla ila, int offsetLength, int epsilon) throws Exception {
-        checkZeroArgImmutability(ila);
-        checkTwoArgImmutability(ila, epsilon);
-        checkTwoFourEquivalence(ila, epsilon);
+        IntIlaUtilCheck.checkAll(ila, epsilon);
         checkFourFiveEquivalence(ila, offsetLength, epsilon);
-    }
-
-    public static void checkZeroArgImmutability(IntIla ila) throws Exception {
-        final long firstLength = ila.length();
-        final int[] firstArray = ila.toArray();
-        final long secondLength = ila.length();
-        final int[] secondArray = ila.toArray();
-        final long thirdLength = ila.length();
-        final int[] thirdArray = ila.toArray();
-        final long fourthLength = ila.length();
-
-        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
-        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
-        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
-
-        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
-        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
-        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
-
-        final Random random = new Random(0);
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            secondArray[ii] = random.nextInt();
-        }
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            if (firstArray[ii] != thirdArray[ii])
-                throw new Exception("firstArray[" + ii + "] ("
-                        + firstArray[ii] + ") != thirdArray["
-                        + ii + "] (" + thirdArray[ii] + ")");
-        }
-    }
-
-    // also performs zero-two equivalence
-    public static void checkTwoArgImmutability(IntIla ila, int epsilon) throws Exception {
-        final int eps = epsilon < 0.0 ? -epsilon : epsilon;
-        final int neps = -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final int[] baseline = ila.toArray(0, ilaLength);
-        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final int[] subset = ila.toArray(start, length);
-                if (subset.length != length) throw new Exception("subset.length != length");
-                for (int ii = 0; ii < subset.length; ++ii) {
-                    int delta = (baseline[ii + (int) start] - subset[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("subset[" + ii + "] ("
-                                + subset[ii] + ") !~ baseline["
-                                + (ii + start) + "] ("
-                                + baseline[ii + (int) start]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
-    }
-
-    public static void checkTwoFourEquivalence(IntIla ila, int epsilon) throws Exception {
-        final int eps = epsilon < 0.0 ? -epsilon : epsilon;
-        final int neps = -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final int[] four = new int[ilaLength];
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final int[] two = ila.toArray(start, length);
-                ila.toArray(four, 0, start, length);
-                for (int ii = 0; ii < length; ++ii) {
-                    int delta = (four[ii] - two[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("four[" + ii + "] ("
-                                + four[ii] + ") !~ two["
-                                + ii + "] ("
-                                + two[ii]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
     }
 
     public static void checkFourFiveEquivalence(IntIla ila, int offsetLength, int epsilon) throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaUtilCheck.java
@@ -1,0 +1,107 @@
+package tfw.immutable.ila.intila;
+
+import java.util.Random;
+
+/**
+ *
+ * @immutables.types=numeric
+ */
+public final class IntIlaUtilCheck {
+    private IntIlaUtilCheck() {
+        // non-instantiable class
+    }
+
+    public static void checkAll(final IntIla actual, int epsilon) throws Exception {
+        checkZeroArgImmutability(actual);
+        checkTwoArgImmutability(actual, epsilon);
+        checkTwoFourEquivalence(actual, epsilon);
+    }
+
+    public static void checkZeroArgImmutability(IntIla ila) throws Exception {
+        final long firstLength = ila.length();
+        final int[] firstArray = IntIlaUtil.toArray(ila);
+        final long secondLength = ila.length();
+        final int[] secondArray = IntIlaUtil.toArray(ila);
+        final long thirdLength = ila.length();
+        final int[] thirdArray = IntIlaUtil.toArray(ila);
+        final long fourthLength = ila.length();
+
+        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
+        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
+        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
+
+        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
+        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
+        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
+
+        final Random random = new Random(0);
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            secondArray[ii] = random.nextInt();
+        }
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            if (firstArray[ii] != thirdArray[ii])
+                throw new Exception("firstArray[" + ii + "] ("
+                        + firstArray[ii] + ") != thirdArray["
+                        + ii + "] (" + thirdArray[ii] + ")");
+        }
+    }
+
+    // also performs zero-two equivalence
+    public static void checkTwoArgImmutability(IntIla ila, int epsilon) throws Exception {
+        final int eps = epsilon < 0.0 ? -epsilon : epsilon;
+        final int neps = -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final int[] baseline = IntIlaUtil.toArray(ila, 0, ilaLength);
+        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final int[] subset = IntIlaUtil.toArray(ila, start, length);
+                if (subset.length != length) throw new Exception("subset.length != length");
+                for (int ii = 0; ii < subset.length; ++ii) {
+                    int delta = (baseline[ii + (int) start] - subset[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("subset[" + ii + "] ("
+                                + subset[ii] + ") !~ baseline["
+                                + (ii + start) + "] ("
+                                + baseline[ii + (int) start]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void checkTwoFourEquivalence(IntIla ila, int epsilon) throws Exception {
+        final int eps = epsilon < 0.0 ? -epsilon : epsilon;
+        final int neps = -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final int[] four = new int[ilaLength];
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final int[] two = IntIlaUtil.toArray(ila, start, length);
+                ila.toArray(four, 0, start, length);
+                for (int ii = 0; ii < length; ++ii) {
+                    int delta = (four[ii] - two[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("four[" + ii + "] ("
+                                + four[ii] + ") !~ two["
+                                + ii + "] ("
+                                + two[ii]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void dump(String msg, int[] array) {
+        System.out.println(msg + ":");
+        for (int ii = 0; ii < array.length; ++ii) {
+            System.out.print(" " + array[ii]);
+        }
+        System.out.println();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaCheck.java
@@ -14,97 +14,14 @@ public final class LongIlaCheck {
     public static void checkAll(
             final LongIla target, final LongIla actual, int addlOffsetLength, int maxAbsStride, long epsilon)
             throws Exception {
-        checkZeroArgImmutability(actual);
-        checkTwoArgImmutability(actual, epsilon);
-        checkTwoFourEquivalence(actual, epsilon);
+        LongIlaUtilCheck.checkAll(actual, epsilon);
         checkFourFiveEquivalence(actual, addlOffsetLength, epsilon);
         checkCorrectness(target, actual, addlOffsetLength, maxAbsStride, epsilon);
     }
 
     public static void checkWithoutCorrectness(LongIla ila, int offsetLength, long epsilon) throws Exception {
-        checkZeroArgImmutability(ila);
-        checkTwoArgImmutability(ila, epsilon);
-        checkTwoFourEquivalence(ila, epsilon);
+        LongIlaUtilCheck.checkAll(ila, epsilon);
         checkFourFiveEquivalence(ila, offsetLength, epsilon);
-    }
-
-    public static void checkZeroArgImmutability(LongIla ila) throws Exception {
-        final long firstLength = ila.length();
-        final long[] firstArray = ila.toArray();
-        final long secondLength = ila.length();
-        final long[] secondArray = ila.toArray();
-        final long thirdLength = ila.length();
-        final long[] thirdArray = ila.toArray();
-        final long fourthLength = ila.length();
-
-        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
-        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
-        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
-
-        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
-        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
-        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
-
-        final Random random = new Random(0);
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            secondArray[ii] = random.nextLong();
-        }
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            if (firstArray[ii] != thirdArray[ii])
-                throw new Exception("firstArray[" + ii + "] ("
-                        + firstArray[ii] + ") != thirdArray["
-                        + ii + "] (" + thirdArray[ii] + ")");
-        }
-    }
-
-    // also performs zero-two equivalence
-    public static void checkTwoArgImmutability(LongIla ila, long epsilon) throws Exception {
-        final long eps = epsilon < 0.0 ? -epsilon : epsilon;
-        final long neps = -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final long[] baseline = ila.toArray(0, ilaLength);
-        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final long[] subset = ila.toArray(start, length);
-                if (subset.length != length) throw new Exception("subset.length != length");
-                for (int ii = 0; ii < subset.length; ++ii) {
-                    long delta = (baseline[ii + (int) start] - subset[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("subset[" + ii + "] ("
-                                + subset[ii] + ") !~ baseline["
-                                + (ii + start) + "] ("
-                                + baseline[ii + (int) start]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
-    }
-
-    public static void checkTwoFourEquivalence(LongIla ila, long epsilon) throws Exception {
-        final long eps = epsilon < 0.0 ? -epsilon : epsilon;
-        final long neps = -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final long[] four = new long[ilaLength];
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final long[] two = ila.toArray(start, length);
-                ila.toArray(four, 0, start, length);
-                for (int ii = 0; ii < length; ++ii) {
-                    long delta = (four[ii] - two[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("four[" + ii + "] ("
-                                + four[ii] + ") !~ two["
-                                + ii + "] ("
-                                + two[ii]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
     }
 
     public static void checkFourFiveEquivalence(LongIla ila, int offsetLength, long epsilon) throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaUtilCheck.java
@@ -1,0 +1,107 @@
+package tfw.immutable.ila.longila;
+
+import java.util.Random;
+
+/**
+ *
+ * @immutables.types=numeric
+ */
+public final class LongIlaUtilCheck {
+    private LongIlaUtilCheck() {
+        // non-instantiable class
+    }
+
+    public static void checkAll(final LongIla actual, long epsilon) throws Exception {
+        checkZeroArgImmutability(actual);
+        checkTwoArgImmutability(actual, epsilon);
+        checkTwoFourEquivalence(actual, epsilon);
+    }
+
+    public static void checkZeroArgImmutability(LongIla ila) throws Exception {
+        final long firstLength = ila.length();
+        final long[] firstArray = LongIlaUtil.toArray(ila);
+        final long secondLength = ila.length();
+        final long[] secondArray = LongIlaUtil.toArray(ila);
+        final long thirdLength = ila.length();
+        final long[] thirdArray = LongIlaUtil.toArray(ila);
+        final long fourthLength = ila.length();
+
+        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
+        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
+        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
+
+        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
+        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
+        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
+
+        final Random random = new Random(0);
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            secondArray[ii] = random.nextLong();
+        }
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            if (firstArray[ii] != thirdArray[ii])
+                throw new Exception("firstArray[" + ii + "] ("
+                        + firstArray[ii] + ") != thirdArray["
+                        + ii + "] (" + thirdArray[ii] + ")");
+        }
+    }
+
+    // also performs zero-two equivalence
+    public static void checkTwoArgImmutability(LongIla ila, long epsilon) throws Exception {
+        final long eps = epsilon < 0.0 ? -epsilon : epsilon;
+        final long neps = -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final long[] baseline = LongIlaUtil.toArray(ila, 0, ilaLength);
+        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final long[] subset = LongIlaUtil.toArray(ila, start, length);
+                if (subset.length != length) throw new Exception("subset.length != length");
+                for (int ii = 0; ii < subset.length; ++ii) {
+                    long delta = (baseline[ii + (int) start] - subset[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("subset[" + ii + "] ("
+                                + subset[ii] + ") !~ baseline["
+                                + (ii + start) + "] ("
+                                + baseline[ii + (int) start]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void checkTwoFourEquivalence(LongIla ila, long epsilon) throws Exception {
+        final long eps = epsilon < 0.0 ? -epsilon : epsilon;
+        final long neps = -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final long[] four = new long[ilaLength];
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final long[] two = LongIlaUtil.toArray(ila, start, length);
+                ila.toArray(four, 0, start, length);
+                for (int ii = 0; ii < length; ++ii) {
+                    long delta = (four[ii] - two[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("four[" + ii + "] ("
+                                + four[ii] + ") !~ two["
+                                + ii + "] ("
+                                + two[ii]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void dump(String msg, long[] array) {
+        System.out.println(msg + ":");
+        for (int ii = 0; ii < array.length; ++ii) {
+            System.out.print(" " + array[ii]);
+        }
+        System.out.println();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java
@@ -12,97 +12,12 @@ public final class ObjectIlaCheck {
     public static void checkAll(
             ObjectIla target, ObjectIla actual, int addlOffsetLength, int maxAbsStride, Object epsilon)
             throws Exception {
-        checkZeroArgImmutability(actual);
-        checkTwoArgImmutability(actual, epsilon);
-        checkTwoFourEquivalence(actual, epsilon);
         checkFourFiveEquivalence(actual, addlOffsetLength, epsilon);
         checkCorrectness(target, actual, addlOffsetLength, maxAbsStride, epsilon);
     }
 
-    public static void checkWithoutCorrectness(ObjectIla ila, int offsetLength, Object epsilon) throws Exception {
-        checkZeroArgImmutability(ila);
-        checkTwoArgImmutability(ila, epsilon);
-        checkTwoFourEquivalence(ila, epsilon);
-        checkFourFiveEquivalence(ila, offsetLength, epsilon);
-    }
-
-    public static void checkZeroArgImmutability(ObjectIla ila) throws Exception {
-        final long firstLength = ila.length();
-        final Object[] firstArray = ila.toArray();
-        final long secondLength = ila.length();
-        final Object[] secondArray = ila.toArray();
-        final long thirdLength = ila.length();
-        final Object[] thirdArray = ila.toArray();
-        final long fourthLength = ila.length();
-
-        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
-        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
-        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
-
-        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
-        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
-        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            secondArray[ii] = new Object();
-        }
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            if (firstArray[ii] != thirdArray[ii])
-                throw new Exception("firstArray[" + ii + "] ("
-                        + firstArray[ii] + ") != thirdArray["
-                        + ii + "] (" + thirdArray[ii] + ")");
-        }
-    }
-
-    // also performs zero-two equivalence
-    public static void checkTwoArgImmutability(ObjectIla ila, Object epsilon) throws Exception {
-        if (epsilon != Object.class) {
-            throw new IllegalArgumentException("epsilon != " + (Object.class) + " not allowed");
-        } else {
-            final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-            final Object[] baseline = ila.toArray(0, ilaLength);
-            if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
-            for (int length = 1; length <= ilaLength; ++length) {
-                for (long start = 0; start < ilaLength - length + 1; ++start) {
-                    final Object[] subset = ila.toArray(start, length);
-                    if (subset.length != length) throw new Exception("subset.length != length");
-                    for (int ii = 0; ii < subset.length; ++ii) {
-                        if (!(baseline[ii + (int) start].equals(subset[ii])))
-                            throw new Exception("subset[" + ii + "] ("
-                                    + subset[ii] + ") !~ baseline["
-                                    + (ii + start) + "] ("
-                                    + baseline[ii + (int) start]
-                                    + ") {length=" + length
-                                    + ",start=" + start + "}");
-                    }
-                }
-            }
-        }
-    }
-
-    public static void checkTwoFourEquivalence(ObjectIla ila, Object epsilon) throws Exception {
-        if (epsilon != Object.class) {
-            throw new IllegalArgumentException("epsilon != " + (Object.class) + " not allowed");
-        } else {
-            final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-            final Object[] four = new Object[ilaLength];
-            for (int length = 1; length <= ilaLength; ++length) {
-                for (long start = 0; start < ilaLength - length + 1; ++start) {
-                    final Object[] two = ila.toArray(start, length);
-                    ila.toArray(four, 0, start, length);
-                    for (int ii = 0; ii < length; ++ii) {
-                        if (!(four[ii].equals(two[ii])))
-                            throw new Exception("four[" + ii + "] ("
-                                    + four[ii] + ") !~ two["
-                                    + ii + "] ("
-                                    + two[ii]
-                                    + ") {length=" + length
-                                    + ",start=" + start + "}");
-                    }
-                }
-            }
-        }
+    public static void checkWithoutCorrectness(ObjectIla actual, int offsetLength, Object epsilon) throws Exception {
+        checkFourFiveEquivalence(actual, offsetLength, epsilon);
     }
 
     public static void checkFourFiveEquivalence(ObjectIla ila, int offsetLength, Object epsilon) throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaCheck.java
@@ -14,97 +14,14 @@ public final class ShortIlaCheck {
     public static void checkAll(
             final ShortIla target, final ShortIla actual, int addlOffsetLength, int maxAbsStride, short epsilon)
             throws Exception {
-        checkZeroArgImmutability(actual);
-        checkTwoArgImmutability(actual, epsilon);
-        checkTwoFourEquivalence(actual, epsilon);
+        ShortIlaUtilCheck.checkAll(actual, epsilon);
         checkFourFiveEquivalence(actual, addlOffsetLength, epsilon);
         checkCorrectness(target, actual, addlOffsetLength, maxAbsStride, epsilon);
     }
 
     public static void checkWithoutCorrectness(ShortIla ila, int offsetLength, short epsilon) throws Exception {
-        checkZeroArgImmutability(ila);
-        checkTwoArgImmutability(ila, epsilon);
-        checkTwoFourEquivalence(ila, epsilon);
+        ShortIlaUtilCheck.checkAll(ila, epsilon);
         checkFourFiveEquivalence(ila, offsetLength, epsilon);
-    }
-
-    public static void checkZeroArgImmutability(ShortIla ila) throws Exception {
-        final long firstLength = ila.length();
-        final short[] firstArray = ila.toArray();
-        final long secondLength = ila.length();
-        final short[] secondArray = ila.toArray();
-        final long thirdLength = ila.length();
-        final short[] thirdArray = ila.toArray();
-        final long fourthLength = ila.length();
-
-        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
-        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
-        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
-
-        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
-        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
-        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
-
-        final Random random = new Random(0);
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            secondArray[ii] = (short) random.nextInt();
-        }
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            if (firstArray[ii] != thirdArray[ii])
-                throw new Exception("firstArray[" + ii + "] ("
-                        + firstArray[ii] + ") != thirdArray["
-                        + ii + "] (" + thirdArray[ii] + ")");
-        }
-    }
-
-    // also performs zero-two equivalence
-    public static void checkTwoArgImmutability(ShortIla ila, short epsilon) throws Exception {
-        final short eps = epsilon < 0.0 ? (short) -epsilon : epsilon;
-        final short neps = (short) -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final short[] baseline = ila.toArray(0, ilaLength);
-        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final short[] subset = ila.toArray(start, length);
-                if (subset.length != length) throw new Exception("subset.length != length");
-                for (int ii = 0; ii < subset.length; ++ii) {
-                    short delta = (short) (baseline[ii + (int) start] - subset[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("subset[" + ii + "] ("
-                                + subset[ii] + ") !~ baseline["
-                                + (ii + start) + "] ("
-                                + baseline[ii + (int) start]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
-    }
-
-    public static void checkTwoFourEquivalence(ShortIla ila, short epsilon) throws Exception {
-        final short eps = epsilon < 0.0 ? (short) -epsilon : epsilon;
-        final short neps = (short) -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final short[] four = new short[ilaLength];
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final short[] two = ila.toArray(start, length);
-                ila.toArray(four, 0, start, length);
-                for (int ii = 0; ii < length; ++ii) {
-                    short delta = (short) (four[ii] - two[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("four[" + ii + "] ("
-                                + four[ii] + ") !~ two["
-                                + ii + "] ("
-                                + two[ii]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
     }
 
     public static void checkFourFiveEquivalence(ShortIla ila, int offsetLength, short epsilon) throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaUtilCheck.java
@@ -1,0 +1,107 @@
+package tfw.immutable.ila.shortila;
+
+import java.util.Random;
+
+/**
+ *
+ * @immutables.types=numeric
+ */
+public final class ShortIlaUtilCheck {
+    private ShortIlaUtilCheck() {
+        // non-instantiable class
+    }
+
+    public static void checkAll(final ShortIla actual, short epsilon) throws Exception {
+        checkZeroArgImmutability(actual);
+        checkTwoArgImmutability(actual, epsilon);
+        checkTwoFourEquivalence(actual, epsilon);
+    }
+
+    public static void checkZeroArgImmutability(ShortIla ila) throws Exception {
+        final long firstLength = ila.length();
+        final short[] firstArray = ShortIlaUtil.toArray(ila);
+        final long secondLength = ila.length();
+        final short[] secondArray = ShortIlaUtil.toArray(ila);
+        final long thirdLength = ila.length();
+        final short[] thirdArray = ShortIlaUtil.toArray(ila);
+        final long fourthLength = ila.length();
+
+        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
+        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
+        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
+
+        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
+        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
+        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
+
+        final Random random = new Random(0);
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            secondArray[ii] = (short) random.nextInt();
+        }
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            if (firstArray[ii] != thirdArray[ii])
+                throw new Exception("firstArray[" + ii + "] ("
+                        + firstArray[ii] + ") != thirdArray["
+                        + ii + "] (" + thirdArray[ii] + ")");
+        }
+    }
+
+    // also performs zero-two equivalence
+    public static void checkTwoArgImmutability(ShortIla ila, short epsilon) throws Exception {
+        final short eps = epsilon < 0.0 ? (short) -epsilon : epsilon;
+        final short neps = (short) -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final short[] baseline = ShortIlaUtil.toArray(ila, 0, ilaLength);
+        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final short[] subset = ShortIlaUtil.toArray(ila, start, length);
+                if (subset.length != length) throw new Exception("subset.length != length");
+                for (int ii = 0; ii < subset.length; ++ii) {
+                    short delta = (short) (baseline[ii + (int) start] - subset[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("subset[" + ii + "] ("
+                                + subset[ii] + ") !~ baseline["
+                                + (ii + start) + "] ("
+                                + baseline[ii + (int) start]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void checkTwoFourEquivalence(ShortIla ila, short epsilon) throws Exception {
+        final short eps = epsilon < 0.0 ? (short) -epsilon : epsilon;
+        final short neps = (short) -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final short[] four = new short[ilaLength];
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final short[] two = ShortIlaUtil.toArray(ila, start, length);
+                ila.toArray(four, 0, start, length);
+                for (int ii = 0; ii < length; ++ii) {
+                    short delta = (short) (four[ii] - two[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("four[" + ii + "] ("
+                                + four[ii] + ") !~ two["
+                                + ii + "] ("
+                                + two[ii]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void dump(String msg, short[] array) {
+        System.out.println(msg + ":");
+        for (int ii = 0; ii < array.length; ++ii) {
+            System.out.print(" " + array[ii]);
+        }
+        System.out.println();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilm/doubleilm/TakeSkipDoubleIlmTest.java
+++ b/src/test/java/tfw/immutable/ilm/doubleilm/TakeSkipDoubleIlmTest.java
@@ -7,12 +7,13 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaRamp;
+import tfw.immutable.ila.doubleila.DoubleIlaUtil;
 
 class TakeSkipDoubleIlmTest {
     @Test
     void testTakeSkipDoubleIlm() throws Exception {
         DoubleIla doubleIla = DoubleIlaRamp.create(-10.0, 1.0, 20);
-        double[] doubleArray = doubleIla.toArray();
+        double[] doubleArray = DoubleIlaUtil.toArray(doubleIla);
 
         DoubleIlm takeSkip1 = TakeSkipDoubleIlm.create(doubleIla, 10, 10);
         double[] takeSkip1Array = takeSkip1.toArray();

--- a/src/test/java/tfw/tsm/MultiplexerTest.java
+++ b/src/test/java/tfw/tsm/MultiplexerTest.java
@@ -86,10 +86,14 @@ class MultiplexerTest {
 
         initiator0.set(valueECD, "0");
         queue.waitTilEmpty();
+
+        final Object[] multiValueArray0 = new Object[(int) mvCommit.value.length()];
+        mvCommit.value.toArray(multiValueArray0, 0, 0, multiValueArray0.length);
+
         assertEquals("0", valueCommit0.value, "value 0 not correct");
         assertEquals("one", valueCommit1.value, "value 1 not correct");
-        assertEquals("0", mvCommit.value.toArray()[0], "multiValue[0] not correct");
-        assertEquals("one", mvCommit.value.toArray()[1], "multiValue[1] not correct");
+        assertEquals("0", multiValueArray0[0], "multiValue[0] not correct");
+        assertEquals("one", multiValueArray0[1], "multiValue[1] not correct");
 
         MyTriggeredConverter tc0 = new MyTriggeredConverter("tc0", triggerECD, "tc0", valueECD);
         MyTriggeredConverter tc1 = new MyTriggeredConverter("tc1", triggerECD, "tc1", valueECD);
@@ -102,10 +106,14 @@ class MultiplexerTest {
 
         triggerInitiator.trigger(triggerECD);
         queue.waitTilEmpty();
+
+        final Object[] multiValueArray1 = new Object[(int) mvCommit.value.length()];
+        mvCommit.value.toArray(multiValueArray1, 0, 0, multiValueArray1.length);
+
         assertEquals("tc0", valueCommit0.value, "value 0 not correct");
         assertEquals("tc1", valueCommit1.value, "value 1 not correct");
-        assertEquals("tc0", mvCommit.value.toArray()[0], "multiValue[0] not correct");
-        assertEquals("tc1", mvCommit.value.toArray()[1], "multiValue[1] not correct");
+        assertEquals("tc0", multiValueArray1[0], "multiValue[0] not correct");
+        assertEquals("tc1", multiValueArray1[1], "multiValue[1] not correct");
         // We remove one of the component to cause a new transaction in order
         // to make sure that no exceptions are thrown...
         subBranch0.remove(valueCommit0);
@@ -120,8 +128,12 @@ class MultiplexerTest {
         tc1.value = tc1Value;
         triggerInitiator.trigger(triggerECD);
         queue.waitTilEmpty();
-        assertEquals(tc0Value, mvCommit.value.toArray()[0], "multiValue[0] not correct");
-        assertEquals(tc1Value, mvCommit.value.toArray()[1], "multiValue[1] not correct");
+
+        final Object[] multiValueArray2 = new Object[(int) mvCommit.value.length()];
+        mvCommit.value.toArray(multiValueArray2, 0, 0, multiValueArray2.length);
+
+        assertEquals(tc0Value, multiValueArray2[0], "multiValue[0] not correct");
+        assertEquals(tc1Value, multiValueArray2[1], "multiValue[1] not correct");
 
         assertNull(exceptionHandler.exp, "Unexpected exception thrown during testing");
         // Now we will remove the multiplexer...and make sure everything still
@@ -130,13 +142,23 @@ class MultiplexerTest {
         queue.waitTilEmpty();
         multiInitiator.set(multiValueECD, obj);
         queue.waitTilEmpty();
-        assertEquals(obj.toArray()[0], mvCommit.value.toArray()[0], "multiValue[0] not correct");
-        assertEquals(obj.toArray()[1], mvCommit.value.toArray()[1], "multiValue[1] not correct");
+
+        final Object[] multiValueArray3 = new Object[(int) mvCommit.value.length()];
+        final Object[] objArray3 = new Object[(int) obj.length()];
+        mvCommit.value.toArray(multiValueArray3, 0, 0, multiValueArray3.length);
+        obj.toArray(objArray3, 0, 0, objArray3.length);
+
+        assertEquals(objArray3[0], multiValueArray3[0], "multiValue[0] not correct");
+        assertEquals(objArray3[1], multiValueArray3[1], "multiValue[1] not correct");
         // Now we put the multiplexer back and make sure it still works.
         root.add(multiBranch);
         queue.waitTilEmpty();
-        assertEquals(obj.toArray()[0], valueCommit0.value, "value 0 not correct");
-        assertEquals(obj.toArray()[1], valueCommit1.value, "value 1 not correct");
+
+        final Object[] objArray4 = new Object[(int) obj.length()];
+        obj.toArray(objArray4, 0, 0, objArray4.length);
+
+        assertEquals(objArray4[0], valueCommit0.value, "value 0 not correct");
+        assertEquals(objArray4[1], valueCommit1.value, "value 1 not correct");
     }
 
     @Test
@@ -277,9 +299,19 @@ class MultiplexerTest {
 
     private Object[][] toArray(ObjectIla objs) throws Exception {
         Object[][] mmArray = new Object[2][];
-        Object[] mma = objs.toArray();
-        mmArray[0] = ((ObjectIla) mma[0]).toArray();
-        mmArray[1] = ((ObjectIla) mma[1]).toArray();
+
+        Object[] mma = new Object[(int) objs.length()];
+        objs.toArray(mma, 0, 0, mma.length);
+
+        final ObjectIla mma0Ila = (ObjectIla) mma[0];
+        final ObjectIla mma1Ila = (ObjectIla) mma[1];
+
+        mmArray[0] = new Object[(int) mma0Ila.length()];
+        mmArray[1] = new Object[(int) mma1Ila.length()];
+
+        mma0Ila.toArray(mmArray[0], 0, 0, mmArray[0].length);
+        mma1Ila.toArray(mmArray[1], 0, 0, mmArray[1].length);
+
         return mmArray;
     }
 

--- a/src/test/java/tfw/visualizer/NodeAndEdgesFromRootProxyTest.java
+++ b/src/test/java/tfw/visualizer/NodeAndEdgesFromRootProxyTest.java
@@ -129,7 +129,9 @@ class NodeAndEdgesFromRootProxyTest {
             new ValidatorProxy(validator)
         };
         Object[] nodesObjectIlaArray =
-                nodeAndEdgesFromRootProxy.getNodesObjectIla().toArray();
+                new Object[(int) nodeAndEdgesFromRootProxy.getNodesObjectIla().length()];
+
+        nodeAndEdgesFromRootProxy.getNodesObjectIla().toArray(nodesObjectIlaArray, 0, 0, nodesObjectIlaArray.length);
 
         Arrays.sort(nodesArray, ProxyNameComparator.INSTANCE);
         Arrays.sort(nodesObjectIlaArray, ProxyNameComparator.INSTANCE);

--- a/src/test/template/tfw/immutable/ila/__IlaCheck..NonNumeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaCheck..NonNumeric.template
@@ -13,97 +13,12 @@ public final class %%NAME%%IlaCheck {
     public static void checkAll(
             %%NAME%%Ila target, %%NAME%%Ila actual, int addlOffsetLength, int maxAbsStride, %%TYPE%% epsilon)
             throws Exception {
-        checkZeroArgImmutability(actual);
-        checkTwoArgImmutability(actual, epsilon);
-        checkTwoFourEquivalence(actual, epsilon);
-        checkFourFiveEquivalence(actual, addlOffsetLength, epsilon);
+        %%UTIL%%checkFourFiveEquivalence(actual, addlOffsetLength, epsilon);
         checkCorrectness(target, actual, addlOffsetLength, maxAbsStride, epsilon);
     }
 
-    public static void checkWithoutCorrectness(%%NAME%%Ila ila, int offsetLength, %%TYPE%% epsilon) throws Exception {
-        checkZeroArgImmutability(ila);
-        checkTwoArgImmutability(ila, epsilon);
-        checkTwoFourEquivalence(ila, epsilon);
-        checkFourFiveEquivalence(ila, offsetLength, epsilon);
-    }
-
-    public static void checkZeroArgImmutability(%%NAME%%Ila ila) throws Exception {
-        final long firstLength = ila.length();
-        final %%TYPE%%[] firstArray = ila.toArray();
-        final long secondLength = ila.length();
-        final %%TYPE%%[] secondArray = ila.toArray();
-        final long thirdLength = ila.length();
-        final %%TYPE%%[] thirdArray = ila.toArray();
-        final long fourthLength = ila.length();
-
-        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
-        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
-        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
-
-        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
-        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
-        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
-
-        %%RANDOM_INIT%%for (int ii = 0; ii < firstLength; ++ii) {
-            secondArray[ii] = %%RANDOM_VALUE%%;
-        }
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            if (firstArray[ii] != thirdArray[ii])
-                throw new Exception("firstArray[" + ii + "] ("
-                        + firstArray[ii] + ") != thirdArray["
-                        + ii + "] (" + thirdArray[ii] + ")");
-        }
-    }
-
-    // also performs zero-two equivalence
-    public static void checkTwoArgImmutability(%%NAME%%Ila ila, %%TYPE%% epsilon) throws Exception {
-        if (epsilon != %%DEFAULT_VALUE%%) {
-            throw new IllegalArgumentException("epsilon != " + (%%DEFAULT_VALUE%%) + " not allowed");
-        } else {
-            final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-            final %%TYPE%%[] baseline = ila.toArray(0, ilaLength);
-            if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
-            for (int length = 1; length <= ilaLength; ++length) {
-                for (long start = 0; start < ilaLength - length + 1; ++start) {
-                    final %%TYPE%%[] subset = ila.toArray(start, length);
-                    if (subset.length != length) throw new Exception("subset.length != length");
-                    for (int ii = 0; ii < subset.length; ++ii) {
-                        if (!(baseline[ii + (int) start]%%IS_EQUALS_START%%subset[ii]%%IS_EQUALS_END%%))
-                            throw new Exception("subset[" + ii + "] ("
-                                    + subset[ii] + ") !~ baseline["
-                                    + (ii + start) + "] ("
-                                    + baseline[ii + (int) start]
-                                    + ") {length=" + length
-                                    + ",start=" + start + "}");
-                    }
-                }
-            }
-        }
-    }
-
-    public static void checkTwoFourEquivalence(%%NAME%%Ila ila, %%TYPE%% epsilon) throws Exception {
-        if (epsilon != %%DEFAULT_VALUE%%) {
-            throw new IllegalArgumentException("epsilon != " + (%%DEFAULT_VALUE%%) + " not allowed");
-        } else {
-            final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-            final %%TYPE%%[] four = new %%TYPE%%[ilaLength];
-            for (int length = 1; length <= ilaLength; ++length) {
-                for (long start = 0; start < ilaLength - length + 1; ++start) {
-                    final %%TYPE%%[] two = ila.toArray(start, length);
-                    ila.toArray(four, 0, start, length);
-                    for (int ii = 0; ii < length; ++ii) {
-                        if (!(four[ii]%%IS_EQUALS_START%%two[ii]%%IS_EQUALS_END%%))
-                            throw new Exception("four[" + ii + "] ("
-                                    + four[ii] + ") !~ two["
-                                    + ii + "] ("
-                                    + two[ii]
-                                    + ") {length=" + length
-                                    + ",start=" + start + "}");
-                    }
-                }
-            }
-        }
+    public static void checkWithoutCorrectness(%%NAME%%Ila actual, int offsetLength, %%TYPE%% epsilon) throws Exception {
+        %%UTIL%%checkFourFiveEquivalence(actual, offsetLength, epsilon);
     }
 
     public static void checkFourFiveEquivalence(%%NAME%%Ila ila, int offsetLength, %%TYPE%% epsilon) throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaCheck..Numeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaCheck..Numeric.template
@@ -14,96 +14,14 @@ public final class %%NAME%%IlaCheck {
     public static void checkAll(
             final %%NAME%%Ila target, final %%NAME%%Ila actual, int addlOffsetLength, int maxAbsStride, %%TYPE%% epsilon)
             throws Exception {
-        checkZeroArgImmutability(actual);
-        checkTwoArgImmutability(actual, epsilon);
-        checkTwoFourEquivalence(actual, epsilon);
+        %%NAME%%IlaUtilCheck.checkAll(actual, epsilon);
         checkFourFiveEquivalence(actual, addlOffsetLength, epsilon);
         checkCorrectness(target, actual, addlOffsetLength, maxAbsStride, epsilon);
     }
 
     public static void checkWithoutCorrectness(%%NAME%%Ila ila, int offsetLength, %%TYPE%% epsilon) throws Exception {
-        checkZeroArgImmutability(ila);
-        checkTwoArgImmutability(ila, epsilon);
-        checkTwoFourEquivalence(ila, epsilon);
+        %%NAME%%IlaUtilCheck.checkAll(ila, epsilon);
         checkFourFiveEquivalence(ila, offsetLength, epsilon);
-    }
-
-    public static void checkZeroArgImmutability(%%NAME%%Ila ila) throws Exception {
-        final long firstLength = ila.length();
-        final %%TYPE%%[] firstArray = ila.toArray();
-        final long secondLength = ila.length();
-        final %%TYPE%%[] secondArray = ila.toArray();
-        final long thirdLength = ila.length();
-        final %%TYPE%%[] thirdArray = ila.toArray();
-        final long fourthLength = ila.length();
-
-        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
-        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
-        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
-
-        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
-        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
-        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
-
-        %%RANDOM_INIT_0%%
-        for (int ii = 0; ii < firstLength; ++ii) {
-            secondArray[ii] = %%RANDOM_VALUE%%;
-        }
-
-        for (int ii = 0; ii < firstLength; ++ii) {
-            if (firstArray[ii] != thirdArray[ii])
-                throw new Exception("firstArray[" + ii + "] ("
-                        + firstArray[ii] + ") != thirdArray["
-                        + ii + "] (" + thirdArray[ii] + ")");
-        }
-    }
-
-    // also performs zero-two equivalence
-    public static void checkTwoArgImmutability(%%NAME%%Ila ila, %%TYPE%% epsilon) throws Exception {
-        final %%TYPE%% eps = epsilon < 0.0 ?%%CAST_FROM_INT%% -epsilon : epsilon;
-        final %%TYPE%% neps =%%CAST_FROM_INT%% -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final %%TYPE%%[] baseline = ila.toArray(0, ilaLength);
-        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final %%TYPE%%[] subset = ila.toArray(start, length);
-                if (subset.length != length) throw new Exception("subset.length != length");
-                for (int ii = 0; ii < subset.length; ++ii) {
-                    %%TYPE%% delta =%%CAST_FROM_INT%% (baseline[ii + (int) start] - subset[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("subset[" + ii + "] ("
-                                + subset[ii] + ") !~ baseline["
-                                + (ii + start) + "] ("
-                                + baseline[ii + (int) start]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
-    }
-
-    public static void checkTwoFourEquivalence(%%NAME%%Ila ila, %%TYPE%% epsilon) throws Exception {
-        final %%TYPE%% eps = epsilon < 0.0 ?%%CAST_FROM_INT%% -epsilon : epsilon;
-        final %%TYPE%% neps =%%CAST_FROM_INT%% -eps;
-        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
-        final %%TYPE%%[] four = new %%TYPE%%[ilaLength];
-        for (int length = 1; length <= ilaLength; ++length) {
-            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                final %%TYPE%%[] two = ila.toArray(start, length);
-                ila.toArray(four, 0, start, length);
-                for (int ii = 0; ii < length; ++ii) {
-                    %%TYPE%% delta =%%CAST_FROM_INT%% (four[ii] - two[ii]);
-                    if (!(neps <= delta && delta <= eps))
-                        throw new Exception("four[" + ii + "] ("
-                                + four[ii] + ") !~ two["
-                                + ii + "] ("
-                                + two[ii]
-                                + ") {length=" + length
-                                + ",start=" + start + "}");
-                }
-            }
-        }
     }
 
     public static void checkFourFiveEquivalence(%%NAME%%Ila ila, int offsetLength, %%TYPE%% epsilon) throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaUtilCheck..NonNumeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaUtilCheck..NonNumeric.template
@@ -1,0 +1,105 @@
+// booleanila
+package %%PACKAGE%%;
+
+%%RANDOM_INCLUDE_2%%/**
+ *
+ * @immutables.types=nonnumeric
+ */
+public final class %%NAME%%IlaUtilCheck {
+    private %%NAME%%IlaUtilCheck() {
+        // non-instantiable class
+    }
+
+    public static void checkAll(%%NAME%%Ila actual, %%TYPE%% epsilon) throws Exception {
+        checkZeroArgImmutability(actual);
+        checkTwoArgImmutability(actual, epsilon);
+        checkTwoFourEquivalence(actual, epsilon);
+    }
+
+    public static void checkZeroArgImmutability(%%NAME%%Ila ila) throws Exception {
+        final long firstLength = ila.length();
+        final %%TYPE%%[] firstArray = %%NAME%%IlaUtil.toArray(ila);
+        final long secondLength = ila.length();
+        final %%TYPE%%[] secondArray = %%NAME%%IlaUtil.toArray(ila);
+        final long thirdLength = ila.length();
+        final %%TYPE%%[] thirdArray = %%NAME%%IlaUtil.toArray(ila);
+        final long fourthLength = ila.length();
+
+        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
+        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
+        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
+
+        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
+        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
+        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
+
+        %%RANDOM_INIT%%for (int ii = 0; ii < firstLength; ++ii) {
+            secondArray[ii] = %%RANDOM_VALUE%%;
+        }
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            if (firstArray[ii] != thirdArray[ii])
+                throw new Exception("firstArray[" + ii + "] ("
+                        + firstArray[ii] + ") != thirdArray["
+                        + ii + "] (" + thirdArray[ii] + ")");
+        }
+    }
+
+    // also performs zero-two equivalence
+    public static void checkTwoArgImmutability(%%NAME%%Ila ila, %%TYPE%% epsilon) throws Exception {
+        if (epsilon != %%DEFAULT_VALUE%%) {
+            throw new IllegalArgumentException("epsilon != " + (%%DEFAULT_VALUE%%) + " not allowed");
+        } else {
+            final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+            final %%TYPE%%[] baseline = %%NAME%%IlaUtil.toArray(ila, 0, ilaLength);
+            if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
+            for (int length = 1; length <= ilaLength; ++length) {
+                for (long start = 0; start < ilaLength - length + 1; ++start) {
+                    final %%TYPE%%[] subset = %%NAME%%IlaUtil.toArray(ila, start, length);
+                    if (subset.length != length) throw new Exception("subset.length != length");
+                    for (int ii = 0; ii < subset.length; ++ii) {
+                        if (!(baseline[ii + (int) start]%%IS_EQUALS_START%%subset[ii]%%IS_EQUALS_END%%))
+                            throw new Exception("subset[" + ii + "] ("
+                                    + subset[ii] + ") !~ baseline["
+                                    + (ii + start) + "] ("
+                                    + baseline[ii + (int) start]
+                                    + ") {length=" + length
+                                    + ",start=" + start + "}");
+                    }
+                }
+            }
+        }
+    }
+
+    public static void checkTwoFourEquivalence(%%NAME%%Ila ila, %%TYPE%% epsilon) throws Exception {
+        if (epsilon != %%DEFAULT_VALUE%%) {
+            throw new IllegalArgumentException("epsilon != " + (%%DEFAULT_VALUE%%) + " not allowed");
+        } else {
+            final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+            final %%TYPE%%[] four = new %%TYPE%%[ilaLength];
+            for (int length = 1; length <= ilaLength; ++length) {
+                for (long start = 0; start < ilaLength - length + 1; ++start) {
+                    final %%TYPE%%[] two = %%NAME%%IlaUtil.toArray(ila, start, length);
+                    ila.toArray(four, 0, start, length);
+                    for (int ii = 0; ii < length; ++ii) {
+                        if (!(four[ii]%%IS_EQUALS_START%%two[ii]%%IS_EQUALS_END%%))
+                            throw new Exception("four[" + ii + "] ("
+                                    + four[ii] + ") !~ two["
+                                    + ii + "] ("
+                                    + two[ii]
+                                    + ") {length=" + length
+                                    + ",start=" + start + "}");
+                    }
+                }
+            }
+        }
+    }
+
+    public static void dump(String msg, %%TYPE%%[] array) {
+        System.out.println(msg + ":");
+        for (int ii = 0; ii < array.length; ++ii) {
+            System.out.print(" " + array[ii]);
+        }
+        System.out.println();
+    }
+}

--- a/src/test/template/tfw/immutable/ila/__IlaUtilCheck..Numeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaUtilCheck..Numeric.template
@@ -1,0 +1,105 @@
+// byteila,charila,doubleila,floatila,intila,longila,shortila
+package %%PACKAGE%%;
+
+%%RANDOM_INCLUDE%%
+/**
+ *
+ * @immutables.types=numeric
+ */
+public final class %%NAME%%IlaUtilCheck {
+    private %%NAME%%IlaUtilCheck() {
+        // non-instantiable class
+    }
+
+    public static void checkAll(final %%NAME%%Ila actual, %%TYPE%% epsilon) throws Exception {
+        checkZeroArgImmutability(actual);
+        checkTwoArgImmutability(actual, epsilon);
+        checkTwoFourEquivalence(actual, epsilon);
+    }
+
+    public static void checkZeroArgImmutability(%%NAME%%Ila ila) throws Exception {
+        final long firstLength = ila.length();
+        final %%TYPE%%[] firstArray = %%NAME%%IlaUtil.toArray(ila);
+        final long secondLength = ila.length();
+        final %%TYPE%%[] secondArray = %%NAME%%IlaUtil.toArray(ila);
+        final long thirdLength = ila.length();
+        final %%TYPE%%[] thirdArray = %%NAME%%IlaUtil.toArray(ila);
+        final long fourthLength = ila.length();
+
+        if (firstArray.length != firstLength) throw new Exception("firstArray.length != firstLength");
+        if (secondArray.length != secondLength) throw new Exception("secondArray.length != secondLength");
+        if (thirdArray.length != thirdLength) throw new Exception("thirdArray.length != thirdLength");
+
+        if (firstLength != secondLength) throw new Exception("firstLength != secondLength");
+        if (secondLength != thirdLength) throw new Exception("secondLength != thirdLength");
+        if (thirdLength != fourthLength) throw new Exception("thirdLength != fourthLength");
+
+        %%RANDOM_INIT_0%%
+        for (int ii = 0; ii < firstLength; ++ii) {
+            secondArray[ii] = %%RANDOM_VALUE%%;
+        }
+
+        for (int ii = 0; ii < firstLength; ++ii) {
+            if (firstArray[ii] != thirdArray[ii])
+                throw new Exception("firstArray[" + ii + "] ("
+                        + firstArray[ii] + ") != thirdArray["
+                        + ii + "] (" + thirdArray[ii] + ")");
+        }
+    }
+
+    // also performs zero-two equivalence
+    public static void checkTwoArgImmutability(%%NAME%%Ila ila, %%TYPE%% epsilon) throws Exception {
+        final %%TYPE%% eps = epsilon < 0.0 ?%%CAST_FROM_INT%% -epsilon : epsilon;
+        final %%TYPE%% neps =%%CAST_FROM_INT%% -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final %%TYPE%%[] baseline = %%NAME%%IlaUtil.toArray(ila, 0, ilaLength);
+        if (baseline.length != ilaLength) throw new Exception("baseline.length != ilaLength");
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final %%TYPE%%[] subset = %%NAME%%IlaUtil.toArray(ila, start, length);
+                if (subset.length != length) throw new Exception("subset.length != length");
+                for (int ii = 0; ii < subset.length; ++ii) {
+                    %%TYPE%% delta =%%CAST_FROM_INT%% (baseline[ii + (int) start] - subset[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("subset[" + ii + "] ("
+                                + subset[ii] + ") !~ baseline["
+                                + (ii + start) + "] ("
+                                + baseline[ii + (int) start]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void checkTwoFourEquivalence(%%NAME%%Ila ila, %%TYPE%% epsilon) throws Exception {
+        final %%TYPE%% eps = epsilon < 0.0 ?%%CAST_FROM_INT%% -epsilon : epsilon;
+        final %%TYPE%% neps =%%CAST_FROM_INT%% -eps;
+        final int ilaLength = ila.length() <= Integer.MAX_VALUE ? (int) ila.length() : Integer.MAX_VALUE;
+        final %%TYPE%%[] four = new %%TYPE%%[ilaLength];
+        for (int length = 1; length <= ilaLength; ++length) {
+            for (long start = 0; start < ilaLength - length + 1; ++start) {
+                final %%TYPE%%[] two = %%NAME%%IlaUtil.toArray(ila, start, length);
+                ila.toArray(four, 0, start, length);
+                for (int ii = 0; ii < length; ++ii) {
+                    %%TYPE%% delta =%%CAST_FROM_INT%% (four[ii] - two[ii]);
+                    if (!(neps <= delta && delta <= eps))
+                        throw new Exception("four[" + ii + "] ("
+                                + four[ii] + ") !~ two["
+                                + ii + "] ("
+                                + two[ii]
+                                + ") {length=" + length
+                                + ",start=" + start + "}");
+                }
+            }
+        }
+    }
+
+    public static void dump(String msg, %%TYPE%%[] array) {
+        System.out.println(msg + ":");
+        for (int ii = 0; ii < array.length; ++ii) {
+            System.out.print(" " + array[ii]);
+        }
+        System.out.println();
+    }
+}

--- a/src/test/template/tfw/immutable/ila/booleanila.mapping
+++ b/src/test/template/tfw/immutable/ila/booleanila.mapping
@@ -1,3 +1,4 @@
+%%UTIL%% = BooleanIlaUtilCheck.checkAll(actual, epsilon);\n\ \ \ \ \ \ \ \ 
 %%TYPE%% = boolean
 %%NAME%% = Boolean
 %%PACKAGE%% = tfw.immutable.ila.booleanila

--- a/src/test/template/tfw/immutable/ila/objectila.mapping
+++ b/src/test/template/tfw/immutable/ila/objectila.mapping
@@ -1,3 +1,4 @@
+%%UTIL%% = 
 %%TYPE%% = Object
 %%NAME%% = Object
 %%PACKAGE%% = tfw.immutable.ila.objectila


### PR DESCRIPTION
This PR moves the toArray() and toArray(start, length) methods from the Ila interface to a Util class. This is being done to help simplify the Ila interface.