### PR TITLE
Update BitIla API to use all longs.

### DIFF
--- a/src/main/java/tfw/immutable/iis/AbstractIis.java
+++ b/src/main/java/tfw/immutable/iis/AbstractIis.java
@@ -1,0 +1,62 @@
+package tfw.immutable.iis;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import tfw.check.Argument;
+
+public abstract class AbstractIis {
+    private static final BigInteger NEGATIVE_ONE = BigInteger.valueOf(-1);
+    private static final BigInteger ZERO = BigInteger.valueOf(0);
+
+    /**
+     * This method replaces the actual close method.
+     *
+     * @throws IOException if something happens while trying to read the bytes.
+     */
+    protected abstract void closeImpl() throws IOException;
+
+    /**
+     * This method replaces the actual skip method and is called after parameter validation.
+     *
+     * @param n the number of bytes to skip.
+     * @return the number of bytes skipped.
+     * @throws IOException if something happens while trying to skip the bytes.
+     */
+    protected abstract long skipImpl(long n) throws IOException;
+
+    protected boolean closed = false;
+
+    public final void close() throws IOException {
+        if (!closed) {
+            closed = true;
+
+            closeImpl();
+        }
+    }
+
+    protected final BigInteger readCheck(final Object array, final int offset, final int length) {
+        Argument.assertNotNull(array, "array");
+        Argument.assertNotLessThan(offset, 0, "offset");
+        Argument.assertNotLessThan(length, 0, "length");
+
+        if (closed) {
+            return NEGATIVE_ONE;
+        }
+        if (length == 0) {
+            return ZERO;
+        }
+
+        return null;
+    }
+
+    public final long skip(final long n) throws IOException {
+        if (closed) {
+            return -1;
+        }
+        if (n < 1) {
+            return 0;
+        }
+
+        return skipImpl(n);
+    }
+}

