### PR TITLE
Set a better log format when building.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,9 @@
                     <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
                         <theme>UNICODE</theme>
                     </statelessTestsetInfoReporter>
+                    <systemPropertyVariables>
+                        <java.util.logging.SimpleFormatter.format>%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$-6s %2$-50.50s %5$s%6$s%n</java.util.logging.SimpleFormatter.format>
+                    </systemPropertyVariables>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
This PR sets the logging format to a more useful single line format than the default double line format.