### PR TITLE
Remove empty Javadoc from src/main templates.

### DIFF
--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIla.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIla.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.booleanila;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.ImmutableLongArray;
 
-/**
- *
- * @immutables.types=all
- */
 public interface BooleanIla extends ImmutableLongArray {
     void toArray(final boolean[] array, final int arrayOffset, final long ilaStart, final int length)
             throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaConcatenate.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaConcatenate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.booleanila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class BooleanIlaConcatenate {
     private BooleanIlaConcatenate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaDecimate.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaDecimate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.booleanila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class BooleanIlaDecimate {
     private BooleanIlaDecimate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaFill.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaFill.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.booleanila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class BooleanIlaFill {
     private BooleanIlaFill() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaFiltered.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaFiltered.java
@@ -4,10 +4,6 @@ import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.AbstractIlaCheck;
 
-/**
- *
- * @immutables.types=all
- */
 public final class BooleanIlaFiltered {
     private BooleanIlaFiltered() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaFromArray.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaFromArray.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.booleanila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class BooleanIlaFromArray {
     private BooleanIlaFromArray() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaInsert.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaInsert.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.booleanila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class BooleanIlaInsert {
     private BooleanIlaInsert() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaInterleave.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaInterleave.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.booleanila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class BooleanIlaInterleave {
     private BooleanIlaInterleave() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaIterator.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaIterator.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.booleanila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class BooleanIlaIterator {
     private final BooleanIla instance;
     private final long instanceLength;

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaMutate.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaMutate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.booleanila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class BooleanIlaMutate {
     private BooleanIlaMutate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaRemove.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaRemove.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.booleanila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class BooleanIlaRemove {
     private BooleanIlaRemove() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaReverse.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaReverse.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.booleanila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class BooleanIlaReverse {
     private BooleanIlaReverse() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaSegment.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/BooleanIlaSegment.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.booleanila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class BooleanIlaSegment {
     private BooleanIlaSegment() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIla.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.ImmutableLongArray;
 
-/**
- *
- * @immutables.types=all
- */
 public interface ByteIla extends ImmutableLongArray {
     void toArray(final byte[] array, final int arrayOffset, final long ilaStart, final int length)
             throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaAdd.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ByteIlaAdd {
     private ByteIlaAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaBound.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaBound.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ByteIlaBound {
     private ByteIlaBound() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaConcatenate.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaConcatenate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ByteIlaConcatenate {
     private ByteIlaConcatenate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaDecimate.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaDecimate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ByteIlaDecimate {
     private ByteIlaDecimate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaDivide.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ByteIlaDivide {
     private ByteIlaDivide() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFill.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFill.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.byteila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ByteIlaFill {
     private ByteIlaFill() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFiltered.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFiltered.java
@@ -4,10 +4,6 @@ import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.AbstractIlaCheck;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ByteIlaFiltered {
     private ByteIlaFiltered() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromArray.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromArray.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.byteila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ByteIlaFromArray {
     private ByteIlaFromArray() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastCharIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastCharIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaIterator;
 import tfw.immutable.ila.charila.CharIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 public final class ByteIlaFromCastCharIla {
     private ByteIlaFromCastCharIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastDoubleIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaIterator;
 import tfw.immutable.ila.doubleila.DoubleIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 public final class ByteIlaFromCastDoubleIla {
     private ByteIlaFromCastDoubleIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastFloatIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaIterator;
 import tfw.immutable.ila.floatila.FloatIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 public final class ByteIlaFromCastFloatIla {
     private ByteIlaFromCastFloatIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaIterator;
 import tfw.immutable.ila.intila.IntIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 public final class ByteIlaFromCastIntIla {
     private ByteIlaFromCastIntIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaIterator;
 import tfw.immutable.ila.longila.LongIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 public final class ByteIlaFromCastLongIla {
     private ByteIlaFromCastLongIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaIterator;
 import tfw.immutable.ila.shortila.ShortIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 public final class ByteIlaFromCastShortIla {
     private ByteIlaFromCastShortIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaInsert.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaInsert.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ByteIlaInsert {
     private ByteIlaInsert() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaInterleave.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaInterleave.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ByteIlaInterleave {
     private ByteIlaInterleave() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaIterator.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaIterator.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ByteIlaIterator {
     private final ByteIla instance;
     private final long instanceLength;

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaMultiply.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ByteIlaMultiply {
     private ByteIlaMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaMutate.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaMutate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ByteIlaMutate {
     private ByteIlaMutate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaNegate.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaNegate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ByteIlaNegate {
     private ByteIlaNegate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaRamp.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaRamp.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.byteila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ByteIlaRamp {
     private ByteIlaRamp() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaRemove.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaRemove.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ByteIlaRemove {
     private ByteIlaRemove() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaReverse.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaReverse.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ByteIlaReverse {
     private ByteIlaReverse() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaScalarAdd.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaScalarAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ByteIlaScalarAdd {
     private ByteIlaScalarAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaScalarMultiply.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaScalarMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ByteIlaScalarMultiply {
     private ByteIlaScalarMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaSegment.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaSegment.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ByteIlaSegment {
     private ByteIlaSegment() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaSubtract.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaSubtract.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.byteila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ByteIlaSubtract {
     private ByteIlaSubtract() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIla.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.ImmutableLongArray;
 
-/**
- *
- * @immutables.types=all
- */
 public interface CharIla extends ImmutableLongArray {
     void toArray(final char[] array, final int arrayOffset, final long ilaStart, final int length)
             throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaAdd.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class CharIlaAdd {
     private CharIlaAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaBound.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaBound.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class CharIlaBound {
     private CharIlaBound() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaConcatenate.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaConcatenate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class CharIlaConcatenate {
     private CharIlaConcatenate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaDecimate.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaDecimate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class CharIlaDecimate {
     private CharIlaDecimate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaDivide.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class CharIlaDivide {
     private CharIlaDivide() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFill.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFill.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.charila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class CharIlaFill {
     private CharIlaFill() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFiltered.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFiltered.java
@@ -4,10 +4,6 @@ import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.AbstractIlaCheck;
 
-/**
- *
- * @immutables.types=all
- */
 public final class CharIlaFiltered {
     private CharIlaFiltered() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromArray.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromArray.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.charila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class CharIlaFromArray {
     private CharIlaFromArray() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastByteIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastByteIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaIterator;
 import tfw.immutable.ila.byteila.ByteIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 public final class CharIlaFromCastByteIla {
     private CharIlaFromCastByteIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastDoubleIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaIterator;
 import tfw.immutable.ila.doubleila.DoubleIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 public final class CharIlaFromCastDoubleIla {
     private CharIlaFromCastDoubleIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastFloatIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaIterator;
 import tfw.immutable.ila.floatila.FloatIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 public final class CharIlaFromCastFloatIla {
     private CharIlaFromCastFloatIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastIntIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastIntIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaIterator;
 import tfw.immutable.ila.intila.IntIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 public final class CharIlaFromCastIntIla {
     private CharIlaFromCastIntIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastLongIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastLongIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaIterator;
 import tfw.immutable.ila.longila.LongIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 public final class CharIlaFromCastLongIla {
     private CharIlaFromCastLongIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastShortIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastShortIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaIterator;
 import tfw.immutable.ila.shortila.ShortIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 public final class CharIlaFromCastShortIla {
     private CharIlaFromCastShortIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaInsert.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaInsert.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class CharIlaInsert {
     private CharIlaInsert() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaInterleave.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaInterleave.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class CharIlaInterleave {
     private CharIlaInterleave() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaIterator.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaIterator.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class CharIlaIterator {
     private final CharIla instance;
     private final long instanceLength;

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaMultiply.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class CharIlaMultiply {
     private CharIlaMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaMutate.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaMutate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class CharIlaMutate {
     private CharIlaMutate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaNegate.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaNegate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class CharIlaNegate {
     private CharIlaNegate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaRamp.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaRamp.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.charila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class CharIlaRamp {
     private CharIlaRamp() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaRemove.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaRemove.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class CharIlaRemove {
     private CharIlaRemove() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaReverse.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaReverse.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class CharIlaReverse {
     private CharIlaReverse() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaScalarAdd.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaScalarAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class CharIlaScalarAdd {
     private CharIlaScalarAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaScalarMultiply.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaScalarMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class CharIlaScalarMultiply {
     private CharIlaScalarMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaSegment.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaSegment.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class CharIlaSegment {
     private CharIlaSegment() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaSubtract.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaSubtract.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.charila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class CharIlaSubtract {
     private CharIlaSubtract() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIla.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.ImmutableLongArray;
 
-/**
- *
- * @immutables.types=all
- */
 public interface DoubleIla extends ImmutableLongArray {
     void toArray(final double[] array, final int arrayOffset, final long ilaStart, final int length)
             throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaAdd.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class DoubleIlaAdd {
     private DoubleIlaAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaBound.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaBound.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class DoubleIlaBound {
     private DoubleIlaBound() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaConcatenate.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaConcatenate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class DoubleIlaConcatenate {
     private DoubleIlaConcatenate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaDecimate.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaDecimate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class DoubleIlaDecimate {
     private DoubleIlaDecimate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaDivide.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class DoubleIlaDivide {
     private DoubleIlaDivide() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFill.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFill.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.doubleila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class DoubleIlaFill {
     private DoubleIlaFill() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFiltered.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFiltered.java
@@ -4,10 +4,6 @@ import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.AbstractIlaCheck;
 
-/**
- *
- * @immutables.types=all
- */
 public final class DoubleIlaFiltered {
     private DoubleIlaFiltered() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromArray.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromArray.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.doubleila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class DoubleIlaFromArray {
     private DoubleIlaFromArray() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastByteIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastByteIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaIterator;
 import tfw.immutable.ila.byteila.ByteIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 public final class DoubleIlaFromCastByteIla {
     private DoubleIlaFromCastByteIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastCharIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastCharIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaIterator;
 import tfw.immutable.ila.charila.CharIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 public final class DoubleIlaFromCastCharIla {
     private DoubleIlaFromCastCharIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastFloatIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaIterator;
 import tfw.immutable.ila.floatila.FloatIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 public final class DoubleIlaFromCastFloatIla {
     private DoubleIlaFromCastFloatIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaIterator;
 import tfw.immutable.ila.intila.IntIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 public final class DoubleIlaFromCastIntIla {
     private DoubleIlaFromCastIntIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaIterator;
 import tfw.immutable.ila.longila.LongIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 public final class DoubleIlaFromCastLongIla {
     private DoubleIlaFromCastLongIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaIterator;
 import tfw.immutable.ila.shortila.ShortIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 public final class DoubleIlaFromCastShortIla {
     private DoubleIlaFromCastShortIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaInsert.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaInsert.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class DoubleIlaInsert {
     private DoubleIlaInsert() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaInterleave.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaInterleave.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class DoubleIlaInterleave {
     private DoubleIlaInterleave() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaInvert.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaInvert.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=floating
- */
 public final class DoubleIlaInvert {
     private DoubleIlaInvert() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaIterator.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaIterator.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class DoubleIlaIterator {
     private final DoubleIla instance;
     private final long instanceLength;

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaMultiply.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class DoubleIlaMultiply {
     private DoubleIlaMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaMutate.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaMutate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class DoubleIlaMutate {
     private DoubleIlaMutate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaNegate.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaNegate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class DoubleIlaNegate {
     private DoubleIlaNegate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaRamp.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaRamp.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.doubleila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class DoubleIlaRamp {
     private DoubleIlaRamp() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaRemove.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaRemove.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class DoubleIlaRemove {
     private DoubleIlaRemove() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaReverse.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaReverse.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class DoubleIlaReverse {
     private DoubleIlaReverse() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaRound.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaRound.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=floating
- */
 public final class DoubleIlaRound {
     private DoubleIlaRound() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaScalarAdd.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaScalarAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class DoubleIlaScalarAdd {
     private DoubleIlaScalarAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaScalarMultiply.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaScalarMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class DoubleIlaScalarMultiply {
     private DoubleIlaScalarMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaSegment.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaSegment.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class DoubleIlaSegment {
     private DoubleIlaSegment() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaSubtract.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaSubtract.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.doubleila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class DoubleIlaSubtract {
     private DoubleIlaSubtract() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIla.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.ImmutableLongArray;
 
-/**
- *
- * @immutables.types=all
- */
 public interface FloatIla extends ImmutableLongArray {
     void toArray(final float[] array, final int arrayOffset, final long ilaStart, final int length)
             throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaAdd.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class FloatIlaAdd {
     private FloatIlaAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaBound.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaBound.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class FloatIlaBound {
     private FloatIlaBound() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaConcatenate.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaConcatenate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class FloatIlaConcatenate {
     private FloatIlaConcatenate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaDecimate.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaDecimate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class FloatIlaDecimate {
     private FloatIlaDecimate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaDivide.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class FloatIlaDivide {
     private FloatIlaDivide() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFill.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFill.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.floatila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class FloatIlaFill {
     private FloatIlaFill() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFiltered.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFiltered.java
@@ -4,10 +4,6 @@ import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.AbstractIlaCheck;
 
-/**
- *
- * @immutables.types=all
- */
 public final class FloatIlaFiltered {
     private FloatIlaFiltered() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromArray.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromArray.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.floatila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class FloatIlaFromArray {
     private FloatIlaFromArray() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastByteIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastByteIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaIterator;
 import tfw.immutable.ila.byteila.ByteIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 public final class FloatIlaFromCastByteIla {
     private FloatIlaFromCastByteIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastCharIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastCharIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaIterator;
 import tfw.immutable.ila.charila.CharIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 public final class FloatIlaFromCastCharIla {
     private FloatIlaFromCastCharIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastDoubleIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaIterator;
 import tfw.immutable.ila.doubleila.DoubleIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 public final class FloatIlaFromCastDoubleIla {
     private FloatIlaFromCastDoubleIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaIterator;
 import tfw.immutable.ila.intila.IntIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 public final class FloatIlaFromCastIntIla {
     private FloatIlaFromCastIntIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaIterator;
 import tfw.immutable.ila.longila.LongIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 public final class FloatIlaFromCastLongIla {
     private FloatIlaFromCastLongIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaIterator;
 import tfw.immutable.ila.shortila.ShortIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 public final class FloatIlaFromCastShortIla {
     private FloatIlaFromCastShortIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaInsert.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaInsert.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class FloatIlaInsert {
     private FloatIlaInsert() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaInterleave.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaInterleave.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class FloatIlaInterleave {
     private FloatIlaInterleave() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaInvert.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaInvert.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=floating
- */
 public final class FloatIlaInvert {
     private FloatIlaInvert() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaIterator.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaIterator.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class FloatIlaIterator {
     private final FloatIla instance;
     private final long instanceLength;

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaMultiply.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class FloatIlaMultiply {
     private FloatIlaMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaMutate.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaMutate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class FloatIlaMutate {
     private FloatIlaMutate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaNegate.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaNegate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class FloatIlaNegate {
     private FloatIlaNegate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaRamp.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaRamp.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.floatila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class FloatIlaRamp {
     private FloatIlaRamp() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaRemove.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaRemove.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class FloatIlaRemove {
     private FloatIlaRemove() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaReverse.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaReverse.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class FloatIlaReverse {
     private FloatIlaReverse() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaRound.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaRound.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=floating
- */
 public final class FloatIlaRound {
     private FloatIlaRound() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaScalarAdd.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaScalarAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class FloatIlaScalarAdd {
     private FloatIlaScalarAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaScalarMultiply.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaScalarMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class FloatIlaScalarMultiply {
     private FloatIlaScalarMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaSegment.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaSegment.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class FloatIlaSegment {
     private FloatIlaSegment() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaSubtract.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaSubtract.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.floatila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class FloatIlaSubtract {
     private FloatIlaSubtract() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIla.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.ImmutableLongArray;
 
-/**
- *
- * @immutables.types=all
- */
 public interface IntIla extends ImmutableLongArray {
     void toArray(final int[] array, final int arrayOffset, final long ilaStart, final int length)
             throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaAdd.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class IntIlaAdd {
     private IntIlaAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaBound.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaBound.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class IntIlaBound {
     private IntIlaBound() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaConcatenate.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaConcatenate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class IntIlaConcatenate {
     private IntIlaConcatenate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaDecimate.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaDecimate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class IntIlaDecimate {
     private IntIlaDecimate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaDivide.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class IntIlaDivide {
     private IntIlaDivide() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFill.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFill.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.intila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class IntIlaFill {
     private IntIlaFill() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFiltered.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFiltered.java
@@ -4,10 +4,6 @@ import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.AbstractIlaCheck;
 
-/**
- *
- * @immutables.types=all
- */
 public final class IntIlaFiltered {
     private IntIlaFiltered() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromArray.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromArray.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.intila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class IntIlaFromArray {
     private IntIlaFromArray() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastByteIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastByteIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaIterator;
 import tfw.immutable.ila.byteila.ByteIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 public final class IntIlaFromCastByteIla {
     private IntIlaFromCastByteIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastCharIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastCharIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaIterator;
 import tfw.immutable.ila.charila.CharIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 public final class IntIlaFromCastCharIla {
     private IntIlaFromCastCharIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastDoubleIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaIterator;
 import tfw.immutable.ila.doubleila.DoubleIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 public final class IntIlaFromCastDoubleIla {
     private IntIlaFromCastDoubleIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastFloatIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaIterator;
 import tfw.immutable.ila.floatila.FloatIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 public final class IntIlaFromCastFloatIla {
     private IntIlaFromCastFloatIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastLongIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastLongIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaIterator;
 import tfw.immutable.ila.longila.LongIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 public final class IntIlaFromCastLongIla {
     private IntIlaFromCastLongIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastShortIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastShortIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaIterator;
 import tfw.immutable.ila.shortila.ShortIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 public final class IntIlaFromCastShortIla {
     private IntIlaFromCastShortIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaInsert.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaInsert.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class IntIlaInsert {
     private IntIlaInsert() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaInterleave.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaInterleave.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class IntIlaInterleave {
     private IntIlaInterleave() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaIterator.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaIterator.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class IntIlaIterator {
     private final IntIla instance;
     private final long instanceLength;

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaMultiply.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class IntIlaMultiply {
     private IntIlaMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaMutate.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaMutate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class IntIlaMutate {
     private IntIlaMutate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaNegate.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaNegate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class IntIlaNegate {
     private IntIlaNegate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaRamp.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaRamp.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.intila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class IntIlaRamp {
     private IntIlaRamp() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaRemove.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaRemove.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class IntIlaRemove {
     private IntIlaRemove() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaReverse.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaReverse.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class IntIlaReverse {
     private IntIlaReverse() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaScalarAdd.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaScalarAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class IntIlaScalarAdd {
     private IntIlaScalarAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaScalarMultiply.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaScalarMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class IntIlaScalarMultiply {
     private IntIlaScalarMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaSegment.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaSegment.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class IntIlaSegment {
     private IntIlaSegment() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaSubtract.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaSubtract.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.intila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class IntIlaSubtract {
     private IntIlaSubtract() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIla.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.ImmutableLongArray;
 
-/**
- *
- * @immutables.types=all
- */
 public interface LongIla extends ImmutableLongArray {
     void toArray(final long[] array, final int arrayOffset, final long ilaStart, final int length)
             throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaAdd.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class LongIlaAdd {
     private LongIlaAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaBound.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaBound.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class LongIlaBound {
     private LongIlaBound() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaConcatenate.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaConcatenate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class LongIlaConcatenate {
     private LongIlaConcatenate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaDecimate.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaDecimate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class LongIlaDecimate {
     private LongIlaDecimate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaDivide.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class LongIlaDivide {
     private LongIlaDivide() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFill.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFill.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.longila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class LongIlaFill {
     private LongIlaFill() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFiltered.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFiltered.java
@@ -4,10 +4,6 @@ import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.AbstractIlaCheck;
 
-/**
- *
- * @immutables.types=all
- */
 public final class LongIlaFiltered {
     private LongIlaFiltered() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromArray.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromArray.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.longila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class LongIlaFromArray {
     private LongIlaFromArray() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastByteIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastByteIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaIterator;
 import tfw.immutable.ila.byteila.ByteIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 public final class LongIlaFromCastByteIla {
     private LongIlaFromCastByteIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastCharIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastCharIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaIterator;
 import tfw.immutable.ila.charila.CharIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 public final class LongIlaFromCastCharIla {
     private LongIlaFromCastCharIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastDoubleIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaIterator;
 import tfw.immutable.ila.doubleila.DoubleIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 public final class LongIlaFromCastDoubleIla {
     private LongIlaFromCastDoubleIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastFloatIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaIterator;
 import tfw.immutable.ila.floatila.FloatIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 public final class LongIlaFromCastFloatIla {
     private LongIlaFromCastFloatIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastIntIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastIntIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaIterator;
 import tfw.immutable.ila.intila.IntIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 public final class LongIlaFromCastIntIla {
     private LongIlaFromCastIntIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastShortIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastShortIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaIterator;
 import tfw.immutable.ila.shortila.ShortIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 public final class LongIlaFromCastShortIla {
     private LongIlaFromCastShortIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaInsert.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaInsert.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class LongIlaInsert {
     private LongIlaInsert() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaInterleave.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaInterleave.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class LongIlaInterleave {
     private LongIlaInterleave() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaIterator.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaIterator.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class LongIlaIterator {
     private final LongIla instance;
     private final long instanceLength;

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaMultiply.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class LongIlaMultiply {
     private LongIlaMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaMutate.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaMutate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class LongIlaMutate {
     private LongIlaMutate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaNegate.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaNegate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class LongIlaNegate {
     private LongIlaNegate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaRamp.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaRamp.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.longila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class LongIlaRamp {
     private LongIlaRamp() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaRemove.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaRemove.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class LongIlaRemove {
     private LongIlaRemove() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaReverse.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaReverse.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class LongIlaReverse {
     private LongIlaReverse() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaScalarAdd.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaScalarAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class LongIlaScalarAdd {
     private LongIlaScalarAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaScalarMultiply.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaScalarMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class LongIlaScalarMultiply {
     private LongIlaScalarMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaSegment.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaSegment.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class LongIlaSegment {
     private LongIlaSegment() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaSubtract.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaSubtract.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.longila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class LongIlaSubtract {
     private LongIlaSubtract() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIla.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIla.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.ImmutableLongArray;
 
-/**
- *
- * @immutables.types=all
- */
 public interface ObjectIla<T> extends ImmutableLongArray {
     void toArray(final T[] array, final int arrayOffset, final long ilaStart, final int length)
             throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIlaConcatenate.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIlaConcatenate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ObjectIlaConcatenate {
     private ObjectIlaConcatenate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIlaDecimate.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIlaDecimate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ObjectIlaDecimate {
     private ObjectIlaDecimate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIlaFill.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIlaFill.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.objectila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ObjectIlaFill {
     private ObjectIlaFill() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIlaFiltered.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIlaFiltered.java
@@ -4,10 +4,6 @@ import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.AbstractIlaCheck;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ObjectIlaFiltered<T> {
     private ObjectIlaFiltered() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIlaFromArray.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIlaFromArray.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.objectila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ObjectIlaFromArray {
     private ObjectIlaFromArray() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIlaInsert.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIlaInsert.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ObjectIlaInsert {
     private ObjectIlaInsert() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIlaInterleave.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIlaInterleave.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ObjectIlaInterleave {
     private ObjectIlaInterleave() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIlaIterator.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIlaIterator.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ObjectIlaIterator<T> {
     private final ObjectIla<T> instance;
     private final long instanceLength;

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIlaMutate.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIlaMutate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ObjectIlaMutate {
     private ObjectIlaMutate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIlaRemove.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIlaRemove.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ObjectIlaRemove {
     private ObjectIlaRemove() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIlaReverse.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIlaReverse.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ObjectIlaReverse {
     private ObjectIlaReverse() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/objectila/ObjectIlaSegment.java
+++ b/src/main/java/tfw/immutable/ila/objectila/ObjectIlaSegment.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ObjectIlaSegment {
     private ObjectIlaSegment() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIla.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.ImmutableLongArray;
 
-/**
- *
- * @immutables.types=all
- */
 public interface ShortIla extends ImmutableLongArray {
     void toArray(final short[] array, final int arrayOffset, final long ilaStart, final int length)
             throws DataInvalidException;

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaAdd.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ShortIlaAdd {
     private ShortIlaAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaBound.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaBound.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ShortIlaBound {
     private ShortIlaBound() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaConcatenate.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaConcatenate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ShortIlaConcatenate {
     private ShortIlaConcatenate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaDecimate.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaDecimate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ShortIlaDecimate {
     private ShortIlaDecimate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaDivide.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ShortIlaDivide {
     private ShortIlaDivide() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFill.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFill.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.shortila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ShortIlaFill {
     private ShortIlaFill() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFiltered.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFiltered.java
@@ -4,10 +4,6 @@ import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.AbstractIlaCheck;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ShortIlaFiltered {
     private ShortIlaFiltered() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromArray.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromArray.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.shortila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ShortIlaFromArray {
     private ShortIlaFromArray() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastByteIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastByteIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaIterator;
 import tfw.immutable.ila.byteila.ByteIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 public final class ShortIlaFromCastByteIla {
     private ShortIlaFromCastByteIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastCharIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastCharIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaIterator;
 import tfw.immutable.ila.charila.CharIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 public final class ShortIlaFromCastCharIla {
     private ShortIlaFromCastCharIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastDoubleIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaIterator;
 import tfw.immutable.ila.doubleila.DoubleIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 public final class ShortIlaFromCastDoubleIla {
     private ShortIlaFromCastDoubleIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastFloatIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaIterator;
 import tfw.immutable.ila.floatila.FloatIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 public final class ShortIlaFromCastFloatIla {
     private ShortIlaFromCastFloatIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaIterator;
 import tfw.immutable.ila.intila.IntIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 public final class ShortIlaFromCastIntIla {
     private ShortIlaFromCastIntIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIla.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaIterator;
 import tfw.immutable.ila.longila.LongIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 public final class ShortIlaFromCastLongIla {
     private ShortIlaFromCastLongIla() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaInsert.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaInsert.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ShortIlaInsert {
     private ShortIlaInsert() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaInterleave.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaInterleave.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ShortIlaInterleave {
     private ShortIlaInterleave() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaIterator.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaIterator.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ShortIlaIterator {
     private final ShortIla instance;
     private final long instanceLength;

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaMultiply.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ShortIlaMultiply {
     private ShortIlaMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaMutate.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaMutate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ShortIlaMutate {
     private ShortIlaMutate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaNegate.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaNegate.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ShortIlaNegate {
     private ShortIlaNegate() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaRamp.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaRamp.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.shortila;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ShortIlaRamp {
     private ShortIlaRamp() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaRemove.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaRemove.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ShortIlaRemove {
     private ShortIlaRemove() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaReverse.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaReverse.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ShortIlaReverse {
     private ShortIlaReverse() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaScalarAdd.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaScalarAdd.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ShortIlaScalarAdd {
     private ShortIlaScalarAdd() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaScalarMultiply.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaScalarMultiply.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ShortIlaScalarMultiply {
     private ShortIlaScalarMultiply() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaSegment.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaSegment.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class ShortIlaSegment {
     private ShortIlaSegment() {
         // non-instantiable class

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaSubtract.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaSubtract.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.shortila;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ShortIlaSubtract {
     private ShortIlaSubtract() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__Ila.template
+++ b/src/main/template/tfw/immutable/ila/__Ila.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.ImmutableLongArray;
 
-/**
- *
- * @immutables.types=all
- */
 public interface %%NAME%%Ila%%TEMPLATE%% extends ImmutableLongArray {
     void toArray(final %%TYPE_OR_TEMPLATE%%[] array, final int arrayOffset, final long ilaStart, final int length)
             throws DataInvalidException;

--- a/src/main/template/tfw/immutable/ila/__IlaAdd.template
+++ b/src/main/template/tfw/immutable/ila/__IlaAdd.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class %%NAME%%IlaAdd {
     private %%NAME%%IlaAdd() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaBound.template
+++ b/src/main/template/tfw/immutable/ila/__IlaBound.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class %%NAME%%IlaBound {
     private %%NAME%%IlaBound() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaConcatenate.template
+++ b/src/main/template/tfw/immutable/ila/__IlaConcatenate.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class %%NAME%%IlaConcatenate {
     private %%NAME%%IlaConcatenate() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaDecimate.template
+++ b/src/main/template/tfw/immutable/ila/__IlaDecimate.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class %%NAME%%IlaDecimate {
     private %%NAME%%IlaDecimate() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaDivide.template
+++ b/src/main/template/tfw/immutable/ila/__IlaDivide.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class %%NAME%%IlaDivide {
     private %%NAME%%IlaDivide() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaFill.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFill.template
@@ -3,10 +3,6 @@ package %%PACKAGE%%;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class %%NAME%%IlaFill {
     private %%NAME%%IlaFill() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaFiltered.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFiltered.template
@@ -5,10 +5,6 @@ import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 import tfw.immutable.ila.AbstractIlaCheck;
 
-/**
- *
- * @immutables.types=all
- */
 public final class %%NAME%%IlaFiltered%%TEMPLATE%% {
     private %%NAME%%IlaFiltered() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaFromArray.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromArray.template
@@ -3,10 +3,6 @@ package %%PACKAGE%%;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=all
- */
 public final class %%NAME%%IlaFromArray {
     private %%NAME%%IlaFromArray() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastByteIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastByteIla.template
@@ -7,10 +7,6 @@ import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaIterator;
 import tfw.immutable.ila.byteila.ByteIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 public final class %%NAME%%IlaFromCastByteIla {
     private %%NAME%%IlaFromCastByteIla() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastCharIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastCharIla.template
@@ -7,10 +7,6 @@ import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaIterator;
 import tfw.immutable.ila.charila.CharIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 public final class %%NAME%%IlaFromCastCharIla {
     private %%NAME%%IlaFromCastCharIla() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastDoubleIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastDoubleIla.template
@@ -7,10 +7,6 @@ import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaIterator;
 import tfw.immutable.ila.doubleila.DoubleIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 public final class %%NAME%%IlaFromCastDoubleIla {
     private %%NAME%%IlaFromCastDoubleIla() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastFloatIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastFloatIla.template
@@ -7,10 +7,6 @@ import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaIterator;
 import tfw.immutable.ila.floatila.FloatIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 public final class %%NAME%%IlaFromCastFloatIla {
     private %%NAME%%IlaFromCastFloatIla() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastIntIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastIntIla.template
@@ -7,10 +7,6 @@ import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaIterator;
 import tfw.immutable.ila.intila.IntIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 public final class %%NAME%%IlaFromCastIntIla {
     private %%NAME%%IlaFromCastIntIla() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastLongIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastLongIla.template
@@ -7,10 +7,6 @@ import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaIterator;
 import tfw.immutable.ila.longila.LongIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 public final class %%NAME%%IlaFromCastLongIla {
     private %%NAME%%IlaFromCastLongIla() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastShortIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastShortIla.template
@@ -7,10 +7,6 @@ import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaIterator;
 import tfw.immutable.ila.shortila.ShortIlaSegment;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 public final class %%NAME%%IlaFromCastShortIla {
     private %%NAME%%IlaFromCastShortIla() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaInsert.template
+++ b/src/main/template/tfw/immutable/ila/__IlaInsert.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class %%NAME%%IlaInsert {
     private %%NAME%%IlaInsert() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaInterleave.template
+++ b/src/main/template/tfw/immutable/ila/__IlaInterleave.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class %%NAME%%IlaInterleave {
     private %%NAME%%IlaInterleave() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaInvert.template
+++ b/src/main/template/tfw/immutable/ila/__IlaInvert.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=floating
- */
 public final class %%NAME%%IlaInvert {
     private %%NAME%%IlaInvert() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaIterator.template
+++ b/src/main/template/tfw/immutable/ila/__IlaIterator.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class %%NAME%%IlaIterator%%TEMPLATE%% {
     private final %%NAME%%Ila%%TEMPLATE%% instance;
     private final long instanceLength;

--- a/src/main/template/tfw/immutable/ila/__IlaMultiply.template
+++ b/src/main/template/tfw/immutable/ila/__IlaMultiply.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class %%NAME%%IlaMultiply {
     private %%NAME%%IlaMultiply() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaMutate.template
+++ b/src/main/template/tfw/immutable/ila/__IlaMutate.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class %%NAME%%IlaMutate {
     private %%NAME%%IlaMutate() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaNegate.template
+++ b/src/main/template/tfw/immutable/ila/__IlaNegate.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class %%NAME%%IlaNegate {
     private %%NAME%%IlaNegate() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaRamp.template
+++ b/src/main/template/tfw/immutable/ila/__IlaRamp.template
@@ -3,10 +3,6 @@ package %%PACKAGE%%;
 
 import tfw.check.Argument;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class %%NAME%%IlaRamp {
     private %%NAME%%IlaRamp() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaRemove.template
+++ b/src/main/template/tfw/immutable/ila/__IlaRemove.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class %%NAME%%IlaRemove {
     private %%NAME%%IlaRemove() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaReverse.template
+++ b/src/main/template/tfw/immutable/ila/__IlaReverse.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class %%NAME%%IlaReverse {
     private %%NAME%%IlaReverse() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaRound.template
+++ b/src/main/template/tfw/immutable/ila/__IlaRound.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=floating
- */
 public final class %%NAME%%IlaRound {
     private %%NAME%%IlaRound() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaScalarAdd.template
+++ b/src/main/template/tfw/immutable/ila/__IlaScalarAdd.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class %%NAME%%IlaScalarAdd {
     private %%NAME%%IlaScalarAdd() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaScalarMultiply.template
+++ b/src/main/template/tfw/immutable/ila/__IlaScalarMultiply.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class %%NAME%%IlaScalarMultiply {
     private %%NAME%%IlaScalarMultiply() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaSegment.template
+++ b/src/main/template/tfw/immutable/ila/__IlaSegment.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=all
- */
 public final class %%NAME%%IlaSegment {
     private %%NAME%%IlaSegment() {
         // non-instantiable class

--- a/src/main/template/tfw/immutable/ila/__IlaSubtract.template
+++ b/src/main/template/tfw/immutable/ila/__IlaSubtract.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 import tfw.check.Argument;
 import tfw.immutable.DataInvalidException;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class %%NAME%%IlaSubtract {
     private %%NAME%%IlaSubtract() {
         // non-instantiable class


### PR DESCRIPTION
This PR removes the empty javadoc from the src/main templates that had custom tags that was giving errorprone warnings.