### PR TITLE
Update ila tests to use AssertJ.

### DIFF
--- a/src/test/java/tfw/immutable/ila/ImmutableLongArrayUtilTest.java
+++ b/src/test/java/tfw/immutable/ila/ImmutableLongArrayUtilTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
-class ImmutableLongArrayUtilTest {
+final class ImmutableLongArrayUtilTest {
     @Test
     void boundsCheckTest() {
         assertThatThrownBy(() -> ImmutableLongArrayUtil.boundsCheck(-1, 0, 0, 0, 0))

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaMutateTest.java
@@ -1,26 +1,32 @@
 package tfw.immutable.ila.booleanila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class BooleanIlaMutateTest {
+final class BooleanIlaMutateTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final Random random = new Random(0);
         final BooleanIla ila = BooleanIlaFromArray.create(new boolean[10]);
         final long ilaLength = ila.length();
         final boolean value = random.nextBoolean();
 
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaMutate.create(null, 0, value));
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaMutate.create(ila, -1, value));
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaMutate.create(ila, ilaLength, value));
+        assertThatThrownBy(() -> BooleanIlaMutate.create(null, 0, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> BooleanIlaMutate.create(ila, -1, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> BooleanIlaMutate.create(ila, ilaLength, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final boolean[] array = new boolean[length];

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaRemoveTest.java
@@ -1,24 +1,30 @@
 package tfw.immutable.ila.booleanila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class BooleanIlaRemoveTest {
+final class BooleanIlaRemoveTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final BooleanIla ila = BooleanIlaFromArray.create(new boolean[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaRemove.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaRemove.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaRemove.create(ila, ilaLength));
+        assertThatThrownBy(() -> BooleanIlaRemove.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> BooleanIlaRemove.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> BooleanIlaRemove.create(ila, ilaLength))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final boolean[] array = new boolean[length];

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaReverseTest.java
@@ -1,23 +1,27 @@
 package tfw.immutable.ila.booleanila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class BooleanIlaReverseTest {
+final class BooleanIlaReverseTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final BooleanIla ila = BooleanIlaFromArray.create(new boolean[10]);
         final boolean[] buffer = new boolean[10];
 
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaReverse.create(null, buffer));
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaReverse.create(ila, null));
+        assertThatThrownBy(() -> BooleanIlaReverse.create(null, buffer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> BooleanIlaReverse.create(ila, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("buffer == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final boolean[] array = new boolean[length];

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaSegmentTest.java
@@ -1,29 +1,45 @@
 package tfw.immutable.ila.booleanila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class BooleanIlaSegmentTest {
+final class BooleanIlaSegmentTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final BooleanIla ila = BooleanIlaFromArray.create(new boolean[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaSegment.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaSegment.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaSegment.create(ila, ilaLength + 1));
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaSegment.create(null, 0, 0));
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaSegment.create(ila, -1, 0));
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaSegment.create(ila, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaSegment.create(ila, ilaLength + 1, 0));
-        assertThrows(IllegalArgumentException.class, () -> BooleanIlaSegment.create(ila, 0, ilaLength + 1));
+        assertThatThrownBy(() -> BooleanIlaSegment.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> BooleanIlaSegment.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> BooleanIlaSegment.create(ila, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> BooleanIlaSegment.create(null, 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> BooleanIlaSegment.create(ila, -1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> BooleanIlaSegment.create(ila, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> BooleanIlaSegment.create(ila, ilaLength + 1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
+        assertThatThrownBy(() -> BooleanIlaSegment.create(ila, 0, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final boolean[] master = new boolean[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaMutateTest.java
@@ -1,26 +1,32 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaMutateTest {
+final class ByteIlaMutateTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final Random random = new Random(0);
         final ByteIla ila = ByteIlaFromArray.create(new byte[10]);
         final long ilaLength = ila.length();
         final byte value = (byte) random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaMutate.create(null, 0, value));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaMutate.create(ila, -1, value));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaMutate.create(ila, ilaLength, value));
+        assertThatThrownBy(() -> ByteIlaMutate.create(null, 0, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaMutate.create(ila, -1, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ByteIlaMutate.create(ila, ilaLength, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] array = new byte[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaRemoveTest.java
@@ -1,24 +1,30 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaRemoveTest {
+final class ByteIlaRemoveTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final ByteIla ila = ByteIlaFromArray.create(new byte[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaRemove.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaRemove.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaRemove.create(ila, ilaLength));
+        assertThatThrownBy(() -> ByteIlaRemove.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaRemove.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ByteIlaRemove.create(ila, ilaLength))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] array = new byte[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaReverseTest.java
@@ -1,23 +1,27 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaReverseTest {
+final class ByteIlaReverseTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ByteIla ila = ByteIlaFromArray.create(new byte[10]);
         final byte[] buffer = new byte[10];
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaReverse.create(null, buffer));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaReverse.create(ila, null));
+        assertThatThrownBy(() -> ByteIlaReverse.create(null, buffer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaReverse.create(ila, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("buffer == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] array = new byte[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaSegmentTest.java
@@ -1,29 +1,45 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaSegmentTest {
+final class ByteIlaSegmentTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final ByteIla ila = ByteIlaFromArray.create(new byte[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaSegment.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaSegment.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaSegment.create(ila, ilaLength + 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaSegment.create(null, 0, 0));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaSegment.create(ila, -1, 0));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaSegment.create(ila, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaSegment.create(ila, ilaLength + 1, 0));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaSegment.create(ila, 0, ilaLength + 1));
+        assertThatThrownBy(() -> ByteIlaSegment.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaSegment.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ByteIlaSegment.create(ila, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ByteIlaSegment.create(null, 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaSegment.create(ila, -1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ByteIlaSegment.create(ila, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ByteIlaSegment.create(ila, ilaLength + 1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
+        assertThatThrownBy(() -> ByteIlaSegment.create(ila, 0, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] master = new byte[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaMutateTest.java
@@ -1,26 +1,32 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaMutateTest {
+final class CharIlaMutateTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final Random random = new Random(0);
         final CharIla ila = CharIlaFromArray.create(new char[10]);
         final long ilaLength = ila.length();
         final char value = (char) random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaMutate.create(null, 0, value));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaMutate.create(ila, -1, value));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaMutate.create(ila, ilaLength, value));
+        assertThatThrownBy(() -> CharIlaMutate.create(null, 0, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> CharIlaMutate.create(ila, -1, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> CharIlaMutate.create(ila, ilaLength, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] array = new char[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaRemoveTest.java
@@ -1,24 +1,30 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaRemoveTest {
+final class CharIlaRemoveTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final CharIla ila = CharIlaFromArray.create(new char[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaRemove.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaRemove.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaRemove.create(ila, ilaLength));
+        assertThatThrownBy(() -> CharIlaRemove.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> CharIlaRemove.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> CharIlaRemove.create(ila, ilaLength))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] array = new char[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaReverseTest.java
@@ -1,23 +1,27 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaReverseTest {
+final class CharIlaReverseTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final CharIla ila = CharIlaFromArray.create(new char[10]);
         final char[] buffer = new char[10];
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaReverse.create(null, buffer));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaReverse.create(ila, null));
+        assertThatThrownBy(() -> CharIlaReverse.create(null, buffer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> CharIlaReverse.create(ila, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("buffer == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] array = new char[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaSegmentTest.java
@@ -1,29 +1,45 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaSegmentTest {
+final class CharIlaSegmentTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final CharIla ila = CharIlaFromArray.create(new char[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaSegment.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaSegment.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaSegment.create(ila, ilaLength + 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaSegment.create(null, 0, 0));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaSegment.create(ila, -1, 0));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaSegment.create(ila, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaSegment.create(ila, ilaLength + 1, 0));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaSegment.create(ila, 0, ilaLength + 1));
+        assertThatThrownBy(() -> CharIlaSegment.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> CharIlaSegment.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> CharIlaSegment.create(ila, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> CharIlaSegment.create(null, 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> CharIlaSegment.create(ila, -1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> CharIlaSegment.create(ila, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> CharIlaSegment.create(ila, ilaLength + 1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
+        assertThatThrownBy(() -> CharIlaSegment.create(ila, 0, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] master = new char[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMutateTest.java
@@ -1,26 +1,32 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaMutateTest {
+final class DoubleIlaMutateTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final Random random = new Random(0);
         final DoubleIla ila = DoubleIlaFromArray.create(new double[10]);
         final long ilaLength = ila.length();
         final double value = random.nextDouble();
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaMutate.create(null, 0, value));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaMutate.create(ila, -1, value));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaMutate.create(ila, ilaLength, value));
+        assertThatThrownBy(() -> DoubleIlaMutate.create(null, 0, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaMutate.create(ila, -1, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> DoubleIlaMutate.create(ila, ilaLength, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRemoveTest.java
@@ -1,24 +1,30 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaRemoveTest {
+final class DoubleIlaRemoveTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final DoubleIla ila = DoubleIlaFromArray.create(new double[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaRemove.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaRemove.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaRemove.create(ila, ilaLength));
+        assertThatThrownBy(() -> DoubleIlaRemove.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaRemove.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> DoubleIlaRemove.create(ila, ilaLength))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaReverseTest.java
@@ -1,23 +1,27 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaReverseTest {
+final class DoubleIlaReverseTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final DoubleIla ila = DoubleIlaFromArray.create(new double[10]);
         final double[] buffer = new double[10];
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaReverse.create(null, buffer));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaReverse.create(ila, null));
+        assertThatThrownBy(() -> DoubleIlaReverse.create(null, buffer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaReverse.create(ila, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("buffer == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSegmentTest.java
@@ -1,29 +1,45 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaSegmentTest {
+final class DoubleIlaSegmentTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final DoubleIla ila = DoubleIlaFromArray.create(new double[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaSegment.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaSegment.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaSegment.create(ila, ilaLength + 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaSegment.create(null, 0, 0));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaSegment.create(ila, -1, 0));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaSegment.create(ila, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaSegment.create(ila, ilaLength + 1, 0));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaSegment.create(ila, 0, ilaLength + 1));
+        assertThatThrownBy(() -> DoubleIlaSegment.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaSegment.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> DoubleIlaSegment.create(ila, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> DoubleIlaSegment.create(null, 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaSegment.create(ila, -1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> DoubleIlaSegment.create(ila, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> DoubleIlaSegment.create(ila, ilaLength + 1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
+        assertThatThrownBy(() -> DoubleIlaSegment.create(ila, 0, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] master = new double[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaMutateTest.java
@@ -1,26 +1,32 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaMutateTest {
+final class FloatIlaMutateTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final Random random = new Random(0);
         final FloatIla ila = FloatIlaFromArray.create(new float[10]);
         final long ilaLength = ila.length();
         final float value = random.nextFloat();
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaMutate.create(null, 0, value));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaMutate.create(ila, -1, value));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaMutate.create(ila, ilaLength, value));
+        assertThatThrownBy(() -> FloatIlaMutate.create(null, 0, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaMutate.create(ila, -1, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> FloatIlaMutate.create(ila, ilaLength, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaRemoveTest.java
@@ -1,24 +1,30 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaRemoveTest {
+final class FloatIlaRemoveTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final FloatIla ila = FloatIlaFromArray.create(new float[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaRemove.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaRemove.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaRemove.create(ila, ilaLength));
+        assertThatThrownBy(() -> FloatIlaRemove.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaRemove.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> FloatIlaRemove.create(ila, ilaLength))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaReverseTest.java
@@ -1,23 +1,27 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaReverseTest {
+final class FloatIlaReverseTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final FloatIla ila = FloatIlaFromArray.create(new float[10]);
         final float[] buffer = new float[10];
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaReverse.create(null, buffer));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaReverse.create(ila, null));
+        assertThatThrownBy(() -> FloatIlaReverse.create(null, buffer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaReverse.create(ila, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("buffer == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaSegmentTest.java
@@ -1,29 +1,45 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaSegmentTest {
+final class FloatIlaSegmentTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final FloatIla ila = FloatIlaFromArray.create(new float[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaSegment.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaSegment.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaSegment.create(ila, ilaLength + 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaSegment.create(null, 0, 0));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaSegment.create(ila, -1, 0));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaSegment.create(ila, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaSegment.create(ila, ilaLength + 1, 0));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaSegment.create(ila, 0, ilaLength + 1));
+        assertThatThrownBy(() -> FloatIlaSegment.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaSegment.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> FloatIlaSegment.create(ila, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> FloatIlaSegment.create(null, 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaSegment.create(ila, -1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> FloatIlaSegment.create(ila, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> FloatIlaSegment.create(ila, ilaLength + 1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
+        assertThatThrownBy(() -> FloatIlaSegment.create(ila, 0, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] master = new float[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaMutateTest.java
@@ -1,26 +1,32 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaMutateTest {
+final class IntIlaMutateTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final Random random = new Random(0);
         final IntIla ila = IntIlaFromArray.create(new int[10]);
         final long ilaLength = ila.length();
         final int value = random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaMutate.create(null, 0, value));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaMutate.create(ila, -1, value));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaMutate.create(ila, ilaLength, value));
+        assertThatThrownBy(() -> IntIlaMutate.create(null, 0, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> IntIlaMutate.create(ila, -1, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> IntIlaMutate.create(ila, ilaLength, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] array = new int[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaRemoveTest.java
@@ -1,24 +1,30 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaRemoveTest {
+final class IntIlaRemoveTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final IntIla ila = IntIlaFromArray.create(new int[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaRemove.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaRemove.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaRemove.create(ila, ilaLength));
+        assertThatThrownBy(() -> IntIlaRemove.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> IntIlaRemove.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> IntIlaRemove.create(ila, ilaLength))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] array = new int[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaReverseTest.java
@@ -1,23 +1,27 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaReverseTest {
+final class IntIlaReverseTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final IntIla ila = IntIlaFromArray.create(new int[10]);
         final int[] buffer = new int[10];
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaReverse.create(null, buffer));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaReverse.create(ila, null));
+        assertThatThrownBy(() -> IntIlaReverse.create(null, buffer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> IntIlaReverse.create(ila, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("buffer == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] array = new int[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaSegmentTest.java
@@ -1,29 +1,45 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaSegmentTest {
+final class IntIlaSegmentTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final IntIla ila = IntIlaFromArray.create(new int[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaSegment.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaSegment.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaSegment.create(ila, ilaLength + 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaSegment.create(null, 0, 0));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaSegment.create(ila, -1, 0));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaSegment.create(ila, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaSegment.create(ila, ilaLength + 1, 0));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaSegment.create(ila, 0, ilaLength + 1));
+        assertThatThrownBy(() -> IntIlaSegment.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> IntIlaSegment.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> IntIlaSegment.create(ila, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> IntIlaSegment.create(null, 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> IntIlaSegment.create(ila, -1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> IntIlaSegment.create(ila, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> IntIlaSegment.create(ila, ilaLength + 1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
+        assertThatThrownBy(() -> IntIlaSegment.create(ila, 0, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] master = new int[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaMutateTest.java
@@ -1,26 +1,32 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaMutateTest {
+final class LongIlaMutateTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final Random random = new Random(0);
         final LongIla ila = LongIlaFromArray.create(new long[10]);
         final long ilaLength = ila.length();
         final long value = random.nextLong();
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaMutate.create(null, 0, value));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaMutate.create(ila, -1, value));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaMutate.create(ila, ilaLength, value));
+        assertThatThrownBy(() -> LongIlaMutate.create(null, 0, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> LongIlaMutate.create(ila, -1, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> LongIlaMutate.create(ila, ilaLength, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] array = new long[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaRemoveTest.java
@@ -1,24 +1,30 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaRemoveTest {
+final class LongIlaRemoveTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final LongIla ila = LongIlaFromArray.create(new long[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaRemove.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaRemove.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaRemove.create(ila, ilaLength));
+        assertThatThrownBy(() -> LongIlaRemove.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> LongIlaRemove.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> LongIlaRemove.create(ila, ilaLength))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] array = new long[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaReverseTest.java
@@ -1,23 +1,27 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaReverseTest {
+final class LongIlaReverseTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final LongIla ila = LongIlaFromArray.create(new long[10]);
         final long[] buffer = new long[10];
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaReverse.create(null, buffer));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaReverse.create(ila, null));
+        assertThatThrownBy(() -> LongIlaReverse.create(null, buffer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> LongIlaReverse.create(ila, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("buffer == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] array = new long[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaSegmentTest.java
@@ -1,29 +1,45 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaSegmentTest {
+final class LongIlaSegmentTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final LongIla ila = LongIlaFromArray.create(new long[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaSegment.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaSegment.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaSegment.create(ila, ilaLength + 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaSegment.create(null, 0, 0));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaSegment.create(ila, -1, 0));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaSegment.create(ila, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaSegment.create(ila, ilaLength + 1, 0));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaSegment.create(ila, 0, ilaLength + 1));
+        assertThatThrownBy(() -> LongIlaSegment.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> LongIlaSegment.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> LongIlaSegment.create(ila, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> LongIlaSegment.create(null, 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> LongIlaSegment.create(ila, -1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> LongIlaSegment.create(ila, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> LongIlaSegment.create(ila, ilaLength + 1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
+        assertThatThrownBy(() -> LongIlaSegment.create(ila, 0, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] master = new long[length];

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaMutateTest.java
@@ -1,24 +1,30 @@
 package tfw.immutable.ila.objectila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ObjectIlaMutateTest {
+final class ObjectIlaMutateTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final ObjectIla<Object> ila = ObjectIlaFromArray.create(new Object[10]);
         final long ilaLength = ila.length();
         final Object value = new Object();
 
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaMutate.create(null, 0, value));
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaMutate.create(ila, -1, value));
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaMutate.create(ila, ilaLength, value));
+        assertThatThrownBy(() -> ObjectIlaMutate.create(null, 0, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ObjectIlaMutate.create(ila, -1, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ObjectIlaMutate.create(ila, ilaLength, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final int length = IlaTestDimensions.defaultIlaLength();
         final Object[] array = new Object[length];
         final Object[] target = new Object[length];

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaRemoveTest.java
@@ -1,23 +1,29 @@
 package tfw.immutable.ila.objectila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ObjectIlaRemoveTest {
+final class ObjectIlaRemoveTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final ObjectIla<Object> ila = ObjectIlaFromArray.create(new Object[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaRemove.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaRemove.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaRemove.create(ila, ilaLength));
+        assertThatThrownBy(() -> ObjectIlaRemove.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ObjectIlaRemove.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ObjectIlaRemove.create(ila, ilaLength))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final int length = IlaTestDimensions.defaultIlaLength();
         final Object[] array = new Object[length];
         final Object[] target = new Object[length - 1];

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaReverseTest.java
@@ -1,22 +1,26 @@
 package tfw.immutable.ila.objectila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ObjectIlaReverseTest {
+final class ObjectIlaReverseTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ObjectIla<Object> ila = ObjectIlaFromArray.create(new Object[10]);
         final Object[] buffer = new Object[10];
 
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaReverse.create(null, buffer));
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaReverse.create(ila, null));
+        assertThatThrownBy(() -> ObjectIlaReverse.create(null, buffer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ObjectIlaReverse.create(ila, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("buffer == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final int length = IlaTestDimensions.defaultIlaLength();
         final Object[] array = new Object[length];
         final Object[] reversed = new Object[length];

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaSegmentTest.java
@@ -1,28 +1,44 @@
 package tfw.immutable.ila.objectila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ObjectIlaSegmentTest {
+final class ObjectIlaSegmentTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final ObjectIla<Object> ila = ObjectIlaFromArray.create(new Object[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaSegment.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaSegment.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaSegment.create(ila, ilaLength + 1));
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaSegment.create(null, 0, 0));
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaSegment.create(ila, -1, 0));
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaSegment.create(ila, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaSegment.create(ila, ilaLength + 1, 0));
-        assertThrows(IllegalArgumentException.class, () -> ObjectIlaSegment.create(ila, 0, ilaLength + 1));
+        assertThatThrownBy(() -> ObjectIlaSegment.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ObjectIlaSegment.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ObjectIlaSegment.create(ila, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ObjectIlaSegment.create(null, 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ObjectIlaSegment.create(ila, -1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ObjectIlaSegment.create(ila, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ObjectIlaSegment.create(ila, ilaLength + 1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
+        assertThatThrownBy(() -> ObjectIlaSegment.create(ila, 0, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final int length = IlaTestDimensions.defaultIlaLength();
         final Object[] master = new Object[length];
         for (int ii = 0; ii < master.length; ++ii) {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaMutateTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaMutateTest.java
@@ -1,26 +1,32 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaMutateTest {
+final class ShortIlaMutateTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final Random random = new Random(0);
         final ShortIla ila = ShortIlaFromArray.create(new short[10]);
         final long ilaLength = ila.length();
         final short value = (short) random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaMutate.create(null, 0, value));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaMutate.create(ila, -1, value));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaMutate.create(ila, ilaLength, value));
+        assertThatThrownBy(() -> ShortIlaMutate.create(null, 0, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaMutate.create(ila, -1, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ShortIlaMutate.create(ila, ilaLength, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] array = new short[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaRemoveTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaRemoveTest.java
@@ -1,24 +1,30 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaRemoveTest {
+final class ShortIlaRemoveTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final ShortIla ila = ShortIlaFromArray.create(new short[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaRemove.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaRemove.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaRemove.create(ila, ilaLength));
+        assertThatThrownBy(() -> ShortIlaRemove.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaRemove.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ShortIlaRemove.create(ila, ilaLength))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] array = new short[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaReverseTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaReverseTest.java
@@ -1,23 +1,27 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaReverseTest {
+final class ShortIlaReverseTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ShortIla ila = ShortIlaFromArray.create(new short[10]);
         final short[] buffer = new short[10];
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaReverse.create(null, buffer));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaReverse.create(ila, null));
+        assertThatThrownBy(() -> ShortIlaReverse.create(null, buffer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaReverse.create(ila, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("buffer == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] array = new short[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaSegmentTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaSegmentTest.java
@@ -1,29 +1,45 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaSegmentTest {
+final class ShortIlaSegmentTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final ShortIla ila = ShortIlaFromArray.create(new short[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaSegment.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaSegment.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaSegment.create(ila, ilaLength + 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaSegment.create(null, 0, 0));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaSegment.create(ila, -1, 0));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaSegment.create(ila, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaSegment.create(ila, ilaLength + 1, 0));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaSegment.create(ila, 0, ilaLength + 1));
+        assertThatThrownBy(() -> ShortIlaSegment.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaSegment.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ShortIlaSegment.create(ila, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ShortIlaSegment.create(null, 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaSegment.create(ila, -1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ShortIlaSegment.create(ila, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ShortIlaSegment.create(ila, ilaLength + 1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
+        assertThatThrownBy(() -> ShortIlaSegment.create(ila, 0, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] master = new short[length];

--- a/src/test/template/tfw/immutable/ila/__IlaMutateTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaMutateTest.template
@@ -1,25 +1,31 @@
 // booleanila,byteila,charila,doubleila,floatila,intila,longila,objectila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaMutateTest {
+final class %%NAME%%IlaMutateTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         %%RANDOM_INIT%%final %%NAME%%Ila%%TEMPLATE%% ila = %%NAME%%IlaFromArray.create(new %%TYPE%%[10]);
         final long ilaLength = ila.length();
         final %%TYPE%% value = %%RANDOM_VALUE%%;
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaMutate.create(null, 0, value));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaMutate.create(ila, -1, value));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaMutate.create(ila, ilaLength, value));
+        assertThatThrownBy(() -> %%NAME%%IlaMutate.create(null, 0, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaMutate.create(ila, -1, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaMutate.create(ila, ilaLength, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%%[] array = new %%TYPE%%[length];
         final %%TYPE%%[] target = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaRemoveTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaRemoveTest.template
@@ -1,24 +1,30 @@
 // booleanila,byteila,charila,doubleila,floatila,intila,longila,objectila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaRemoveTest {
+final class %%NAME%%IlaRemoveTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final %%NAME%%Ila%%TEMPLATE%% ila = %%NAME%%IlaFromArray.create(new %%TYPE%%[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaRemove.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaRemove.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaRemove.create(ila, ilaLength));
+        assertThatThrownBy(() -> %%NAME%%IlaRemove.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaRemove.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaRemove.create(ila, ilaLength))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index (=10) >= ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%%[] array = new %%TYPE%%[length];
         final %%TYPE%%[] target = new %%TYPE%%[length - 1];

--- a/src/test/template/tfw/immutable/ila/__IlaReverseTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaReverseTest.template
@@ -1,23 +1,27 @@
 // booleanila,byteila,charila,doubleila,floatila,intila,longila,objectila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaReverseTest {
+final class %%NAME%%IlaReverseTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final %%NAME%%Ila%%TEMPLATE%% ila = %%NAME%%IlaFromArray.create(new %%TYPE%%[10]);
         final %%TYPE%%[] buffer = new %%TYPE%%[10];
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaReverse.create(null, buffer));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaReverse.create(ila, null));
+        assertThatThrownBy(() -> %%NAME%%IlaReverse.create(null, buffer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaReverse.create(ila, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("buffer == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%%[] array = new %%TYPE%%[length];
         final %%TYPE%%[] reversed = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaSegmentTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaSegmentTest.template
@@ -1,29 +1,45 @@
 // booleanila,byteila,charila,doubleila,floatila,intila,longila,objectila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaSegmentTest {
+final class %%NAME%%IlaSegmentTest {
     @Test
-    void testArguments() throws Exception {
+    void argumentsTest() throws Exception {
         final %%NAME%%Ila%%TEMPLATE%% ila = %%NAME%%IlaFromArray.create(new %%TYPE%%[10]);
         final long ilaLength = ila.length();
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaSegment.create(null, 0));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaSegment.create(ila, -1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaSegment.create(ila, ilaLength + 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaSegment.create(null, 0, 0));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaSegment.create(ila, -1, 0));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaSegment.create(ila, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaSegment.create(ila, ilaLength + 1, 0));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaSegment.create(ila, 0, ilaLength + 1));
+        assertThatThrownBy(() -> %%NAME%%IlaSegment.create(null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaSegment.create(ila, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaSegment.create(ila, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaSegment.create(null, 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaSegment.create(ila, -1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaSegment.create(ila, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaSegment.create(ila, ilaLength + 1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaSegment.create(ila, 0, ilaLength + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start + length (=11) > ila.length() (=10) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%%[] master = new %%TYPE%%[length];
         for (int ii = 0; ii < master.length; ++ii) {


### PR DESCRIPTION
This PR updates the non-numerical ila packages to use AssertJ.

## Summary by Sourcery

Tests:
- Use AssertJ assertions in ILA tests.