--- a/src/main/java/tfw/immutable/iis/bitiis/BitIisFromBitIla.java
+++ b/src/main/java/tfw/immutable/iis/bitiis/BitIisFromBitIla.java
@@ -24,16 +24,16 @@ public final class BitIisFromBitIla {
 
         @Override
         public void closeImpl() throws IOException {
-            index = ila.length();
+            index = ila.lengthInBits();
         }
 
         @Override
         protected long readImpl(long[] array, long offsetInBits, long lengthInBits) throws IOException {
-            if (index == ila.length()) {
+            if (index == ila.lengthInBits()) {
                 return -1;
             }
 
-            final int elementsToGet = (int) Math.min(ila.length() - index, lengthInBits);
+            final int elementsToGet = (int) Math.min(ila.lengthInBits() - index, lengthInBits);
 
             ila.get(array, (int) offsetInBits, index, elementsToGet);
 
@@ -44,13 +44,13 @@ public final class BitIisFromBitIla {
 
         @Override
         protected long skipImpl(long n) throws IOException {
-            if (index == ila.length()) {
+            if (index == ila.lengthInBits()) {
                 return -1;
             }
 
             final long originalIndex = index;
 
-            index = Math.min(ila.length(), index + n);
+            index = Math.min(ila.lengthInBits(), index + n);
 
             return index - originalIndex;
         }

--- a/src/main/java/tfw/immutable/iis/booleaniis/AbstractBooleanIis.java
+++ b/src/main/java/tfw/immutable/iis/booleaniis/AbstractBooleanIis.java
@@ -1,20 +1,14 @@
 package tfw.immutable.iis.booleaniis;
 
 import java.io.IOException;
-import tfw.check.Argument;
+import java.math.BigInteger;
+import tfw.immutable.iis.AbstractIis;
 
 /**
  * This class is an optional abstract class that implements BooleanIis and provides
  * some common parameter validation.
  */
-public abstract class AbstractBooleanIis implements BooleanIis {
-    /**
-     * This method replaces the actual close method.
-     *
-     * @throws IOException if something happens while trying to read the booleans.
-     */
-    protected abstract void closeImpl() throws IOException;
-
+public abstract class AbstractBooleanIis extends AbstractIis implements BooleanIis {
     /**
      * This method replaces the actual read method and is called after parameter validation.
      *
@@ -26,52 +20,11 @@ public abstract class AbstractBooleanIis implements BooleanIis {
      */
     protected abstract int readImpl(boolean[] array, int offset, int length) throws IOException;
 
-    /**
-     * This method replaces the actual skip method and is called after parameter validation.
-     *
-     * @param n the number of booleans to skip.
-     * @return the number of booleans skipped.
-     * @throws IOException if something happens while trying to skip the booleans.
-     */
-    protected abstract long skipImpl(long n) throws IOException;
-
-    private boolean closed = false;
-
-    @Override
-    public void close() throws IOException {
-        if (!closed) {
-            closed = true;
-
-            closeImpl();
-        }
-    }
-
     @Override
     public final int read(final boolean[] array, final int offset, final int length) throws IOException {
-        Argument.assertNotNull(array, "array");
-        Argument.assertNotLessThan(offset, 0, "offset");
-        Argument.assertNotLessThan(length, 0, "length");
+        final BigInteger r = readCheck(array, offset, length);
 
-        if (closed) {
-            return -1;
-        }
-        if (length == 0) {
-            return 0;
-        }
-
-        return readImpl(array, offset, length);
-    }
-
-    @Override
-    public final long skip(final long n) throws IOException {
-        if (closed) {
-            return -1;
-        }
-        if (n < 1) {
-            return 0;
-        }
-
-        return skipImpl(n);
+        return r == null ? readImpl(array, offset, length) : r.intValue();
     }
 }
 // AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/iis/byteiis/AbstractByteIis.java
+++ b/src/main/java/tfw/immutable/iis/byteiis/AbstractByteIis.java
@@ -1,20 +1,14 @@
 package tfw.immutable.iis.byteiis;
 
 import java.io.IOException;
-import tfw.check.Argument;
+import java.math.BigInteger;
+import tfw.immutable.iis.AbstractIis;
 
 /**
  * This class is an optional abstract class that implements ByteIis and provides
  * some common parameter validation.
  */
-public abstract class AbstractByteIis implements ByteIis {
-    /**
-     * This method replaces the actual close method.
-     *
-     * @throws IOException if something happens while trying to read the bytes.
-     */
-    protected abstract void closeImpl() throws IOException;
-
+public abstract class AbstractByteIis extends AbstractIis implements ByteIis {
     /**
      * This method replaces the actual read method and is called after parameter validation.
      *
@@ -26,52 +20,11 @@ public abstract class AbstractByteIis implements ByteIis {
      */
     protected abstract int readImpl(byte[] array, int offset, int length) throws IOException;
 
-    /**
-     * This method replaces the actual skip method and is called after parameter validation.
-     *
-     * @param n the number of bytes to skip.
-     * @return the number of bytes skipped.
-     * @throws IOException if something happens while trying to skip the bytes.
-     */
-    protected abstract long skipImpl(long n) throws IOException;
-
-    private boolean closed = false;
-
-    @Override
-    public void close() throws IOException {
-        if (!closed) {
-            closed = true;
-
-            closeImpl();
-        }
-    }
-
     @Override
     public final int read(final byte[] array, final int offset, final int length) throws IOException {
-        Argument.assertNotNull(array, "array");
-        Argument.assertNotLessThan(offset, 0, "offset");
-        Argument.assertNotLessThan(length, 0, "length");
+        final BigInteger r = readCheck(array, offset, length);
 
-        if (closed) {
-            return -1;
-        }
-        if (length == 0) {
-            return 0;
-        }
-
-        return readImpl(array, offset, length);
-    }
-
-    @Override
-    public final long skip(final long n) throws IOException {
-        if (closed) {
-            return -1;
-        }
-        if (n < 1) {
-            return 0;
-        }
-
-        return skipImpl(n);
+        return r == null ? readImpl(array, offset, length) : r.intValue();
     }
 }
 // AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/iis/chariis/AbstractCharIis.java
+++ b/src/main/java/tfw/immutable/iis/chariis/AbstractCharIis.java
@@ -1,20 +1,14 @@
 package tfw.immutable.iis.chariis;
 
 import java.io.IOException;
-import tfw.check.Argument;
+import java.math.BigInteger;
+import tfw.immutable.iis.AbstractIis;
 
 /**
  * This class is an optional abstract class that implements CharIis and provides
  * some common parameter validation.
  */
-public abstract class AbstractCharIis implements CharIis {
-    /**
-     * This method replaces the actual close method.
-     *
-     * @throws IOException if something happens while trying to read the chars.
-     */
-    protected abstract void closeImpl() throws IOException;
-
+public abstract class AbstractCharIis extends AbstractIis implements CharIis {
     /**
      * This method replaces the actual read method and is called after parameter validation.
      *
@@ -26,52 +20,11 @@ public abstract class AbstractCharIis implements CharIis {
      */
     protected abstract int readImpl(char[] array, int offset, int length) throws IOException;
 
-    /**
-     * This method replaces the actual skip method and is called after parameter validation.
-     *
-     * @param n the number of chars to skip.
-     * @return the number of chars skipped.
-     * @throws IOException if something happens while trying to skip the chars.
-     */
-    protected abstract long skipImpl(long n) throws IOException;
-
-    private boolean closed = false;
-
-    @Override
-    public void close() throws IOException {
-        if (!closed) {
-            closed = true;
-
-            closeImpl();
-        }
-    }
-
     @Override
     public final int read(final char[] array, final int offset, final int length) throws IOException {
-        Argument.assertNotNull(array, "array");
-        Argument.assertNotLessThan(offset, 0, "offset");
-        Argument.assertNotLessThan(length, 0, "length");
+        final BigInteger r = readCheck(array, offset, length);
 
-        if (closed) {
-            return -1;
-        }
-        if (length == 0) {
-            return 0;
-        }
-
-        return readImpl(array, offset, length);
-    }
-
-    @Override
-    public final long skip(final long n) throws IOException {
-        if (closed) {
-            return -1;
-        }
-        if (n < 1) {
-            return 0;
-        }
-
-        return skipImpl(n);
+        return r == null ? readImpl(array, offset, length) : r.intValue();
     }
 }
 // AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/iis/doubleiis/AbstractDoubleIis.java
+++ b/src/main/java/tfw/immutable/iis/doubleiis/AbstractDoubleIis.java
@@ -1,20 +1,14 @@
 package tfw.immutable.iis.doubleiis;
 
 import java.io.IOException;
-import tfw.check.Argument;
+import java.math.BigInteger;
+import tfw.immutable.iis.AbstractIis;
 
 /**
  * This class is an optional abstract class that implements DoubleIis and provides
  * some common parameter validation.
  */
-public abstract class AbstractDoubleIis implements DoubleIis {
-    /**
-     * This method replaces the actual close method.
-     *
-     * @throws IOException if something happens while trying to read the doubles.
-     */
-    protected abstract void closeImpl() throws IOException;
-
+public abstract class AbstractDoubleIis extends AbstractIis implements DoubleIis {
     /**
      * This method replaces the actual read method and is called after parameter validation.
      *
@@ -26,52 +20,11 @@ public abstract class AbstractDoubleIis implements DoubleIis {
      */
     protected abstract int readImpl(double[] array, int offset, int length) throws IOException;
 
-    /**
-     * This method replaces the actual skip method and is called after parameter validation.
-     *
-     * @param n the number of doubles to skip.
-     * @return the number of doubles skipped.
-     * @throws IOException if something happens while trying to skip the doubles.
-     */
-    protected abstract long skipImpl(long n) throws IOException;
-
-    private boolean closed = false;
-
-    @Override
-    public void close() throws IOException {
-        if (!closed) {
-            closed = true;
-
-            closeImpl();
-        }
-    }
-
     @Override
     public final int read(final double[] array, final int offset, final int length) throws IOException {
-        Argument.assertNotNull(array, "array");
-        Argument.assertNotLessThan(offset, 0, "offset");
-        Argument.assertNotLessThan(length, 0, "length");
+        final BigInteger r = readCheck(array, offset, length);
 
-        if (closed) {
-            return -1;
-        }
-        if (length == 0) {
-            return 0;
-        }
-
-        return readImpl(array, offset, length);
-    }
-
-    @Override
-    public final long skip(final long n) throws IOException {
-        if (closed) {
-            return -1;
-        }
-        if (n < 1) {
-            return 0;
-        }
-
-        return skipImpl(n);
+        return r == null ? readImpl(array, offset, length) : r.intValue();
     }
 }
 // AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/iis/floatiis/AbstractFloatIis.java
+++ b/src/main/java/tfw/immutable/iis/floatiis/AbstractFloatIis.java
@@ -1,20 +1,14 @@
 package tfw.immutable.iis.floatiis;
 
 import java.io.IOException;
-import tfw.check.Argument;
+import java.math.BigInteger;
+import tfw.immutable.iis.AbstractIis;
 
 /**
  * This class is an optional abstract class that implements FloatIis and provides
  * some common parameter validation.
  */
-public abstract class AbstractFloatIis implements FloatIis {
-    /**
-     * This method replaces the actual close method.
-     *
-     * @throws IOException if something happens while trying to read the floats.
-     */
-    protected abstract void closeImpl() throws IOException;
-
+public abstract class AbstractFloatIis extends AbstractIis implements FloatIis {
     /**
      * This method replaces the actual read method and is called after parameter validation.
      *
@@ -26,52 +20,11 @@ public abstract class AbstractFloatIis implements FloatIis {
      */
     protected abstract int readImpl(float[] array, int offset, int length) throws IOException;
 
-    /**
-     * This method replaces the actual skip method and is called after parameter validation.
-     *
-     * @param n the number of floats to skip.
-     * @return the number of floats skipped.
-     * @throws IOException if something happens while trying to skip the floats.
-     */
-    protected abstract long skipImpl(long n) throws IOException;
-
-    private boolean closed = false;
-
-    @Override
-    public void close() throws IOException {
-        if (!closed) {
-            closed = true;
-
-            closeImpl();
-        }
-    }
-
     @Override
     public final int read(final float[] array, final int offset, final int length) throws IOException {
-        Argument.assertNotNull(array, "array");
-        Argument.assertNotLessThan(offset, 0, "offset");
-        Argument.assertNotLessThan(length, 0, "length");
+        final BigInteger r = readCheck(array, offset, length);
 
-        if (closed) {
-            return -1;
-        }
-        if (length == 0) {
-            return 0;
-        }
-
-        return readImpl(array, offset, length);
-    }
-
-    @Override
-    public final long skip(final long n) throws IOException {
-        if (closed) {
-            return -1;
-        }
-        if (n < 1) {
-            return 0;
-        }
-
-        return skipImpl(n);
+        return r == null ? readImpl(array, offset, length) : r.intValue();
     }
 }
 // AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/iis/intiis/AbstractIntIis.java
+++ b/src/main/java/tfw/immutable/iis/intiis/AbstractIntIis.java
@@ -1,20 +1,14 @@
 package tfw.immutable.iis.intiis;
 
 import java.io.IOException;
-import tfw.check.Argument;
+import java.math.BigInteger;
+import tfw.immutable.iis.AbstractIis;
 
 /**
  * This class is an optional abstract class that implements IntIis and provides
  * some common parameter validation.
  */
-public abstract class AbstractIntIis implements IntIis {
-    /**
-     * This method replaces the actual close method.
-     *
-     * @throws IOException if something happens while trying to read the ints.
-     */
-    protected abstract void closeImpl() throws IOException;
-
+public abstract class AbstractIntIis extends AbstractIis implements IntIis {
     /**
      * This method replaces the actual read method and is called after parameter validation.
      *
@@ -26,52 +20,11 @@ public abstract class AbstractIntIis implements IntIis {
      */
     protected abstract int readImpl(int[] array, int offset, int length) throws IOException;
 
-    /**
-     * This method replaces the actual skip method and is called after parameter validation.
-     *
-     * @param n the number of ints to skip.
-     * @return the number of ints skipped.
-     * @throws IOException if something happens while trying to skip the ints.
-     */
-    protected abstract long skipImpl(long n) throws IOException;
-
-    private boolean closed = false;
-
-    @Override
-    public void close() throws IOException {
-        if (!closed) {
-            closed = true;
-
-            closeImpl();
-        }
-    }
-
     @Override
     public final int read(final int[] array, final int offset, final int length) throws IOException {
-        Argument.assertNotNull(array, "array");
-        Argument.assertNotLessThan(offset, 0, "offset");
-        Argument.assertNotLessThan(length, 0, "length");
+        final BigInteger r = readCheck(array, offset, length);
 
-        if (closed) {
-            return -1;
-        }
-        if (length == 0) {
-            return 0;
-        }
-
-        return readImpl(array, offset, length);
-    }
-
-    @Override
-    public final long skip(final long n) throws IOException {
-        if (closed) {
-            return -1;
-        }
-        if (n < 1) {
-            return 0;
-        }
-
-        return skipImpl(n);
+        return r == null ? readImpl(array, offset, length) : r.intValue();
     }
 }
 // AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/iis/longiis/AbstractLongIis.java
+++ b/src/main/java/tfw/immutable/iis/longiis/AbstractLongIis.java
@@ -1,20 +1,14 @@
 package tfw.immutable.iis.longiis;
 
 import java.io.IOException;
-import tfw.check.Argument;
+import java.math.BigInteger;
+import tfw.immutable.iis.AbstractIis;
 
 /**
  * This class is an optional abstract class that implements LongIis and provides
  * some common parameter validation.
  */
-public abstract class AbstractLongIis implements LongIis {
-    /**
-     * This method replaces the actual close method.
-     *
-     * @throws IOException if something happens while trying to read the longs.
-     */
-    protected abstract void closeImpl() throws IOException;
-
+public abstract class AbstractLongIis extends AbstractIis implements LongIis {
     /**
      * This method replaces the actual read method and is called after parameter validation.
      *
@@ -26,52 +20,11 @@ public abstract class AbstractLongIis implements LongIis {
      */
     protected abstract int readImpl(long[] array, int offset, int length) throws IOException;
 
-    /**
-     * This method replaces the actual skip method and is called after parameter validation.
-     *
-     * @param n the number of longs to skip.
-     * @return the number of longs skipped.
-     * @throws IOException if something happens while trying to skip the longs.
-     */
-    protected abstract long skipImpl(long n) throws IOException;
-
-    private boolean closed = false;
-
-    @Override
-    public void close() throws IOException {
-        if (!closed) {
-            closed = true;
-
-            closeImpl();
-        }
-    }
-
     @Override
     public final int read(final long[] array, final int offset, final int length) throws IOException {
-        Argument.assertNotNull(array, "array");
-        Argument.assertNotLessThan(offset, 0, "offset");
-        Argument.assertNotLessThan(length, 0, "length");
+        final BigInteger r = readCheck(array, offset, length);
 
-        if (closed) {
-            return -1;
-        }
-        if (length == 0) {
-            return 0;
-        }
-
-        return readImpl(array, offset, length);
-    }
-
-    @Override
-    public final long skip(final long n) throws IOException {
-        if (closed) {
-            return -1;
-        }
-        if (n < 1) {
-            return 0;
-        }
-
-        return skipImpl(n);
+        return r == null ? readImpl(array, offset, length) : r.intValue();
     }
 }
 // AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/iis/objectiis/AbstractObjectIis.java
+++ b/src/main/java/tfw/immutable/iis/objectiis/AbstractObjectIis.java
@@ -1,20 +1,14 @@
 package tfw.immutable.iis.objectiis;
 
 import java.io.IOException;
-import tfw.check.Argument;
+import java.math.BigInteger;
+import tfw.immutable.iis.AbstractIis;
 
 /**
  * This class is an optional abstract class that implements ObjectIis and provides
  * some common parameter validation.
  */
-public abstract class AbstractObjectIis<T> implements ObjectIis<T> {
-    /**
-     * This method replaces the actual close method.
-     *
-     * @throws IOException if something happens while trying to read the Objects.
-     */
-    protected abstract void closeImpl() throws IOException;
-
+public abstract class AbstractObjectIis<T> extends AbstractIis implements ObjectIis<T> {
     /**
      * This method replaces the actual read method and is called after parameter validation.
      *
@@ -26,52 +20,11 @@ public abstract class AbstractObjectIis<T> implements ObjectIis<T> {
      */
     protected abstract int readImpl(T[] array, int offset, int length) throws IOException;
 
-    /**
-     * This method replaces the actual skip method and is called after parameter validation.
-     *
-     * @param n the number of Objects to skip.
-     * @return the number of Objects skipped.
-     * @throws IOException if something happens while trying to skip the Objects.
-     */
-    protected abstract long skipImpl(long n) throws IOException;
-
-    private boolean closed = false;
-
-    @Override
-    public void close() throws IOException {
-        if (!closed) {
-            closed = true;
-
-            closeImpl();
-        }
-    }
-
     @Override
     public final int read(final T[] array, final int offset, final int length) throws IOException {
-        Argument.assertNotNull(array, "array");
-        Argument.assertNotLessThan(offset, 0, "offset");
-        Argument.assertNotLessThan(length, 0, "length");
+        final BigInteger r = readCheck(array, offset, length);
 
-        if (closed) {
-            return -1;
-        }
-        if (length == 0) {
-            return 0;
-        }
-
-        return readImpl(array, offset, length);
-    }
-
-    @Override
-    public final long skip(final long n) throws IOException {
-        if (closed) {
-            return -1;
-        }
-        if (n < 1) {
-            return 0;
-        }
-
-        return skipImpl(n);
+        return r == null ? readImpl(array, offset, length) : r.intValue();
     }
 }
 // AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/iis/shortiis/AbstractShortIis.java
+++ b/src/main/java/tfw/immutable/iis/shortiis/AbstractShortIis.java
@@ -1,20 +1,14 @@
 package tfw.immutable.iis.shortiis;
 
 import java.io.IOException;
-import tfw.check.Argument;
+import java.math.BigInteger;
+import tfw.immutable.iis.AbstractIis;
 
 /**
  * This class is an optional abstract class that implements ShortIis and provides
  * some common parameter validation.
  */
-public abstract class AbstractShortIis implements ShortIis {
-    /**
-     * This method replaces the actual close method.
-     *
-     * @throws IOException if something happens while trying to read the shorts.
-     */
-    protected abstract void closeImpl() throws IOException;
-
+public abstract class AbstractShortIis extends AbstractIis implements ShortIis {
     /**
      * This method replaces the actual read method and is called after parameter validation.
      *
@@ -26,52 +20,11 @@ public abstract class AbstractShortIis implements ShortIis {
      */
     protected abstract int readImpl(short[] array, int offset, int length) throws IOException;
 
-    /**
-     * This method replaces the actual skip method and is called after parameter validation.
-     *
-     * @param n the number of shorts to skip.
-     * @return the number of shorts skipped.
-     * @throws IOException if something happens while trying to skip the shorts.
-     */
-    protected abstract long skipImpl(long n) throws IOException;
-
-    private boolean closed = false;
-
-    @Override
-    public void close() throws IOException {
-        if (!closed) {
-            closed = true;
-
-            closeImpl();
-        }
-    }
-
     @Override
     public final int read(final short[] array, final int offset, final int length) throws IOException {
-        Argument.assertNotNull(array, "array");
-        Argument.assertNotLessThan(offset, 0, "offset");
-        Argument.assertNotLessThan(length, 0, "length");
+        final BigInteger r = readCheck(array, offset, length);
 
-        if (closed) {
-            return -1;
-        }
-        if (length == 0) {
-            return 0;
-        }
-
-        return readImpl(array, offset, length);
-    }
-
-    @Override
-    public final long skip(final long n) throws IOException {
-        if (closed) {
-            return -1;
-        }
-        if (n < 1) {
-            return 0;
-        }
-
-        return skipImpl(n);
+        return r == null ? readImpl(array, offset, length) : r.intValue();
     }
 }
 // AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ila/bitila/AbstractBitIla.java
+++ b/src/main/java/tfw/immutable/ila/bitila/AbstractBitIla.java
@@ -2,24 +2,34 @@ package tfw.immutable.ila.bitila;
 
 import java.io.IOException;
 import tfw.check.Argument;
-import tfw.immutable.ila.AbstractIla;
 
-public abstract class AbstractBitIla extends AbstractIla implements BitIla {
+public abstract class AbstractBitIla implements BitIla {
     protected abstract void getImpl(
-            final long[] array, final int arrayOffsetInBits, final long ilaStartInBits, final long lengthInBits)
+            final long[] array, final long arrayOffsetInBits, final long ilaStartInBits, final long lengthInBits)
             throws IOException;
+
+    protected abstract long lengthInBitsImpl() throws IOException;
+
+    @Override
+    public final long lengthInBits() throws IOException {
+        return lengthInBitsImpl();
+    }
 
     @Override
     public final void get(
-            final long[] array, final int arrayOffsetInBits, final long ilaStartInBits, final long lengthInBits)
+            final long[] array, final long arrayOffsetInBits, final long ilaStartInBits, final long lengthInBits)
             throws IOException {
         Argument.assertNotNull(array, "array");
         Argument.assertNotLessThan(arrayOffsetInBits, 0, "offset");
         Argument.assertNotGreaterThanOrEquals(
+                arrayOffsetInBits, MAX_BITS_IN_ARRAY, "arrayOffsetInBits", "MAX_BITS_IN_ARRAY");
+        Argument.assertNotGreaterThanOrEquals(
                 arrayOffsetInBits + lengthInBits, array.length * (long) Long.SIZE, "offset", "array.length");
         Argument.assertNotLessThan(ilaStartInBits, 0, "start");
         Argument.assertNotLessThan(lengthInBits, 0, "length");
-        Argument.assertNotGreaterThan(ilaStartInBits + lengthInBits, length(), "start+length", "Ila.length()");
+        Argument.assertNotGreaterThanOrEquals(lengthInBits, MAX_BITS_IN_ARRAY, "lengthInBits", "MAX_BITS_IN_ARRAY");
+        Argument.assertNotGreaterThan(
+                ilaStartInBits + lengthInBits, lengthInBits(), "start+length", "Ila.lengthInBits()");
 
         if (lengthInBits == 0) {
             return;

--- a/src/main/java/tfw/immutable/ila/bitila/BitIla.java
+++ b/src/main/java/tfw/immutable/ila/bitila/BitIla.java
@@ -1,9 +1,12 @@
 package tfw.immutable.ila.bitila;
 
 import java.io.IOException;
-import tfw.immutable.ila.ImmutableLongArray;
 
-public interface BitIla extends ImmutableLongArray {
-    void get(final long[] array, final int arrayOffsetInBits, final long ilaStartInBits, final long lengthInBits)
+public interface BitIla {
+    long MAX_BITS_IN_ARRAY = (Integer.MAX_VALUE - 8) * (long) Long.SIZE;
+
+    long lengthInBits() throws IOException;
+
+    void get(final long[] array, final long arrayOffsetInBits, final long ilaStartInBits, final long lengthInBits)
             throws IOException;
 }

--- a/src/main/java/tfw/immutable/ila/bitila/BitIlaAnd.java
+++ b/src/main/java/tfw/immutable/ila/bitila/BitIlaAnd.java
@@ -86,14 +86,14 @@ public final class BitIlaAnd {
         }
 
         @Override
-        protected long lengthImpl() throws IOException {
-            return Math.min(leftIla.length(), rightIla.length());
+        protected long lengthInBitsImpl() throws IOException {
+            return Math.min(leftIla.lengthInBits(), rightIla.lengthInBits());
         }
 
         @Override
-        protected void getImpl(long[] array, int arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
+        protected void getImpl(long[] array, long arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
                 throws IOException {
-            final int rightOffsetInBits = arrayOffsetInBits % Long.SIZE;
+            final long rightOffsetInBits = arrayOffsetInBits % Long.SIZE;
             final long[] rightArray = new long[(int) ((rightOffsetInBits + lengthInBits) / Long.SIZE + 1)];
 
             leftIla.get(array, arrayOffsetInBits, ilaStartInBits, lengthInBits);

--- a/src/main/java/tfw/immutable/ila/bitila/BitIlaConcatenate.java
+++ b/src/main/java/tfw/immutable/ila/bitila/BitIlaConcatenate.java
@@ -23,19 +23,19 @@ public final class BitIlaConcatenate {
         }
 
         @Override
-        protected long lengthImpl() throws IOException {
-            return leftIla.length() + rightIla.length();
+        protected long lengthInBitsImpl() throws IOException {
+            return leftIla.lengthInBits() + rightIla.lengthInBits();
         }
 
         @Override
-        protected void getImpl(long[] array, int arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
+        protected void getImpl(long[] array, long arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
                 throws IOException {
-            if (ilaStartInBits + lengthInBits <= leftIla.length()) {
+            if (ilaStartInBits + lengthInBits <= leftIla.lengthInBits()) {
                 leftIla.get(array, arrayOffsetInBits, ilaStartInBits, lengthInBits);
-            } else if (ilaStartInBits >= leftIla.length()) {
-                rightIla.get(array, arrayOffsetInBits, ilaStartInBits - leftIla.length(), lengthInBits);
+            } else if (ilaStartInBits >= leftIla.lengthInBits()) {
+                rightIla.get(array, arrayOffsetInBits, ilaStartInBits - leftIla.lengthInBits(), lengthInBits);
             } else {
-                final int leftAmount = (int) (leftIla.length() - ilaStartInBits);
+                final int leftAmount = (int) (leftIla.lengthInBits() - ilaStartInBits);
 
                 leftIla.get(array, arrayOffsetInBits, ilaStartInBits, leftAmount);
                 rightIla.get(array, arrayOffsetInBits + leftAmount, 0, lengthInBits - leftAmount);

--- a/src/main/java/tfw/immutable/ila/bitila/BitIlaFill.java
+++ b/src/main/java/tfw/immutable/ila/bitila/BitIlaFill.java
@@ -90,12 +90,12 @@ public final class BitIlaFill {
         }
 
         @Override
-        protected long lengthImpl() throws IOException {
+        protected long lengthInBitsImpl() throws IOException {
             return lengthInBits;
         }
 
         @Override
-        protected void getImpl(long[] array, int arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
+        protected void getImpl(long[] array, long arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
                 throws IOException {
             fill(array, arrayOffsetInBits, lengthInBits, value);
         }

--- a/src/main/java/tfw/immutable/ila/bitila/BitIlaFromLongIla.java
+++ b/src/main/java/tfw/immutable/ila/bitila/BitIlaFromLongIla.java
@@ -28,13 +28,13 @@ public final class BitIlaFromLongIla {
         }
 
         @Override
-        protected long lengthImpl() throws IOException {
+        protected long lengthInBitsImpl() throws IOException {
             return lengthInBits;
         }
 
         @Override
         protected void getImpl(
-                final long[] array, final int arrayOffsetInBits, final long ilaStartInBits, final long lengthInBits)
+                final long[] array, final long arrayOffsetInBits, final long ilaStartInBits, final long lengthInBits)
                 throws IOException {
             final long ilaStartInLongs = ilaStartInBits / Long.SIZE;
             final long ilaEndInLongs = (ilaStartInBits + lengthInBits) / Long.SIZE;

--- a/src/main/java/tfw/immutable/ila/bitila/BitIlaNot.java
+++ b/src/main/java/tfw/immutable/ila/bitila/BitIlaNot.java
@@ -77,12 +77,12 @@ public final class BitIlaNot {
         }
 
         @Override
-        protected long lengthImpl() throws IOException {
-            return bitIla.length();
+        protected long lengthInBitsImpl() throws IOException {
+            return bitIla.lengthInBits();
         }
 
         @Override
-        protected void getImpl(long[] array, int arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
+        protected void getImpl(long[] array, long arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
                 throws IOException {
             bitIla.get(array, arrayOffsetInBits, ilaStartInBits, lengthInBits);
 

--- a/src/main/java/tfw/immutable/ila/bitila/BitIlaOr.java
+++ b/src/main/java/tfw/immutable/ila/bitila/BitIlaOr.java
@@ -86,14 +86,14 @@ public final class BitIlaOr {
         }
 
         @Override
-        protected long lengthImpl() throws IOException {
-            return leftIla.length();
+        protected long lengthInBitsImpl() throws IOException {
+            return leftIla.lengthInBits();
         }
 
         @Override
-        protected void getImpl(long[] array, int arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
+        protected void getImpl(long[] array, long arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
                 throws IOException {
-            final int rightOffsetInBits = arrayOffsetInBits % Long.SIZE;
+            final long rightOffsetInBits = arrayOffsetInBits % Long.SIZE;
             final long[] rightArray = new long[(int) ((rightOffsetInBits + lengthInBits) / Long.SIZE + 1)];
 
             leftIla.get(array, arrayOffsetInBits, ilaStartInBits, lengthInBits);

--- a/src/main/java/tfw/immutable/ila/bitila/BitIlaReverse.java
+++ b/src/main/java/tfw/immutable/ila/bitila/BitIlaReverse.java
@@ -111,16 +111,16 @@ public final class BitIlaReverse {
         }
 
         @Override
-        protected void getImpl(long[] array, int arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
+        protected void getImpl(long[] array, long arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
                 throws IOException {
-            bitIla.get(array, arrayOffsetInBits, bitIla.length() - ilaStartInBits - lengthInBits, lengthInBits);
+            bitIla.get(array, arrayOffsetInBits, bitIla.lengthInBits() - ilaStartInBits - lengthInBits, lengthInBits);
 
             reverse(array, arrayOffsetInBits, lengthInBits);
         }
 
         @Override
-        protected long lengthImpl() throws IOException {
-            return bitIla.length();
+        protected long lengthInBitsImpl() throws IOException {
+            return bitIla.lengthInBits();
         }
     }
 }

--- a/src/main/java/tfw/immutable/ila/bitila/BitIlaSegment.java
+++ b/src/main/java/tfw/immutable/ila/bitila/BitIlaSegment.java
@@ -26,12 +26,12 @@ public final class BitIlaSegment {
         }
 
         @Override
-        protected long lengthImpl() throws IOException {
+        protected long lengthInBitsImpl() throws IOException {
             return ilaLengthInBits;
         }
 
         @Override
-        protected void getImpl(long[] array, int arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
+        protected void getImpl(long[] array, long arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
                 throws IOException {
             bitIla.get(array, arrayOffsetInBits, ilaOffsetInBits + ilaStartInBits, lengthInBits);
         }

--- a/src/main/java/tfw/immutable/ila/bitila/BitIlaXor.java
+++ b/src/main/java/tfw/immutable/ila/bitila/BitIlaXor.java
@@ -86,14 +86,14 @@ public final class BitIlaXor {
         }
 
         @Override
-        protected long lengthImpl() throws IOException {
-            return leftIla.length();
+        protected long lengthInBitsImpl() throws IOException {
+            return leftIla.lengthInBits();
         }
 
         @Override
-        protected void getImpl(long[] array, int arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
+        protected void getImpl(long[] array, long arrayOffsetInBits, long ilaStartInBits, long lengthInBits)
                 throws IOException {
-            final int rightOffsetInBits = arrayOffsetInBits % Long.SIZE;
+            final long rightOffsetInBits = arrayOffsetInBits % Long.SIZE;
             final long[] rightArray = new long[(int) ((rightOffsetInBits + lengthInBits) / Long.SIZE + 1)];
 
             leftIla.get(array, arrayOffsetInBits, ilaStartInBits, lengthInBits);

--- a/src/main/java/tfw/immutable/ila/bitila/LongIlaFromBitIla.java
+++ b/src/main/java/tfw/immutable/ila/bitila/LongIlaFromBitIla.java
@@ -23,13 +23,13 @@ public final class LongIlaFromBitIla {
 
         @Override
         protected long lengthImpl() throws IOException {
-            return bitIla.length() / Long.SIZE + bitIla.length() % Long.SIZE == 0 ? 0 : 1;
+            return bitIla.lengthInBits() / Long.SIZE + bitIla.lengthInBits() % Long.SIZE == 0 ? 0 : 1;
         }
 
         @Override
         protected void getImpl(long[] array, int offset, long start, int length) throws IOException {
             final long startInBits = start * Long.SIZE;
-            final long lengthInBits = Math.min(length * (long) Long.SIZE, startInBits + bitIla.length());
+            final long lengthInBits = Math.min(length * (long) Long.SIZE, startInBits + bitIla.lengthInBits());
 
             bitIla.get(array, offset, startInBits, lengthInBits);
         }

--- a/src/main/template/tfw/immutable/iis/Abstract__Iis.template
+++ b/src/main/template/tfw/immutable/iis/Abstract__Iis.template
@@ -2,20 +2,14 @@
 package %%PACKAGE%%;
 
 import java.io.IOException;
-import tfw.check.Argument;
+import java.math.BigInteger;
+import tfw.immutable.iis.AbstractIis;
 
 /**
  * This class is an optional abstract class that implements %%NAME%%Iis and provides
  * some common parameter validation.
  */
-public abstract class Abstract%%NAME%%Iis%%TEMPLATE%% implements %%NAME%%Iis%%TEMPLATE%% {
-    /**
-     * This method replaces the actual close method.
-     *
-     * @throws IOException if something happens while trying to read the %%TYPE%%s.
-     */
-    protected abstract void closeImpl() throws IOException;
-
+public abstract class Abstract%%NAME%%Iis%%TEMPLATE%% extends AbstractIis implements %%NAME%%Iis%%TEMPLATE%% {
     /**
      * This method replaces the actual read method and is called after parameter validation.
      *
@@ -27,51 +21,10 @@ public abstract class Abstract%%NAME%%Iis%%TEMPLATE%% implements %%NAME%%Iis%%TE
      */
     protected abstract int readImpl(%%TYPE_OR_TEMPLATE%%[] array, int offset, int length) throws IOException;
 
-    /**
-     * This method replaces the actual skip method and is called after parameter validation.
-     *
-     * @param n the number of %%TYPE%%s to skip.
-     * @return the number of %%TYPE%%s skipped.
-     * @throws IOException if something happens while trying to skip the %%TYPE%%s.
-     */
-    protected abstract long skipImpl(long n) throws IOException;
-
-    private boolean closed = false;
-
-    @Override
-    public void close() throws IOException {
-        if (!closed) {
-            closed = true;
-
-            closeImpl();
-        }
-    }
-
     @Override
     public final int read(final %%TYPE_OR_TEMPLATE%%[] array, final int offset, final int length) throws IOException {
-        Argument.assertNotNull(array, "array");
-        Argument.assertNotLessThan(offset, 0, "offset");
-        Argument.assertNotLessThan(length, 0, "length");
+        final BigInteger r = readCheck(array, offset, length);
 
-        if (closed) {
-            return -1;
-        }
-        if (length == 0) {
-            return 0;
-        }
-
-        return readImpl(array, offset, length);
-    }
-
-    @Override
-    public final long skip(final long n) throws IOException {
-        if (closed) {
-            return -1;
-        }
-        if (n < 1) {
-            return 0;
-        }
-
-        return skipImpl(n);
+        return r == null ? readImpl(array, offset, length) : r.intValue();
     }
 }

--- a/src/test/java/tfw/immutable/iis/booleaniis/AbstractBooleanIisTest.java
+++ b/src/test/java/tfw/immutable/iis/booleaniis/AbstractBooleanIisTest.java
@@ -51,6 +51,10 @@ class AbstractBooleanIisTest {
 
         @Override
         protected int readImpl(boolean[] array, int offset, int length) throws IOException {
+            if (length == 0) {
+                throw new IOException("length == 0 should have been detected!");
+            }
+
             return length;
         }
 

--- a/src/test/java/tfw/immutable/iis/byteiis/AbstractByteIisTest.java
+++ b/src/test/java/tfw/immutable/iis/byteiis/AbstractByteIisTest.java
@@ -51,6 +51,10 @@ class AbstractByteIisTest {
 
         @Override
         protected int readImpl(byte[] array, int offset, int length) throws IOException {
+            if (length == 0) {
+                throw new IOException("length == 0 should have been detected!");
+            }
+
             return length;
         }
 

--- a/src/test/java/tfw/immutable/iis/chariis/AbstractCharIisTest.java
+++ b/src/test/java/tfw/immutable/iis/chariis/AbstractCharIisTest.java
@@ -51,6 +51,10 @@ class AbstractCharIisTest {
 
         @Override
         protected int readImpl(char[] array, int offset, int length) throws IOException {
+            if (length == 0) {
+                throw new IOException("length == 0 should have been detected!");
+            }
+
             return length;
         }
 

--- a/src/test/java/tfw/immutable/iis/doubleiis/AbstractDoubleIisTest.java
+++ b/src/test/java/tfw/immutable/iis/doubleiis/AbstractDoubleIisTest.java
@@ -51,6 +51,10 @@ class AbstractDoubleIisTest {
 
         @Override
         protected int readImpl(double[] array, int offset, int length) throws IOException {
+            if (length == 0) {
+                throw new IOException("length == 0 should have been detected!");
+            }
+
             return length;
         }
 

--- a/src/test/java/tfw/immutable/iis/floatiis/AbstractFloatIisTest.java
+++ b/src/test/java/tfw/immutable/iis/floatiis/AbstractFloatIisTest.java
@@ -51,6 +51,10 @@ class AbstractFloatIisTest {
 
         @Override
         protected int readImpl(float[] array, int offset, int length) throws IOException {
+            if (length == 0) {
+                throw new IOException("length == 0 should have been detected!");
+            }
+
             return length;
         }
 

--- a/src/test/java/tfw/immutable/iis/intiis/AbstractIntIisTest.java
+++ b/src/test/java/tfw/immutable/iis/intiis/AbstractIntIisTest.java
@@ -51,6 +51,10 @@ class AbstractIntIisTest {
 
         @Override
         protected int readImpl(int[] array, int offset, int length) throws IOException {
+            if (length == 0) {
+                throw new IOException("length == 0 should have been detected!");
+            }
+
             return length;
         }
 

--- a/src/test/java/tfw/immutable/iis/longiis/AbstractLongIisTest.java
+++ b/src/test/java/tfw/immutable/iis/longiis/AbstractLongIisTest.java
@@ -51,6 +51,10 @@ class AbstractLongIisTest {
 
         @Override
         protected int readImpl(long[] array, int offset, int length) throws IOException {
+            if (length == 0) {
+                throw new IOException("length == 0 should have been detected!");
+            }
+
             return length;
         }
 

--- a/src/test/java/tfw/immutable/iis/objectiis/AbstractObjectIisTest.java
+++ b/src/test/java/tfw/immutable/iis/objectiis/AbstractObjectIisTest.java
@@ -51,6 +51,10 @@ class AbstractObjectIisTest {
 
         @Override
         protected int readImpl(Object[] array, int offset, int length) throws IOException {
+            if (length == 0) {
+                throw new IOException("length == 0 should have been detected!");
+            }
+
             return length;
         }
 

--- a/src/test/java/tfw/immutable/iis/shortiis/AbstractShortIisTest.java
+++ b/src/test/java/tfw/immutable/iis/shortiis/AbstractShortIisTest.java
@@ -51,6 +51,10 @@ class AbstractShortIisTest {
 
         @Override
         protected int readImpl(short[] array, int offset, int length) throws IOException {
+            if (length == 0) {
+                throw new IOException("length == 0 should have been detected!");
+            }
+
             return length;
         }
 

--- a/src/test/java/tfw/immutable/ila/bitila/BitIlaAndTest.java
+++ b/src/test/java/tfw/immutable/ila/bitila/BitIlaAndTest.java
@@ -34,7 +34,7 @@ class BitIlaAndTest {
         final BitIla bitIla2 = BitIlaFromLongIla.create(LongIlaFromArray.create(new long[1]), 0, length);
         final BitIla bitIla = BitIlaAnd.create(bitIla1, bitIla2);
 
-        assertEquals(length, bitIla.length());
+        assertEquals(length, bitIla.lengthInBits());
     }
 
     @Test

--- a/src/test/java/tfw/immutable/ila/bitila/BitIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/bitila/BitIlaCheck.java
@@ -8,7 +8,7 @@ public final class BitIlaCheck {
     private BitIlaCheck() {}
 
     public static void checkGetArguments(final BitIla ila) throws IOException {
-        final long ilaLength = ila.length();
+        final long ilaLength = ila.lengthInBits();
         final long[] array = new long[1];
 
         assertThrows(IllegalArgumentException.class, () -> ila.get(null, 0, 0, 1));

--- a/src/test/java/tfw/immutable/ila/bitila/BitIlaConcatenateTest.java
+++ b/src/test/java/tfw/immutable/ila/bitila/BitIlaConcatenateTest.java
@@ -23,7 +23,7 @@ class BitIlaConcatenateTest {
         final BitIla bitIla2 = BitIlaFromLongIla.create(LongIlaFromArray.create(new long[1]), 0, length);
         final BitIla bitIla = BitIlaConcatenate.create(bitIla1, bitIla2);
 
-        assertEquals(2 * length, bitIla.length());
+        assertEquals(2 * length, bitIla.lengthInBits());
     }
 
     @Test

--- a/src/test/java/tfw/immutable/ila/bitila/BitIlaFillTest.java
+++ b/src/test/java/tfw/immutable/ila/bitila/BitIlaFillTest.java
@@ -24,7 +24,7 @@ class BitIlaFillTest {
         final long length = 64;
         final BitIla bitIla = BitIlaFill.create(true, length);
 
-        assertEquals(length, bitIla.length());
+        assertEquals(length, bitIla.lengthInBits());
     }
 
     @Test

--- a/src/test/java/tfw/immutable/ila/bitila/BitIlaFromLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/bitila/BitIlaFromLongIlaTest.java
@@ -47,14 +47,14 @@ class BitIlaFromLongIlaTest {
                 final LongIla longIla = LongIlaFromArray.create(originalLongs);
                 final BitIla bitIla = BitIlaFromLongIla.create(longIla, start, length);
 
-                assertEquals(length, bitIla.length());
+                assertEquals(length, bitIla.lengthInBits());
 
                 final long[] actualLongs = new long[numberOfLongs + 1];
                 final long[] modExpectedLongs = new long[numberOfLongs + 1];
 
                 for (int getLength = 1; getLength <= length; getLength++) {
                     for (int getOffset = 0; getOffset < Long.SIZE; getOffset++) {
-                        for (int getStart = 0; getStart < bitIla.length() - getLength; getStart++) {
+                        for (int getStart = 0; getStart < bitIla.lengthInBits() - getLength; getStart++) {
                             Arrays.fill(modExpectedLongs, 0);
                             Arrays.fill(actualLongs, 0);
 

--- a/src/test/java/tfw/immutable/ila/bitila/BitIlaNotTest.java
+++ b/src/test/java/tfw/immutable/ila/bitila/BitIlaNotTest.java
@@ -26,7 +26,7 @@ class BitIlaNotTest {
         final BitIla bitIla = BitIlaFromLongIla.create(LongIlaFromArray.create(new long[1]), 0, length);
         final BitIla bitIlaNot = BitIlaNot.create(bitIla);
 
-        assertEquals(length, bitIlaNot.length());
+        assertEquals(length, bitIlaNot.lengthInBits());
     }
 
     @Test

--- a/src/test/java/tfw/immutable/ila/bitila/BitIlaOrTest.java
+++ b/src/test/java/tfw/immutable/ila/bitila/BitIlaOrTest.java
@@ -34,7 +34,7 @@ class BitIlaOrTest {
         final BitIla bitIla2 = BitIlaFromLongIla.create(LongIlaFromArray.create(new long[1]), 0, length);
         final BitIla bitIla = BitIlaOr.create(bitIla1, bitIla2);
 
-        assertEquals(length, bitIla.length());
+        assertEquals(length, bitIla.lengthInBits());
     }
 
     @Test

--- a/src/test/java/tfw/immutable/ila/bitila/BitIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/bitila/BitIlaReverseTest.java
@@ -26,7 +26,7 @@ class BitIlaReverseTest {
         final BitIla bitIla1 = BitIlaFromLongIla.create(LongIlaFromArray.create(new long[1]), 0, length);
         final BitIla bitIla = BitIlaReverse.create(bitIla1);
 
-        assertEquals(length, bitIla.length());
+        assertEquals(length, bitIla.lengthInBits());
     }
 
     @Test

--- a/src/test/java/tfw/immutable/ila/bitila/BitIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/bitila/BitIlaSegmentTest.java
@@ -23,7 +23,7 @@ class BitIlaSegmentTest {
         final BitIla bitIla1 = BitIlaFromLongIla.create(LongIlaFromArray.create(new long[2]), 0, length);
         final BitIla bitIla = BitIlaSegment.create(bitIla1, 32, 64);
 
-        assertEquals(length / 2, bitIla.length());
+        assertEquals(length / 2, bitIla.lengthInBits());
     }
 
     @Test

--- a/src/test/java/tfw/immutable/ila/bitila/BitIlaXorTest.java
+++ b/src/test/java/tfw/immutable/ila/bitila/BitIlaXorTest.java
@@ -34,7 +34,7 @@ class BitIlaXorTest {
         final BitIla bitIla2 = BitIlaFromLongIla.create(LongIlaFromArray.create(new long[1]), 0, length);
         final BitIla bitIla = BitIlaXor.create(bitIla1, bitIla2);
 
-        assertEquals(length, bitIla.length());
+        assertEquals(length, bitIla.lengthInBits());
     }
 
     @Test

--- a/src/test/template/tfw/immutable/iis/Abstract__IisTest.template
+++ b/src/test/template/tfw/immutable/iis/Abstract__IisTest.template
@@ -52,6 +52,10 @@ class Abstract%%NAME%%IisTest {
 
         @Override
         protected int readImpl(%%TYPE%%[] array, int offset, int length) throws IOException {
+            if (length == 0) {
+                throw new IOException("length == 0 should have been detected!");
+            }
+
             return length;
         }
 


### PR DESCRIPTION
This PR updates the BitIla API to use longs when referring to bit positions.