### PR TITLE
Remove empty Javadoc from the src/test templates.

### DIFF
--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.booleanila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=nonnumeric
- */
 public final class BooleanIlaCheck {
     private BooleanIlaCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaConcatenateTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaConcatenateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class BooleanIlaConcatenateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaDecimateTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaDecimateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class BooleanIlaDecimateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaFillTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaFillTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class BooleanIlaFillTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaFromArrayTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaFromArrayTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class BooleanIlaFromArrayTest {
     @Test
     void testImmutabilityCheck() throws Exception {

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaInsertTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaInsertTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class BooleanIlaInsertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaInterleaveTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaInterleaveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class BooleanIlaInterleaveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaMutateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class BooleanIlaMutateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaRemoveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class BooleanIlaRemoveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaReverseTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class BooleanIlaReverseTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaSegmentTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class BooleanIlaSegmentTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaUtilCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.booleanila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=nonnumeric
- */
 public final class BooleanIlaUtilCheck {
     private BooleanIlaUtilCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ByteIlaAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaBoundTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ByteIlaBoundTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.byteila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ByteIlaCheck {
     private ByteIlaCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaConcatenateTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaConcatenateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ByteIlaConcatenateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaDecimateTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaDecimateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ByteIlaDecimateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaDivideTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ByteIlaDivideTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFillTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFillTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ByteIlaFillTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromArrayTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromArrayTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ByteIlaFromArrayTest {
     @Test
     void testImmutabilityCheck() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastCharIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastCharIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 class ByteIlaFromCastCharIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastDoubleIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastDoubleIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 class ByteIlaFromCastDoubleIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastFloatIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastFloatIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 class ByteIlaFromCastFloatIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 class ByteIlaFromCastIntIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 class ByteIlaFromCastLongIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 class ByteIlaFromCastShortIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaInsertTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaInsertTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ByteIlaInsertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaInterleaveTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaInterleaveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ByteIlaInterleaveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ByteIlaMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaMutateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ByteIlaMutateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaNegateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ByteIlaNegateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaRampTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ByteIlaRampTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaRemoveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ByteIlaRemoveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaReverseTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ByteIlaReverseTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ByteIlaScalarAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ByteIlaScalarMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaSegmentTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ByteIlaSegmentTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaSubtractTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ByteIlaSubtractTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaUtilCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.byteila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ByteIlaUtilCheck {
     private ByteIlaUtilCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class CharIlaAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaBoundTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class CharIlaBoundTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.charila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class CharIlaCheck {
     private CharIlaCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaConcatenateTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaConcatenateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class CharIlaConcatenateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaDecimateTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaDecimateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class CharIlaDecimateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaDivideTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class CharIlaDivideTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFillTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFillTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class CharIlaFillTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromArrayTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromArrayTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class CharIlaFromArrayTest {
     @Test
     void testImmutabilityCheck() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastByteIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 class CharIlaFromCastByteIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastDoubleIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastDoubleIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 class CharIlaFromCastDoubleIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastFloatIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastFloatIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 class CharIlaFromCastFloatIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastIntIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 class CharIlaFromCastIntIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastLongIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 class CharIlaFromCastLongIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastShortIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastShortIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 class CharIlaFromCastShortIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaInsertTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaInsertTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class CharIlaInsertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaInterleaveTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaInterleaveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class CharIlaInterleaveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class CharIlaMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaMutateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class CharIlaMutateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaNegateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class CharIlaNegateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaRampTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class CharIlaRampTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaRemoveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class CharIlaRemoveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaReverseTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class CharIlaReverseTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaScalarAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class CharIlaScalarAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaScalarMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class CharIlaScalarMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaSegmentTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class CharIlaSegmentTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaSubtractTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class CharIlaSubtractTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaUtilCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.charila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class CharIlaUtilCheck {
     private CharIlaUtilCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class DoubleIlaAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaBoundTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class DoubleIlaBoundTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.doubleila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class DoubleIlaCheck {
     private DoubleIlaCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaConcatenateTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaConcatenateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class DoubleIlaConcatenateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaDecimateTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaDecimateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class DoubleIlaDecimateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaDivideTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class DoubleIlaDivideTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFillTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFillTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class DoubleIlaFillTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromArrayTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromArrayTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class DoubleIlaFromArrayTest {
     @Test
     void testImmutabilityCheck() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastByteIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 class DoubleIlaFromCastByteIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastCharIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastCharIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 class DoubleIlaFromCastCharIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastFloatIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastFloatIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 class DoubleIlaFromCastFloatIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 class DoubleIlaFromCastIntIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 class DoubleIlaFromCastLongIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 class DoubleIlaFromCastShortIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaInsertTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaInsertTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class DoubleIlaInsertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaInterleaveTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaInterleaveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class DoubleIlaInterleaveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaInvertTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaInvertTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=floating
- */
 class DoubleIlaInvertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class DoubleIlaMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMutateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class DoubleIlaMutateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaNegateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class DoubleIlaNegateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRampTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class DoubleIlaRampTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRemoveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class DoubleIlaRemoveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaReverseTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class DoubleIlaReverseTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRoundTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRoundTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=floating
- */
 class DoubleIlaRoundTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class DoubleIlaScalarAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class DoubleIlaScalarMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSegmentTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class DoubleIlaSegmentTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSubtractTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class DoubleIlaSubtractTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaUtilCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.doubleila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class DoubleIlaUtilCheck {
     private DoubleIlaUtilCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class FloatIlaAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaBoundTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class FloatIlaBoundTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.floatila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class FloatIlaCheck {
     private FloatIlaCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaConcatenateTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaConcatenateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class FloatIlaConcatenateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaDecimateTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaDecimateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class FloatIlaDecimateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaDivideTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class FloatIlaDivideTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFillTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFillTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class FloatIlaFillTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromArrayTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromArrayTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class FloatIlaFromArrayTest {
     @Test
     void testImmutabilityCheck() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastByteIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 class FloatIlaFromCastByteIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastCharIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastCharIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 class FloatIlaFromCastCharIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastDoubleIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastDoubleIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 class FloatIlaFromCastDoubleIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 class FloatIlaFromCastIntIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 class FloatIlaFromCastLongIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 class FloatIlaFromCastShortIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaInsertTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaInsertTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class FloatIlaInsertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaInterleaveTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaInterleaveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class FloatIlaInterleaveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaInvertTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaInvertTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=floating
- */
 class FloatIlaInvertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class FloatIlaMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaMutateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class FloatIlaMutateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaNegateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class FloatIlaNegateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaRampTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class FloatIlaRampTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaRemoveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class FloatIlaRemoveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaReverseTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class FloatIlaReverseTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaRoundTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaRoundTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=floating
- */
 class FloatIlaRoundTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class FloatIlaScalarAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class FloatIlaScalarMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaSegmentTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class FloatIlaSegmentTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaSubtractTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class FloatIlaSubtractTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaUtilCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.floatila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class FloatIlaUtilCheck {
     private FloatIlaUtilCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class IntIlaAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaBoundTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class IntIlaBoundTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.intila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class IntIlaCheck {
     private IntIlaCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaConcatenateTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaConcatenateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class IntIlaConcatenateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaDecimateTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaDecimateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class IntIlaDecimateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaDivideTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class IntIlaDivideTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFillTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFillTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class IntIlaFillTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromArrayTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromArrayTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class IntIlaFromArrayTest {
     @Test
     void testImmutabilityCheck() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastByteIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 class IntIlaFromCastByteIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastCharIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastCharIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 class IntIlaFromCastCharIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastDoubleIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastDoubleIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 class IntIlaFromCastDoubleIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastFloatIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastFloatIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 class IntIlaFromCastFloatIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastLongIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 class IntIlaFromCastLongIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastShortIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastShortIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 class IntIlaFromCastShortIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaInsertTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaInsertTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class IntIlaInsertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaInterleaveTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaInterleaveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class IntIlaInterleaveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class IntIlaMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaMutateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class IntIlaMutateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaNegateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class IntIlaNegateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaRampTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class IntIlaRampTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaRemoveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class IntIlaRemoveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaReverseTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class IntIlaReverseTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaScalarAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class IntIlaScalarAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaScalarMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class IntIlaScalarMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaSegmentTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class IntIlaSegmentTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaSubtractTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class IntIlaSubtractTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaUtilCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.intila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class IntIlaUtilCheck {
     private IntIlaUtilCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class LongIlaAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaBoundTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class LongIlaBoundTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.longila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class LongIlaCheck {
     private LongIlaCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaConcatenateTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaConcatenateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class LongIlaConcatenateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaDecimateTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaDecimateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class LongIlaDecimateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaDivideTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class LongIlaDivideTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFillTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFillTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class LongIlaFillTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromArrayTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromArrayTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class LongIlaFromArrayTest {
     @Test
     void testImmutabilityCheck() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastByteIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 class LongIlaFromCastByteIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastCharIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastCharIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 class LongIlaFromCastCharIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastDoubleIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastDoubleIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 class LongIlaFromCastDoubleIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastFloatIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastFloatIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 class LongIlaFromCastFloatIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastIntIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 class LongIlaFromCastIntIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastShortIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastShortIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 class LongIlaFromCastShortIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaInsertTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaInsertTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class LongIlaInsertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaInterleaveTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaInterleaveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class LongIlaInterleaveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class LongIlaMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaMutateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class LongIlaMutateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaNegateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class LongIlaNegateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaRampTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class LongIlaRampTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaRemoveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class LongIlaRemoveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaReverseTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class LongIlaReverseTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaScalarAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class LongIlaScalarAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaScalarMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class LongIlaScalarMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaSegmentTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class LongIlaSegmentTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaSubtractTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class LongIlaSubtractTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaUtilCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.longila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class LongIlaUtilCheck {
     private LongIlaUtilCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java
@@ -1,9 +1,5 @@
 package tfw.immutable.ila.objectila;
 
-/**
- *
- * @immutables.types=nonnumeric
- */
 public final class ObjectIlaCheck {
     private ObjectIlaCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaConcatenateTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaConcatenateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ObjectIlaConcatenateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaDecimateTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaDecimateTest.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ObjectIlaDecimateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaFillTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaFillTest.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ObjectIlaFillTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaFromArrayTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaFromArrayTest.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ObjectIlaFromArrayTest {
     @Test
     void testImmutabilityCheck() throws Exception {

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaInsertTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaInsertTest.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ObjectIlaInsertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaInterleaveTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaInterleaveTest.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ObjectIlaInterleaveTest {
     @Test
     @SuppressWarnings("unchecked")

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaMutateTest.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ObjectIlaMutateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaRemoveTest.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ObjectIlaRemoveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaReverseTest.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ObjectIlaReverseTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaSegmentTest.java
@@ -3,10 +3,6 @@ package tfw.immutable.ila.objectila;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ObjectIlaSegmentTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ShortIlaAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaBoundTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ShortIlaBoundTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.shortila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ShortIlaCheck {
     private ShortIlaCheck() {
         // non-instantiable class

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaConcatenateTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaConcatenateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ShortIlaConcatenateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaDecimateTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaDecimateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ShortIlaDecimateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaDivideTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ShortIlaDivideTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFillTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFillTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ShortIlaFillTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromArrayTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromArrayTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ShortIlaFromArrayTest {
     @Test
     void testImmutabilityCheck() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastByteIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 class ShortIlaFromCastByteIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastCharIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastCharIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 class ShortIlaFromCastCharIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastDoubleIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastDoubleIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 class ShortIlaFromCastDoubleIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastFloatIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastFloatIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 class ShortIlaFromCastFloatIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 class ShortIlaFromCastIntIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIlaTest.java
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 class ShortIlaFromCastLongIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaInsertTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaInsertTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ShortIlaInsertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaInterleaveTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaInterleaveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ShortIlaInterleaveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ShortIlaMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaMutateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ShortIlaMutateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaNegateTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ShortIlaNegateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaRampTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ShortIlaRampTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaRemoveTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ShortIlaRemoveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaReverseTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ShortIlaReverseTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarAddTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ShortIlaScalarAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarMultiplyTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ShortIlaScalarMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaSegmentTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class ShortIlaSegmentTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaSubtractTest.java
@@ -4,10 +4,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class ShortIlaSubtractTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaUtilCheck.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaUtilCheck.java
@@ -2,10 +2,6 @@ package tfw.immutable.ila.shortila;
 
 import java.util.Random;
 
-/**
- *
- * @immutables.types=numeric
- */
 public final class ShortIlaUtilCheck {
     private ShortIlaUtilCheck() {
         // non-instantiable class

--- a/src/test/template/tfw/immutable/ila/__IlaAddTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaAddTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class %%NAME%%IlaAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaBoundTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaBoundTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class %%NAME%%IlaBoundTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaCheck..NonNumeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaCheck..NonNumeric.template
@@ -1,11 +1,7 @@
 // booleanila,objectila
 package %%PACKAGE%%;
 
-%%RANDOM_INCLUDE_2%%/**
- *
- * @immutables.types=nonnumeric
- */
-public final class %%NAME%%IlaCheck {
+%%RANDOM_INCLUDE_2%%public final class %%NAME%%IlaCheck {
     private %%NAME%%IlaCheck() {
         // non-instantiable class
     }

--- a/src/test/template/tfw/immutable/ila/__IlaCheck..Numeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaCheck..Numeric.template
@@ -2,10 +2,6 @@
 package %%PACKAGE%%;
 
 %%RANDOM_INCLUDE%%
-/**
- *
- * @immutables.types=numeric
- */
 public final class %%NAME%%IlaCheck {
     private %%NAME%%IlaCheck() {
         // non-instantiable class

--- a/src/test/template/tfw/immutable/ila/__IlaConcatenateTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaConcatenateTest.template
@@ -5,10 +5,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class %%NAME%%IlaConcatenateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaDecimateTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaDecimateTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class %%NAME%%IlaDecimateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaDivideTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaDivideTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class %%NAME%%IlaDivideTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaFillTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFillTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class %%NAME%%IlaFillTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaFromArrayTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromArrayTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class %%NAME%%IlaFromArrayTest {
     @Test
     void testImmutabilityCheck() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastByteIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastByteIlaTest.template
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotbyte
- */
 class %%NAME%%IlaFromCastByteIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastCharIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastCharIlaTest.template
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotchar
- */
 class %%NAME%%IlaFromCastCharIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastDoubleIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastDoubleIlaTest.template
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotdouble
- */
 class %%NAME%%IlaFromCastDoubleIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastFloatIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastFloatIlaTest.template
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotfloat
- */
 class %%NAME%%IlaFromCastFloatIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastIntIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastIntIlaTest.template
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotint
- */
 class %%NAME%%IlaFromCastIntIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastLongIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastLongIlaTest.template
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotlong
- */
 class %%NAME%%IlaFromCastLongIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastShortIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastShortIlaTest.template
@@ -6,10 +6,6 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-/**
- *
- * @immutables.types=numericnotshort
- */
 class %%NAME%%IlaFromCastShortIlaTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaInsertTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaInsertTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class %%NAME%%IlaInsertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaInterleaveTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaInterleaveTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class %%NAME%%IlaInterleaveTest {
     @Test%%SUPPRESS%%
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaInvertTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaInvertTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=floating
- */
 class %%NAME%%IlaInvertTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaMultiplyTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaMultiplyTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class %%NAME%%IlaMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaMutateTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaMutateTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class %%NAME%%IlaMutateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaNegateTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaNegateTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class %%NAME%%IlaNegateTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaRampTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaRampTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class %%NAME%%IlaRampTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaRemoveTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaRemoveTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class %%NAME%%IlaRemoveTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaReverseTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaReverseTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class %%NAME%%IlaReverseTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaRoundTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaRoundTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=floating
- */
 class %%NAME%%IlaRoundTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaScalarAddTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaScalarAddTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class %%NAME%%IlaScalarAddTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaScalarMultiplyTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaScalarMultiplyTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class %%NAME%%IlaScalarMultiplyTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaSegmentTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaSegmentTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=all
- */
 class %%NAME%%IlaSegmentTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaSubtractTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaSubtractTest.template
@@ -4,10 +4,6 @@ package %%PACKAGE%%;
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-/**
- *
- * @immutables.types=numeric
- */
 class %%NAME%%IlaSubtractTest {
     @Test
     void testAll() throws Exception {

--- a/src/test/template/tfw/immutable/ila/__IlaUtilCheck..NonNumeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaUtilCheck..NonNumeric.template
@@ -1,11 +1,7 @@
 // booleanila
 package %%PACKAGE%%;
 
-%%RANDOM_INCLUDE_2%%/**
- *
- * @immutables.types=nonnumeric
- */
-public final class %%NAME%%IlaUtilCheck {
+%%RANDOM_INCLUDE_2%%public final class %%NAME%%IlaUtilCheck {
     private %%NAME%%IlaUtilCheck() {
         // non-instantiable class
     }

--- a/src/test/template/tfw/immutable/ila/__IlaUtilCheck..Numeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaUtilCheck..Numeric.template
@@ -2,10 +2,6 @@
 package %%PACKAGE%%;
 
 %%RANDOM_INCLUDE%%
-/**
- *
- * @immutables.types=numeric
- */
 public final class %%NAME%%IlaUtilCheck {
     private %%NAME%%IlaUtilCheck() {
         // non-instantiable class


### PR DESCRIPTION
This PR removes the empty javadoc from the src/test templates that had custom tags that was giving errorprone warnings.