### PR TITLE
Update "ila" tests to use AssertJ - Part 3

### DIFF
--- a/src/main/java/tfw/immutable/ila/booleanila/AbstractBooleanIla.java
+++ b/src/main/java/tfw/immutable/ila/booleanila/AbstractBooleanIla.java
@@ -1,6 +1,7 @@
 package tfw.immutable.ila.booleanila;
 
 import java.io.IOException;
+import tfw.check.Argument;
 import tfw.immutable.ila.AbstractIla;
 
 public abstract class AbstractBooleanIla extends AbstractIla implements BooleanIla {
@@ -14,6 +15,7 @@ public abstract class AbstractBooleanIla extends AbstractIla implements BooleanI
             return;
         }
 
+        Argument.assertNotNull(array, "array");
         boundsCheck(array.length, offset, start, length);
         getImpl(array, offset, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/byteila/AbstractByteIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/AbstractByteIla.java
@@ -1,6 +1,7 @@
 package tfw.immutable.ila.byteila;
 
 import java.io.IOException;
+import tfw.check.Argument;
 import tfw.immutable.ila.AbstractIla;
 
 public abstract class AbstractByteIla extends AbstractIla implements ByteIla {
@@ -14,6 +15,7 @@ public abstract class AbstractByteIla extends AbstractIla implements ByteIla {
             return;
         }
 
+        Argument.assertNotNull(array, "array");
         boundsCheck(array.length, offset, start, length);
         getImpl(array, offset, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/charila/AbstractCharIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/AbstractCharIla.java
@@ -1,6 +1,7 @@
 package tfw.immutable.ila.charila;
 
 import java.io.IOException;
+import tfw.check.Argument;
 import tfw.immutable.ila.AbstractIla;
 
 public abstract class AbstractCharIla extends AbstractIla implements CharIla {
@@ -14,6 +15,7 @@ public abstract class AbstractCharIla extends AbstractIla implements CharIla {
             return;
         }
 
+        Argument.assertNotNull(array, "array");
         boundsCheck(array.length, offset, start, length);
         getImpl(array, offset, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/doubleila/AbstractDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/AbstractDoubleIla.java
@@ -1,6 +1,7 @@
 package tfw.immutable.ila.doubleila;
 
 import java.io.IOException;
+import tfw.check.Argument;
 import tfw.immutable.ila.AbstractIla;
 
 public abstract class AbstractDoubleIla extends AbstractIla implements DoubleIla {
@@ -14,6 +15,7 @@ public abstract class AbstractDoubleIla extends AbstractIla implements DoubleIla
             return;
         }
 
+        Argument.assertNotNull(array, "array");
         boundsCheck(array.length, offset, start, length);
         getImpl(array, offset, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/floatila/AbstractFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/AbstractFloatIla.java
@@ -1,6 +1,7 @@
 package tfw.immutable.ila.floatila;
 
 import java.io.IOException;
+import tfw.check.Argument;
 import tfw.immutable.ila.AbstractIla;
 
 public abstract class AbstractFloatIla extends AbstractIla implements FloatIla {
@@ -14,6 +15,7 @@ public abstract class AbstractFloatIla extends AbstractIla implements FloatIla {
             return;
         }
 
+        Argument.assertNotNull(array, "array");
         boundsCheck(array.length, offset, start, length);
         getImpl(array, offset, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/intila/AbstractIntIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/AbstractIntIla.java
@@ -1,6 +1,7 @@
 package tfw.immutable.ila.intila;
 
 import java.io.IOException;
+import tfw.check.Argument;
 import tfw.immutable.ila.AbstractIla;
 
 public abstract class AbstractIntIla extends AbstractIla implements IntIla {
@@ -14,6 +15,7 @@ public abstract class AbstractIntIla extends AbstractIla implements IntIla {
             return;
         }
 
+        Argument.assertNotNull(array, "array");
         boundsCheck(array.length, offset, start, length);
         getImpl(array, offset, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/longila/AbstractLongIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/AbstractLongIla.java
@@ -1,6 +1,7 @@
 package tfw.immutable.ila.longila;
 
 import java.io.IOException;
+import tfw.check.Argument;
 import tfw.immutable.ila.AbstractIla;
 
 public abstract class AbstractLongIla extends AbstractIla implements LongIla {
@@ -14,6 +15,7 @@ public abstract class AbstractLongIla extends AbstractIla implements LongIla {
             return;
         }
 
+        Argument.assertNotNull(array, "array");
         boundsCheck(array.length, offset, start, length);
         getImpl(array, offset, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/objectila/AbstractObjectIla.java
+++ b/src/main/java/tfw/immutable/ila/objectila/AbstractObjectIla.java
@@ -1,6 +1,7 @@
 package tfw.immutable.ila.objectila;
 
 import java.io.IOException;
+import tfw.check.Argument;
 import tfw.immutable.ila.AbstractIla;
 
 public abstract class AbstractObjectIla<T> extends AbstractIla implements ObjectIla<T> {
@@ -14,6 +15,7 @@ public abstract class AbstractObjectIla<T> extends AbstractIla implements Object
             return;
         }
 
+        Argument.assertNotNull(array, "array");
         boundsCheck(array.length, offset, start, length);
         getImpl(array, offset, start, length);
     }

--- a/src/main/java/tfw/immutable/ila/shortila/AbstractShortIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/AbstractShortIla.java
@@ -1,6 +1,7 @@
 package tfw.immutable.ila.shortila;
 
 import java.io.IOException;
+import tfw.check.Argument;
 import tfw.immutable.ila.AbstractIla;
 
 public abstract class AbstractShortIla extends AbstractIla implements ShortIla {
@@ -14,6 +15,7 @@ public abstract class AbstractShortIla extends AbstractIla implements ShortIla {
             return;
         }
 
+        Argument.assertNotNull(array, "array");
         boundsCheck(array.length, offset, start, length);
         getImpl(array, offset, start, length);
     }

--- a/src/main/template/tfw/immutable/ila/Abstract__Ila.template
+++ b/src/main/template/tfw/immutable/ila/Abstract__Ila.template
@@ -2,6 +2,7 @@
 package %%PACKAGE%%;
 
 import java.io.IOException;
+import tfw.check.Argument;
 import tfw.immutable.ila.AbstractIla;
 
 public abstract class Abstract%%NAME%%Ila%%TEMPLATE%% extends AbstractIla implements %%NAME%%Ila%%TEMPLATE%% {
@@ -15,6 +16,7 @@ public abstract class Abstract%%NAME%%Ila%%TEMPLATE%% extends AbstractIla implem
             return;
         }
 
+        Argument.assertNotNull(array, "array");
         boundsCheck(array.length, offset, start, length);
         getImpl(array, offset, start, length);
     }

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java
@@ -15,14 +15,30 @@ public final class BooleanIlaCheck {
         final long ilaLength = ila.length();
         final boolean[] array = new boolean[10];
 
-        assertThatThrownBy(() -> ila.get(null, 0, 0, 1)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> ila.get(array, -1, 0, 1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, 0, -1, 1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, 0, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ila.get(null, 0, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("array == null not allowed!");
+        assertThatThrownBy(() -> ila.get(array, -1, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, -1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=10) >= array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
     }
 
     public static void checkGetExhaustively(BooleanIla ila1, BooleanIla ila2) throws IOException {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaAddTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaAddTest {
+final class ByteIlaAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ByteIla ila1 = ByteIlaFromArray.create(new byte[10]);
         final ByteIla ila2 = ByteIlaFromArray.create(new byte[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaAdd.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaAdd.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaAdd.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaAdd.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> ByteIlaAdd.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaAdd.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaAdd.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> ByteIlaAdd.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] leftArray = new byte[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaBoundTest.java
@@ -1,22 +1,28 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaBoundTest {
+final class ByteIlaBoundTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
+        final byte low = (byte) 5;
+        final byte high = (byte) 10;
         final ByteIla ila = ByteIlaFromArray.create(new byte[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaBound.create(null, (byte) 5, (byte) 10));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaBound.create(ila, (byte) 10, (byte) 5));
+        assertThatThrownBy(() -> ByteIlaBound.create(null, low, high))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaBound.create(ila, high, low))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("minimum (=" + high + ") > maximum (=" + low + ") not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] array = new byte[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaCheck.java
@@ -1,8 +1,7 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.Random;
@@ -16,21 +15,37 @@ public final class ByteIlaCheck {
         final long ilaLength = ila.length();
         final byte[] array = new byte[10];
 
-        assertThrows(NullPointerException.class, () -> ila.get(null, 0, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, -1, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, -1, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length - 1, 0, 2));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength - 1, 2));
+        assertThatThrownBy(() -> ila.get(null, 0, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("array == null not allowed!");
+        assertThatThrownBy(() -> ila.get(array, -1, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, -1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=10) >= array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
     }
 
     public static void checkGetExhaustively(final ByteIla ila1, final ByteIla ila2) throws IOException {
         final int length1 = (int) Math.min(ila1.length(), Integer.MAX_VALUE);
         final int length2 = (int) Math.min(ila2.length(), Integer.MAX_VALUE);
 
-        assertEquals(length1, length2);
+        assertThat(length2).isEqualTo(length1);
 
         final byte[] a1 = new byte[length1];
         final byte[] a2 = new byte[length1];
@@ -41,7 +56,7 @@ public final class ByteIlaCheck {
                     ila1.get(a1, o, s, l);
                     ila2.get(a2, o, s, l);
 
-                    assertArrayEquals(a1, a2);
+                    assertThat(a2).isEqualTo(a1);
                 }
             }
         }

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaDivideTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaDivideTest {
+final class ByteIlaDivideTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ByteIla ila1 = ByteIlaFromArray.create(new byte[10]);
         final ByteIla ila2 = ByteIlaFromArray.create(new byte[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaDivide.create(null, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaDivide.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaDivide.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaDivide.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> ByteIlaDivide.create(null, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaDivide.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaDivide.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> ByteIlaDivide.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] leftArray = new byte[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastCharIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastCharIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-class ByteIlaFromCastCharIlaTest {
+final class ByteIlaFromCastCharIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final CharIla ila = CharIlaFromArray.create(new char[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaFromCastCharIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaFromCastCharIla.create(ila, 0));
+        assertThatThrownBy(() -> ByteIlaFromCastCharIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaFromCastCharIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] array = new char[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastDoubleIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastDoubleIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-class ByteIlaFromCastDoubleIlaTest {
+final class ByteIlaFromCastDoubleIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final DoubleIla ila = DoubleIlaFromArray.create(new double[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaFromCastDoubleIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaFromCastDoubleIla.create(ila, 0));
+        assertThatThrownBy(() -> ByteIlaFromCastDoubleIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaFromCastDoubleIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastFloatIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastFloatIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-class ByteIlaFromCastFloatIlaTest {
+final class ByteIlaFromCastFloatIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final FloatIla ila = FloatIlaFromArray.create(new float[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaFromCastFloatIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaFromCastFloatIla.create(ila, 0));
+        assertThatThrownBy(() -> ByteIlaFromCastFloatIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaFromCastFloatIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaAddTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaAddTest {
+final class CharIlaAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final CharIla ila1 = CharIlaFromArray.create(new char[10]);
         final CharIla ila2 = CharIlaFromArray.create(new char[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaAdd.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaAdd.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaAdd.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaAdd.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> CharIlaAdd.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaAdd.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaAdd.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> CharIlaAdd.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] leftArray = new char[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaBoundTest.java
@@ -1,22 +1,28 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaBoundTest {
+final class CharIlaBoundTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
+        final char low = (char) 5;
+        final char high = (char) 10;
         final CharIla ila = CharIlaFromArray.create(new char[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaBound.create(null, (char) 5, (char) 10));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaBound.create(ila, (char) 10, (char) 5));
+        assertThatThrownBy(() -> CharIlaBound.create(null, low, high))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> CharIlaBound.create(ila, high, low))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("minimum (=" + (int) high + ") > maximum (=" + (int) low + ") not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] array = new char[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaCheck.java
@@ -1,8 +1,7 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.Random;
@@ -16,21 +15,37 @@ public final class CharIlaCheck {
         final long ilaLength = ila.length();
         final char[] array = new char[10];
 
-        assertThrows(NullPointerException.class, () -> ila.get(null, 0, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, -1, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, -1, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length - 1, 0, 2));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength - 1, 2));
+        assertThatThrownBy(() -> ila.get(null, 0, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("array == null not allowed!");
+        assertThatThrownBy(() -> ila.get(array, -1, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, -1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=10) >= array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
     }
 
     public static void checkGetExhaustively(final CharIla ila1, final CharIla ila2) throws IOException {
         final int length1 = (int) Math.min(ila1.length(), Integer.MAX_VALUE);
         final int length2 = (int) Math.min(ila2.length(), Integer.MAX_VALUE);
 
-        assertEquals(length1, length2);
+        assertThat(length2).isEqualTo(length1);
 
         final char[] a1 = new char[length1];
         final char[] a2 = new char[length1];
@@ -41,7 +56,7 @@ public final class CharIlaCheck {
                     ila1.get(a1, o, s, l);
                     ila2.get(a2, o, s, l);
 
-                    assertArrayEquals(a1, a2);
+                    assertThat(a2).isEqualTo(a1);
                 }
             }
         }

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaDivideTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaDivideTest {
+final class CharIlaDivideTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final CharIla ila1 = CharIlaFromArray.create(new char[10]);
         final CharIla ila2 = CharIlaFromArray.create(new char[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaDivide.create(null, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaDivide.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaDivide.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaDivide.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> CharIlaDivide.create(null, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaDivide.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaDivide.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> CharIlaDivide.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] leftArray = new char[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastByteIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-class CharIlaFromCastByteIlaTest {
+final class CharIlaFromCastByteIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ByteIla ila = ByteIlaFromArray.create(new byte[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaFromCastByteIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaFromCastByteIla.create(ila, 0));
+        assertThatThrownBy(() -> CharIlaFromCastByteIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaFromCastByteIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] array = new byte[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastDoubleIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastDoubleIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-class CharIlaFromCastDoubleIlaTest {
+final class CharIlaFromCastDoubleIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final DoubleIla ila = DoubleIlaFromArray.create(new double[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaFromCastDoubleIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaFromCastDoubleIla.create(ila, 0));
+        assertThatThrownBy(() -> CharIlaFromCastDoubleIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaFromCastDoubleIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastFloatIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastFloatIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-class CharIlaFromCastFloatIlaTest {
+final class CharIlaFromCastFloatIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final FloatIla ila = FloatIlaFromArray.create(new float[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaFromCastFloatIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaFromCastFloatIla.create(ila, 0));
+        assertThatThrownBy(() -> CharIlaFromCastFloatIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaFromCastFloatIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaAddTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaAddTest {
+final class DoubleIlaAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final DoubleIla ila1 = DoubleIlaFromArray.create(new double[10]);
         final DoubleIla ila2 = DoubleIlaFromArray.create(new double[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaAdd.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaAdd.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaAdd.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaAdd.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> DoubleIlaAdd.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaAdd.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaAdd.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> DoubleIlaAdd.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] leftArray = new double[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaBoundTest.java
@@ -1,22 +1,28 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaBoundTest {
+final class DoubleIlaBoundTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
+        final double low = 5;
+        final double high = 10;
         final DoubleIla ila = DoubleIlaFromArray.create(new double[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaBound.create(null, 5, 10));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaBound.create(ila, 10, 5));
+        assertThatThrownBy(() -> DoubleIlaBound.create(null, low, high))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaBound.create(ila, high, low))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("minimum (=" + high + ") > maximum (=" + low + ") not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaCheck.java
@@ -1,8 +1,7 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.Random;
@@ -16,21 +15,37 @@ public final class DoubleIlaCheck {
         final long ilaLength = ila.length();
         final double[] array = new double[10];
 
-        assertThrows(NullPointerException.class, () -> ila.get(null, 0, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, -1, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, -1, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length - 1, 0, 2));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength - 1, 2));
+        assertThatThrownBy(() -> ila.get(null, 0, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("array == null not allowed!");
+        assertThatThrownBy(() -> ila.get(array, -1, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, -1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=10) >= array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
     }
 
     public static void checkGetExhaustively(final DoubleIla ila1, final DoubleIla ila2) throws IOException {
         final int length1 = (int) Math.min(ila1.length(), Integer.MAX_VALUE);
         final int length2 = (int) Math.min(ila2.length(), Integer.MAX_VALUE);
 
-        assertEquals(length1, length2);
+        assertThat(length2).isEqualTo(length1);
 
         final double[] a1 = new double[length1];
         final double[] a2 = new double[length1];
@@ -41,7 +56,7 @@ public final class DoubleIlaCheck {
                     ila1.get(a1, o, s, l);
                     ila2.get(a2, o, s, l);
 
-                    assertArrayEquals(a1, a2);
+                    assertThat(a2).isEqualTo(a1);
                 }
             }
         }

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaDivideTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaDivideTest {
+final class DoubleIlaDivideTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final DoubleIla ila1 = DoubleIlaFromArray.create(new double[10]);
         final DoubleIla ila2 = DoubleIlaFromArray.create(new double[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaDivide.create(null, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaDivide.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaDivide.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaDivide.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> DoubleIlaDivide.create(null, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaDivide.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaDivide.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> DoubleIlaDivide.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] leftArray = new double[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastByteIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-class DoubleIlaFromCastByteIlaTest {
+final class DoubleIlaFromCastByteIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ByteIla ila = ByteIlaFromArray.create(new byte[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaFromCastByteIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaFromCastByteIla.create(ila, 0));
+        assertThatThrownBy(() -> DoubleIlaFromCastByteIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaFromCastByteIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] array = new byte[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastCharIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastCharIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-class DoubleIlaFromCastCharIlaTest {
+final class DoubleIlaFromCastCharIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final CharIla ila = CharIlaFromArray.create(new char[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaFromCastCharIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaFromCastCharIla.create(ila, 0));
+        assertThatThrownBy(() -> DoubleIlaFromCastCharIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaFromCastCharIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] array = new char[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastFloatIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastFloatIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-class DoubleIlaFromCastFloatIlaTest {
+final class DoubleIlaFromCastFloatIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final FloatIla ila = FloatIlaFromArray.create(new float[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaFromCastFloatIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaFromCastFloatIla.create(ila, 0));
+        assertThatThrownBy(() -> DoubleIlaFromCastFloatIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaFromCastFloatIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaAddTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaAddTest {
+final class FloatIlaAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final FloatIla ila1 = FloatIlaFromArray.create(new float[10]);
         final FloatIla ila2 = FloatIlaFromArray.create(new float[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaAdd.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaAdd.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaAdd.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaAdd.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> FloatIlaAdd.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaAdd.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaAdd.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> FloatIlaAdd.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] leftArray = new float[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaBoundTest.java
@@ -1,22 +1,28 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaBoundTest {
+final class FloatIlaBoundTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
+        final float low = 5;
+        final float high = 10;
         final FloatIla ila = FloatIlaFromArray.create(new float[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaBound.create(null, 5, 10));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaBound.create(ila, 10, 5));
+        assertThatThrownBy(() -> FloatIlaBound.create(null, low, high))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaBound.create(ila, high, low))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("minimum (=" + high + ") > maximum (=" + low + ") not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaCheck.java
@@ -1,8 +1,7 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.Random;
@@ -16,21 +15,37 @@ public final class FloatIlaCheck {
         final long ilaLength = ila.length();
         final float[] array = new float[10];
 
-        assertThrows(NullPointerException.class, () -> ila.get(null, 0, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, -1, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, -1, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length - 1, 0, 2));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength - 1, 2));
+        assertThatThrownBy(() -> ila.get(null, 0, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("array == null not allowed!");
+        assertThatThrownBy(() -> ila.get(array, -1, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, -1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=10) >= array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
     }
 
     public static void checkGetExhaustively(final FloatIla ila1, final FloatIla ila2) throws IOException {
         final int length1 = (int) Math.min(ila1.length(), Integer.MAX_VALUE);
         final int length2 = (int) Math.min(ila2.length(), Integer.MAX_VALUE);
 
-        assertEquals(length1, length2);
+        assertThat(length2).isEqualTo(length1);
 
         final float[] a1 = new float[length1];
         final float[] a2 = new float[length1];
@@ -41,7 +56,7 @@ public final class FloatIlaCheck {
                     ila1.get(a1, o, s, l);
                     ila2.get(a2, o, s, l);
 
-                    assertArrayEquals(a1, a2);
+                    assertThat(a2).isEqualTo(a1);
                 }
             }
         }

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaDivideTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaDivideTest {
+final class FloatIlaDivideTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final FloatIla ila1 = FloatIlaFromArray.create(new float[10]);
         final FloatIla ila2 = FloatIlaFromArray.create(new float[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaDivide.create(null, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaDivide.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaDivide.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaDivide.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> FloatIlaDivide.create(null, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaDivide.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaDivide.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> FloatIlaDivide.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] leftArray = new float[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastByteIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-class FloatIlaFromCastByteIlaTest {
+final class FloatIlaFromCastByteIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ByteIla ila = ByteIlaFromArray.create(new byte[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaFromCastByteIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaFromCastByteIla.create(ila, 0));
+        assertThatThrownBy(() -> FloatIlaFromCastByteIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaFromCastByteIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] array = new byte[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastCharIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastCharIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-class FloatIlaFromCastCharIlaTest {
+final class FloatIlaFromCastCharIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final CharIla ila = CharIlaFromArray.create(new char[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaFromCastCharIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaFromCastCharIla.create(ila, 0));
+        assertThatThrownBy(() -> FloatIlaFromCastCharIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaFromCastCharIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] array = new char[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastDoubleIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastDoubleIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-class FloatIlaFromCastDoubleIlaTest {
+final class FloatIlaFromCastDoubleIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final DoubleIla ila = DoubleIlaFromArray.create(new double[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaFromCastDoubleIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaFromCastDoubleIla.create(ila, 0));
+        assertThatThrownBy(() -> FloatIlaFromCastDoubleIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaFromCastDoubleIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaAddTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaAddTest {
+final class IntIlaAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final IntIla ila1 = IntIlaFromArray.create(new int[10]);
         final IntIla ila2 = IntIlaFromArray.create(new int[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaAdd.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaAdd.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaAdd.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaAdd.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> IntIlaAdd.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaAdd.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaAdd.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> IntIlaAdd.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] leftArray = new int[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaBoundTest.java
@@ -1,22 +1,28 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaBoundTest {
+final class IntIlaBoundTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
+        final int low = 5;
+        final int high = 10;
         final IntIla ila = IntIlaFromArray.create(new int[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaBound.create(null, 5, 10));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaBound.create(ila, 10, 5));
+        assertThatThrownBy(() -> IntIlaBound.create(null, low, high))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> IntIlaBound.create(ila, high, low))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("minimum (=" + high + ") > maximum (=" + low + ") not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] array = new int[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaCheck.java
@@ -1,8 +1,7 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.Random;
@@ -16,21 +15,37 @@ public final class IntIlaCheck {
         final long ilaLength = ila.length();
         final int[] array = new int[10];
 
-        assertThrows(NullPointerException.class, () -> ila.get(null, 0, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, -1, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, -1, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length - 1, 0, 2));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength - 1, 2));
+        assertThatThrownBy(() -> ila.get(null, 0, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("array == null not allowed!");
+        assertThatThrownBy(() -> ila.get(array, -1, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, -1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=10) >= array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
     }
 
     public static void checkGetExhaustively(final IntIla ila1, final IntIla ila2) throws IOException {
         final int length1 = (int) Math.min(ila1.length(), Integer.MAX_VALUE);
         final int length2 = (int) Math.min(ila2.length(), Integer.MAX_VALUE);
 
-        assertEquals(length1, length2);
+        assertThat(length2).isEqualTo(length1);
 
         final int[] a1 = new int[length1];
         final int[] a2 = new int[length1];
@@ -41,7 +56,7 @@ public final class IntIlaCheck {
                     ila1.get(a1, o, s, l);
                     ila2.get(a2, o, s, l);
 
-                    assertArrayEquals(a1, a2);
+                    assertThat(a2).isEqualTo(a1);
                 }
             }
         }

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaDivideTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaDivideTest {
+final class IntIlaDivideTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final IntIla ila1 = IntIlaFromArray.create(new int[10]);
         final IntIla ila2 = IntIlaFromArray.create(new int[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaDivide.create(null, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaDivide.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaDivide.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaDivide.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> IntIlaDivide.create(null, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaDivide.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaDivide.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> IntIlaDivide.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] leftArray = new int[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastByteIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-class IntIlaFromCastByteIlaTest {
+final class IntIlaFromCastByteIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ByteIla ila = ByteIlaFromArray.create(new byte[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaFromCastByteIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaFromCastByteIla.create(ila, 0));
+        assertThatThrownBy(() -> IntIlaFromCastByteIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaFromCastByteIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] array = new byte[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastCharIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastCharIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-class IntIlaFromCastCharIlaTest {
+final class IntIlaFromCastCharIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final CharIla ila = CharIlaFromArray.create(new char[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaFromCastCharIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaFromCastCharIla.create(ila, 0));
+        assertThatThrownBy(() -> IntIlaFromCastCharIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaFromCastCharIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] array = new char[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastDoubleIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastDoubleIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-class IntIlaFromCastDoubleIlaTest {
+final class IntIlaFromCastDoubleIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final DoubleIla ila = DoubleIlaFromArray.create(new double[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaFromCastDoubleIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaFromCastDoubleIla.create(ila, 0));
+        assertThatThrownBy(() -> IntIlaFromCastDoubleIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaFromCastDoubleIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastFloatIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastFloatIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-class IntIlaFromCastFloatIlaTest {
+final class IntIlaFromCastFloatIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final FloatIla ila = FloatIlaFromArray.create(new float[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaFromCastFloatIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaFromCastFloatIla.create(ila, 0));
+        assertThatThrownBy(() -> IntIlaFromCastFloatIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaFromCastFloatIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaAddTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaAddTest {
+final class LongIlaAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final LongIla ila1 = LongIlaFromArray.create(new long[10]);
         final LongIla ila2 = LongIlaFromArray.create(new long[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaAdd.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaAdd.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaAdd.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaAdd.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> LongIlaAdd.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaAdd.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaAdd.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> LongIlaAdd.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] leftArray = new long[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaBoundTest.java
@@ -1,22 +1,28 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaBoundTest {
+final class LongIlaBoundTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
+        final long low = 5;
+        final long high = 10;
         final LongIla ila = LongIlaFromArray.create(new long[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaBound.create(null, 5, 10));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaBound.create(ila, 10, 5));
+        assertThatThrownBy(() -> LongIlaBound.create(null, low, high))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> LongIlaBound.create(ila, high, low))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("minimum (=" + high + ") > maximum (=" + low + ") not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] array = new long[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaCheck.java
@@ -1,8 +1,7 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.Random;
@@ -16,21 +15,37 @@ public final class LongIlaCheck {
         final long ilaLength = ila.length();
         final long[] array = new long[10];
 
-        assertThrows(NullPointerException.class, () -> ila.get(null, 0, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, -1, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, -1, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length - 1, 0, 2));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength - 1, 2));
+        assertThatThrownBy(() -> ila.get(null, 0, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("array == null not allowed!");
+        assertThatThrownBy(() -> ila.get(array, -1, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, -1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=10) >= array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
     }
 
     public static void checkGetExhaustively(final LongIla ila1, final LongIla ila2) throws IOException {
         final int length1 = (int) Math.min(ila1.length(), Integer.MAX_VALUE);
         final int length2 = (int) Math.min(ila2.length(), Integer.MAX_VALUE);
 
-        assertEquals(length1, length2);
+        assertThat(length2).isEqualTo(length1);
 
         final long[] a1 = new long[length1];
         final long[] a2 = new long[length1];
@@ -41,7 +56,7 @@ public final class LongIlaCheck {
                     ila1.get(a1, o, s, l);
                     ila2.get(a2, o, s, l);
 
-                    assertArrayEquals(a1, a2);
+                    assertThat(a2).isEqualTo(a1);
                 }
             }
         }

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaDivideTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaDivideTest {
+final class LongIlaDivideTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final LongIla ila1 = LongIlaFromArray.create(new long[10]);
         final LongIla ila2 = LongIlaFromArray.create(new long[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaDivide.create(null, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaDivide.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaDivide.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaDivide.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> LongIlaDivide.create(null, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaDivide.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaDivide.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> LongIlaDivide.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] leftArray = new long[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastByteIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-class LongIlaFromCastByteIlaTest {
+final class LongIlaFromCastByteIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ByteIla ila = ByteIlaFromArray.create(new byte[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaFromCastByteIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaFromCastByteIla.create(ila, 0));
+        assertThatThrownBy(() -> LongIlaFromCastByteIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaFromCastByteIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] array = new byte[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastCharIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastCharIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-class LongIlaFromCastCharIlaTest {
+final class LongIlaFromCastCharIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final CharIla ila = CharIlaFromArray.create(new char[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaFromCastCharIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaFromCastCharIla.create(ila, 0));
+        assertThatThrownBy(() -> LongIlaFromCastCharIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaFromCastCharIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] array = new char[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastDoubleIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastDoubleIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-class LongIlaFromCastDoubleIlaTest {
+final class LongIlaFromCastDoubleIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final DoubleIla ila = DoubleIlaFromArray.create(new double[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaFromCastDoubleIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaFromCastDoubleIla.create(ila, 0));
+        assertThatThrownBy(() -> LongIlaFromCastDoubleIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaFromCastDoubleIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastFloatIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastFloatIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-class LongIlaFromCastFloatIlaTest {
+final class LongIlaFromCastFloatIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final FloatIla ila = FloatIlaFromArray.create(new float[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaFromCastFloatIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaFromCastFloatIla.create(ila, 0));
+        assertThatThrownBy(() -> LongIlaFromCastFloatIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaFromCastFloatIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java
@@ -14,14 +14,30 @@ public final class ObjectIlaCheck {
         final long ilaLength = ila.length();
         final Object[] array = new Object[10];
 
-        assertThatThrownBy(() -> ila.get(null, 0, 0, 1)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> ila.get(array, -1, 0, 1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, 0, -1, 1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, 0, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ila.get(null, 0, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("array == null not allowed!");
+        assertThatThrownBy(() -> ila.get(array, -1, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, -1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=10) >= array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
     }
 
     public static void checkGetExhaustively(ObjectIla<Object> ila1, ObjectIla<Object> ila2) throws IOException {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaAddTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaAddTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaAddTest {
+final class ShortIlaAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ShortIla ila1 = ShortIlaFromArray.create(new short[10]);
         final ShortIla ila2 = ShortIlaFromArray.create(new short[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaAdd.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaAdd.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaAdd.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaAdd.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> ShortIlaAdd.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaAdd.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaAdd.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> ShortIlaAdd.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] leftArray = new short[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaBoundTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaBoundTest.java
@@ -1,22 +1,28 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaBoundTest {
+final class ShortIlaBoundTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
+        final short low = (short) 5;
+        final short high = (short) 10;
         final ShortIla ila = ShortIlaFromArray.create(new short[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaBound.create(null, (short) 5, (short) 10));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaBound.create(ila, (short) 10, (short) 5));
+        assertThatThrownBy(() -> ShortIlaBound.create(null, low, high))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaBound.create(ila, high, low))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("minimum (=" + high + ") > maximum (=" + low + ") not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] array = new short[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaCheck.java
@@ -1,8 +1,7 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.Random;
@@ -16,21 +15,37 @@ public final class ShortIlaCheck {
         final long ilaLength = ila.length();
         final short[] array = new short[10];
 
-        assertThrows(NullPointerException.class, () -> ila.get(null, 0, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, -1, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, -1, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length - 1, 0, 2));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength - 1, 2));
+        assertThatThrownBy(() -> ila.get(null, 0, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("array == null not allowed!");
+        assertThatThrownBy(() -> ila.get(array, -1, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, -1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=10) >= array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
     }
 
     public static void checkGetExhaustively(final ShortIla ila1, final ShortIla ila2) throws IOException {
         final int length1 = (int) Math.min(ila1.length(), Integer.MAX_VALUE);
         final int length2 = (int) Math.min(ila2.length(), Integer.MAX_VALUE);
 
-        assertEquals(length1, length2);
+        assertThat(length2).isEqualTo(length1);
 
         final short[] a1 = new short[length1];
         final short[] a2 = new short[length1];
@@ -41,7 +56,7 @@ public final class ShortIlaCheck {
                     ila1.get(a1, o, s, l);
                     ila2.get(a2, o, s, l);
 
-                    assertArrayEquals(a1, a2);
+                    assertThat(a2).isEqualTo(a1);
                 }
             }
         }

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaDivideTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaDivideTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaDivideTest {
+final class ShortIlaDivideTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ShortIla ila1 = ShortIlaFromArray.create(new short[10]);
         final ShortIla ila2 = ShortIlaFromArray.create(new short[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaDivide.create(null, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaDivide.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaDivide.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaDivide.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> ShortIlaDivide.create(null, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaDivide.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaDivide.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> ShortIlaDivide.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] leftArray = new short[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastByteIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-class ShortIlaFromCastByteIlaTest {
+final class ShortIlaFromCastByteIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ByteIla ila = ByteIlaFromArray.create(new byte[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaFromCastByteIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaFromCastByteIla.create(ila, 0));
+        assertThatThrownBy(() -> ShortIlaFromCastByteIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaFromCastByteIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] array = new byte[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastCharIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastCharIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-class ShortIlaFromCastCharIlaTest {
+final class ShortIlaFromCastCharIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final CharIla ila = CharIlaFromArray.create(new char[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaFromCastCharIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaFromCastCharIla.create(ila, 0));
+        assertThatThrownBy(() -> ShortIlaFromCastCharIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaFromCastCharIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] array = new char[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastDoubleIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastDoubleIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-class ShortIlaFromCastDoubleIlaTest {
+final class ShortIlaFromCastDoubleIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final DoubleIla ila = DoubleIlaFromArray.create(new double[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaFromCastDoubleIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaFromCastDoubleIla.create(ila, 0));
+        assertThatThrownBy(() -> ShortIlaFromCastDoubleIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaFromCastDoubleIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastFloatIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastFloatIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-class ShortIlaFromCastFloatIlaTest {
+final class ShortIlaFromCastFloatIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final FloatIla ila = FloatIlaFromArray.create(new float[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaFromCastFloatIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaFromCastFloatIla.create(ila, 0));
+        assertThatThrownBy(() -> ShortIlaFromCastFloatIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaFromCastFloatIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/template/tfw/immutable/ila/__IlaAddTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaAddTest.template
@@ -1,25 +1,33 @@
 // byteila,charila,doubleila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaAddTest {
+final class %%NAME%%IlaAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final %%NAME%%Ila ila1 = %%NAME%%IlaFromArray.create(new %%TYPE%%[10]);
         final %%NAME%%Ila ila2 = %%NAME%%IlaFromArray.create(new %%TYPE%%[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaAdd.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaAdd.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaAdd.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaAdd.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> %%NAME%%IlaAdd.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaAdd.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaAdd.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaAdd.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%%[] leftArray = new %%TYPE%%[length];
         final %%TYPE%%[] rightArray = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaBoundTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaBoundTest.template
@@ -1,22 +1,28 @@
 // byteila,charila,doubleila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaBoundTest {
+final class %%NAME%%IlaBoundTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
+        final %%TYPE%% low = %%CAST_FROM_INT%%5;
+        final %%TYPE%% high = %%CAST_FROM_INT%%10;
         final %%NAME%%Ila ila = %%NAME%%IlaFromArray.create(new %%TYPE%%[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaBound.create(null, %%CAST_FROM_INT%%5, %%CAST_FROM_INT%%10));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaBound.create(ila, %%CAST_FROM_INT%%10, %%CAST_FROM_INT%%5));
+        assertThatThrownBy(() -> %%NAME%%IlaBound.create(null, low, high))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaBound.create(ila, high, low))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("minimum (=" + %%CHAR_CAST_TO_INT%%high + ") > maximum (=" + %%CHAR_CAST_TO_INT%%low + ") not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%%[] array = new %%TYPE%%[length];
         final %%TYPE%%[] target = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaCheck..NonNumeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaCheck..NonNumeric.template
@@ -14,14 +14,30 @@ import java.io.IOException;
         final long ilaLength = ila.length();
         final %%TYPE%%[] array = new %%TYPE%%[10];
 
-        assertThatThrownBy(() -> ila.get(null, 0, 0, 1)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> ila.get(array, -1, 0, 1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, 0, -1, 1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, 0, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ila.get(null, 0, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("array == null not allowed!");
+        assertThatThrownBy(() -> ila.get(array, -1, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, -1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=10) >= array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
     }
 
     public static void checkGetExhaustively(%%NAME%%Ila%%TEMPLATE%% ila1, %%NAME%%Ila%%TEMPLATE%% ila2) throws IOException {

--- a/src/test/template/tfw/immutable/ila/__IlaCheck..Numeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaCheck..Numeric.template
@@ -1,9 +1,8 @@
 // byteila,charila,doubleila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 %%RANDOM_INCLUDE%%
@@ -16,21 +15,37 @@ public final class %%NAME%%IlaCheck {
         final long ilaLength = ila.length();
         final %%TYPE%%[] array = new %%TYPE%%[10];
 
-        assertThrows(NullPointerException.class, () -> ila.get(null, 0, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, -1, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, -1, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length, 0, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength, 1));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, array.length - 1, 0, 2));
-        assertThrows(IllegalArgumentException.class, () -> ila.get(array, 0, ilaLength - 1, 2));
+        assertThatThrownBy(() -> ila.get(null, 0, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("array == null not allowed!");
+        assertThatThrownBy(() -> ila.get(array, -1, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, -1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, 0, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset (=10) >= array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+        assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
+        assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
     }
 
     public static void checkGetExhaustively(final %%NAME%%Ila ila1, final %%NAME%%Ila ila2) throws IOException {
         final int length1 = (int) Math.min(ila1.length(), Integer.MAX_VALUE);
         final int length2 = (int) Math.min(ila2.length(), Integer.MAX_VALUE);
 
-        assertEquals(length1, length2);
+        assertThat(length2).isEqualTo(length1);
 
         final %%TYPE%%[] a1 = new %%TYPE%%[length1];
         final %%TYPE%%[] a2 = new %%TYPE%%[length1];
@@ -41,7 +56,7 @@ public final class %%NAME%%IlaCheck {
                     ila1.get(a1, o, s, l);
                     ila2.get(a2, o, s, l);
 
-                    assertArrayEquals(a1, a2);
+                    assertThat(a2).isEqualTo(a1);
                 }
             }
         }

--- a/src/test/template/tfw/immutable/ila/__IlaDivideTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaDivideTest.template
@@ -1,25 +1,33 @@
 // byteila,charila,doubleila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaDivideTest {
+final class %%NAME%%IlaDivideTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final %%NAME%%Ila ila1 = %%NAME%%IlaFromArray.create(new %%TYPE%%[10]);
         final %%NAME%%Ila ila2 = %%NAME%%IlaFromArray.create(new %%TYPE%%[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaDivide.create(null, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaDivide.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaDivide.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaDivide.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> %%NAME%%IlaDivide.create(null, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaDivide.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaDivide.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaDivide.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%%[] leftArray = new %%TYPE%%[length];
         final %%TYPE%%[] rightArray = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastByteIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastByteIlaTest.template
@@ -1,24 +1,28 @@
 // charila,doubleila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-class %%NAME%%IlaFromCastByteIlaTest {
+final class %%NAME%%IlaFromCastByteIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ByteIla ila = ByteIlaFromArray.create(new byte[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastByteIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastByteIla.create(ila, 0));
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastByteIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastByteIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] array = new byte[length];
         final %%TYPE%%[] target = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastCharIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastCharIlaTest.template
@@ -1,24 +1,28 @@
 // byteila,doubleila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.charila.CharIla;
 import tfw.immutable.ila.charila.CharIlaFromArray;
 
-class %%NAME%%IlaFromCastCharIlaTest {
+final class %%NAME%%IlaFromCastCharIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final CharIla ila = CharIlaFromArray.create(new char[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastCharIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastCharIla.create(ila, 0));
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastCharIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastCharIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final char[] array = new char[length];
         final %%TYPE%%[] target = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastDoubleIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastDoubleIlaTest.template
@@ -1,24 +1,28 @@
 // byteila,charila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.doubleila.DoubleIla;
 import tfw.immutable.ila.doubleila.DoubleIlaFromArray;
 
-class %%NAME%%IlaFromCastDoubleIlaTest {
+final class %%NAME%%IlaFromCastDoubleIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final DoubleIla ila = DoubleIlaFromArray.create(new double[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastDoubleIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastDoubleIla.create(ila, 0));
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastDoubleIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastDoubleIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];
         final %%TYPE%%[] target = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastFloatIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastFloatIlaTest.template
@@ -1,24 +1,28 @@
 // byteila,charila,doubleila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.floatila.FloatIla;
 import tfw.immutable.ila.floatila.FloatIlaFromArray;
 
-class %%NAME%%IlaFromCastFloatIlaTest {
+final class %%NAME%%IlaFromCastFloatIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final FloatIla ila = FloatIlaFromArray.create(new float[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastFloatIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastFloatIla.create(ila, 0));
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastFloatIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastFloatIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];
         final %%TYPE%%[] target = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/booleanila.mapping
+++ b/src/test/template/tfw/immutable/ila/booleanila.mapping
@@ -18,3 +18,4 @@
 %%SUPPRESS%% =
 %%FULL_CAST%% = (BooleanIla[])\ 
 %%DIAMOND%% =
+%%CHAR_CAST_TO_INT%% =

--- a/src/test/template/tfw/immutable/ila/byteila.mapping
+++ b/src/test/template/tfw/immutable/ila/byteila.mapping
@@ -17,3 +17,4 @@
 %%SUPPRESS%% =
 %%FULL_CAST%% = (ByteIla[])\ 
 %%DIAMOND%% =
+%%CHAR_CAST_TO_INT%% =

--- a/src/test/template/tfw/immutable/ila/charila.mapping
+++ b/src/test/template/tfw/immutable/ila/charila.mapping
@@ -17,3 +17,4 @@
 %%SUPPRESS%% =
 %%FULL_CAST%% = (CharIla[])\ 
 %%DIAMOND%% =
+%%CHAR_CAST_TO_INT%% = (int)\ 

--- a/src/test/template/tfw/immutable/ila/doubleila.mapping
+++ b/src/test/template/tfw/immutable/ila/doubleila.mapping
@@ -17,3 +17,4 @@
 %%SUPPRESS%% =
 %%FULL_CAST%% = (DoubleIla[])\ 
 %%DIAMOND%% =
+%%CHAR_CAST_TO_INT%% =

--- a/src/test/template/tfw/immutable/ila/floatila.mapping
+++ b/src/test/template/tfw/immutable/ila/floatila.mapping
@@ -17,3 +17,4 @@
 %%SUPPRESS%% =
 %%FULL_CAST%% = (FloatIla[])\ 
 %%DIAMOND%% =
+%%CHAR_CAST_TO_INT%% =

--- a/src/test/template/tfw/immutable/ila/intila.mapping
+++ b/src/test/template/tfw/immutable/ila/intila.mapping
@@ -17,3 +17,4 @@
 %%SUPPRESS%% =
 %%FULL_CAST%% = (IntIla[])\ 
 %%DIAMOND%% =
+%%CHAR_CAST_TO_INT%% =

--- a/src/test/template/tfw/immutable/ila/longila.mapping
+++ b/src/test/template/tfw/immutable/ila/longila.mapping
@@ -17,3 +17,4 @@
 %%SUPPRESS%% =
 %%FULL_CAST%% = (LongIla[])\ 
 %%DIAMOND%% =
+%%CHAR_CAST_TO_INT%% =

--- a/src/test/template/tfw/immutable/ila/objectila.mapping
+++ b/src/test/template/tfw/immutable/ila/objectila.mapping
@@ -18,3 +18,4 @@
 %%SUPPRESS%% = \n\ \ \ \ @SuppressWarnings("unchecked")
 %%FULL_CAST%% = (ObjectIla<Object>[])\ 
 %%DIAMOND%% = <>
+%%CHAR_CAST_TO_INT%% =

--- a/src/test/template/tfw/immutable/ila/shortila.mapping
+++ b/src/test/template/tfw/immutable/ila/shortila.mapping
@@ -17,3 +17,4 @@
 %%SUPPRESS%% =
 %%FULL_CAST%% = (ShortIla[])\ 
 %%DIAMOND%% =
+%%CHAR_CAST_TO_INT%% =


### PR DESCRIPTION
This is the third part of updating the "ila" package tests to use AssertJ.

## Summary by Sourcery

Tests:
- Migrated tests for `ila` implementations to use AssertJ instead of JUnit assertions.