### PR TITLE
Quiet Maven javadoc messages.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.6.3</version>
+                <configuration>
+                    <quiet>true</quiet>
+                    <doclint>all</doclint>
+                    <failOnWarnings>true</failOnWarnings>
+                    <failOnError>true</failOnError>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
This PR quiets the mass of messages produced by the Maven javadoc plugin, but still stops on warnings and errors.