### PR TITLE
Update ila tests to use AssertJ.

### DIFF
--- a/deleteme.txt
+++ b/deleteme.txt
@@ -1,0 +1,4606 @@
+[[1;34mINFO[m] Scanning for projects...
+[[1;34mINFO[m] Inspecting build with total of 1 modules...
+[[1;34mINFO[m] Installing Nexus Staging features:
+[[1;34mINFO[m]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m-----------------------< [0;36mio.github.tfw-org:tfw[0;1m >------------------------[m
+[[1;34mINFO[m] [1mBuilding tfw 2024.5-SNAPSHOT[m
+[[1;34mINFO[m] [1m--------------------------------[ jar ]---------------------------------[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-clean-plugin:2.5:clean[m [1m(default-clean)[m @ [36mtfw[0;1m ---[m
+[[1;34mINFO[m] Deleting /home/pi/git/tfw/target
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-resources-plugin:2.6:resources[m [1m(default-resources)[m @ [36mtfw[0;1m ---[m
+[[1;34mINFO[m] Using 'UTF-8' encoding to copy filtered resources.
+[[1;34mINFO[m] skip non existing resourceDirectory /home/pi/git/tfw/src/main/resources
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-compiler-plugin:3.13.0:compile[m [1m(default-compile)[m @ [36mtfw[0;1m ---[m
+[[1;34mINFO[m] Recompiling the module because of [1mchanged source code[m.
+[[1;34mINFO[m] Compiling 767 source files with javac [debug release 8] to target/classes
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/demo/IntegerStringConverter.java:[18,19] found raw type: tfw.value.ValueConstraint
+  missing type arguments for generic class tfw.value.ValueConstraint<T>
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/objectila/ObjectIlaInterleave.java:[31,37] found raw type: tfw.immutable.ila.objectila.StridedObjectIla
+  missing type arguments for generic class tfw.immutable.ila.objectila.StridedObjectIla<T>
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/objectila/ObjectIlaInterleave.java:[31,33] unchecked conversion
+  required: tfw.immutable.ila.objectila.StridedObjectIla<T>[]
+  found:    tfw.immutable.ila.objectila.StridedObjectIla[]
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ilm/objectilm/ObjectIlmUtil.java:[25,36] redundant cast to int
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/ObjectIlaMultiplexerStrategy.java:[30,40] found raw type: tfw.immutable.ila.objectila.ObjectIla
+  missing type arguments for generic class tfw.immutable.ila.objectila.ObjectIla<T>
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/ObjectIlaMultiplexerStrategy.java:[34,24] unchecked call to get(T[],int,long,int) as a member of the raw type tfw.immutable.ila.objectila.ObjectIla
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/ObjectIlaMultiplexerStrategy.java:[62,17] found raw type: tfw.immutable.ila.objectila.ObjectIla
+  missing type arguments for generic class tfw.immutable.ila.objectila.ObjectIla<T>
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/ObjectIlaMultiplexerStrategy.java:[65,30] unchecked call to get(T[],int,long,int) as a member of the raw type tfw.immutable.ila.objectila.ObjectIla
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/audio/au/Au.java:[203,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(encoding == ISDN_U_LAW_8_BIT || encoding == LINEAR_8_BIT || encoding == LINEAR_16_BIT || encoding == LINEAR_24_BIT || encoding == LINEAR_32_BIT || encoding == IEEE_FLOATING_POINT_32_BIT || encoding == IEEE_FLOATING_POINT_64_BIT || encoding == CCITT_G_721_4_BIT_ADPCM || encoding == CCITT_G_722_ADPCM || encoding == CCITT_G_723_3_BIT_ADPCM || encoding == CCITT_G_723_5_BIT_ADPCM || encoding == ISDN_A_LAW_8_BIT, "Unknown encoding type: " + encoding);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/audio/au/Au.java:[224,21] [IntLongMath] Expression of type int may overflow before being assigned to a long
+    (see https://errorprone.info/bugpattern/IntLongMath)
+  Did you mean 'return ((bytes[offset] & 0xFF) << 24L)'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/audio/au/Au.java:[224,23] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
+    (see https://errorprone.info/bugpattern/UnnecessaryParentheses)
+  Did you mean '|  (bytes[offset + 3] & 0xFF);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/audio/au/Au.java:[229,21] [IntLongMath] Expression of type int may overflow before being assigned to a long
+    (see https://errorprone.info/bugpattern/IntLongMath)
+  Did you mean 'return ((bytes[offset + 3] & 0xFF) << 24L)'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/audio/au/Au.java:[229,23] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
+    (see https://errorprone.info/bugpattern/UnnecessaryParentheses)
+  Did you mean '|  (bytes[offset] & 0xFF);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/audio/byteila/ALawByteIlaFromLinearShortIla.java:[70,34] [ComparisonOutOfRange] shorts may have a value in the range -32768 to 32767; therefore, this comparison to 0x7FFF will always evaluate to true
+    (see https://errorprone.info/bugpattern/ComparisonOutOfRange)
+  Did you mean 'else if (true) seg = 7;'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/audio/demo/AuDemo.java:[28,46] [DefaultCharset] Implicit use of the platform default charset, which can result in differing behaviour between JVM executions or incorrect behavior if the encoding of the data source doesn't match expectations.
+    (see https://errorprone.info/bugpattern/DefaultCharset)
+  Did you mean 'System.out.println("annotation = " + new String(ByteIlaUtil.toArray(auFileFormat.annotation), UTF_8));' or 'System.out.println("annotation = " + new String(ByteIlaUtil.toArray(auFileFormat.annotation), Charset.defaultCharset()));'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/audio/wave/Wave.java:[30,15] [EmptyCatch] Caught exceptions should not be ignored
+    (see https://google.github.io/styleguide/javaguide.html#s6.2-caught-exceptions)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/audio/wave/Wave.java:[38,15] [EmptyCatch] Caught exceptions should not be ignored
+    (see https://google.github.io/styleguide/javaguide.html#s6.2-caught-exceptions)
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BaseCommit.java:[85,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(sink != null, sinkEventChannel + " not found");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/EventHandler.java:[146,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(sink != null, "The component, '" + this.getName() + "', does not subscribe to the requested event channel, '" + sinkEventChannel.getEventChannelName() + "'.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/EventHandler.java:[214,13] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(sources[i] != null, "eventChannelState[" + i + "].getECD().getEventChannelName() == " + ecName + " is not a known event channel");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/EventHandler.java:[152,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(sink.eventChannel != null, "The requested sink, '" + sinkEventChannel.getEventChannelName() + "', is not connected to an event channel");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/EventHandler.java:[193,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(source != null, "initiateECD.getEventChannelName() == " + initiateECD.getEventChannelName() + " is not a known event channel.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/EventHandler.java:[38,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(portCount != 0, "(nonTriggeringSinks.length + nonTriggeringSinks.length"'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/EventHandler.java:[99,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(!(ecd instanceof StatelessTriggerECD), "The event channel '" + ecd.getEventChannelName() + "' is stateless, no state available.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/EventHandler.java:[126,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(sink.eventChannel != null, sinkEventChannel + " is not connected to an event channel");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/EventHandler.java:[122,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(sink != null, sinkEventChannel.getEventChannelName() + " not found");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/EventHandler.java:[225,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(isRooted(), "This component is not connected to a root");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/EventHandler.java:[71,25] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (!list.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[160,17] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(map.put(eventChannels[i].getECD().getEventChannelName(), eventChannels[i]) == null, "Multiple event channels detected with name '" + eventChannels[i].getECD() + "'");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[368,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(isRooted(), "'"'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[102,17] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(map.put(sinks[i].ecd, sinks[i]) == null, "Multiple sinks detected for event channel '" + sinks[i].ecd.getEventChannelName() + "'");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[130,17] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(!list.contains(sources[i]), "Multiple sources detected for event channel '" + sources[i].ecd.getEventChannelName() + "'");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[280,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(sinks.containsKey(eventChannelName), eventChannelName + " is invalid sink in Leaf[" + getName() + "]");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[329,13] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(sink.eventChannel != null, eventChannelArray[i] + " is not connected to an event channel");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[400,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(parent != null, "Event channels left unterminated:\n" + connections);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[390,32] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (connections.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[396,32] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (connections.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[18,24] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'unmodifiableMap(new HashMap<EventChannelDescription, Sink>(0));'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[20,24] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'unmodifiableList(new ArrayList<EventChannelDescription>(0));'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[21,70] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'private static final List<Source> EMPTY_SOURCE_LIST = unmodifiableList(new ArrayList<Source>(0));'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[23,24] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'unmodifiableMap(new HashMap<String, EventChannel>(0));'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[72,39] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'sinksECDList = unmodifiableList(arrayList);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[108,31] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'return unmodifiableMap(map);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[138,31] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'return unmodifiableList(list);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeComponent.java:[166,30] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'map = unmodifiableMap(map);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/ecd/EventChannelDescription.java:[57,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(this.eventChannelName.length() != 0, "eventChannelName.trim().length() == 0 not allowed!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Initiator.java:[95,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(sources.length != 0, "sources.length == 0 not allowed");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Initiator.java:[229,13] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(source != null, eventChannel + " not found");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Initiator.java:[197,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(source != null, sourceEventChannel + " not found");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Port.java:[85,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(this.component != null, "Port '" + name + "' for event channel '" + ecd.getEventChannelName() + "' has not been connected to a component");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Port.java:[72,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(this.component == null, "Illegal attempt to re-assign component");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/InitiatorSource.java:[49,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(this.getTreeComponent().isRooted(), "Attempt to set state on disconnected event channel (" + eventChannel.getECD() + ").");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/ValueException.java:[6,1] [MissingSummary] A summary line is required on public/protected Javadocs.
+    (see https://google.github.io/styleguide/javaguide.html#s7.2-summary-fragment)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/EventChannel.java:[63,8] [MissingSummary] A summary fragment is required; consider using the value of the @return block as a summary fragment instead.
+    (see https://google.github.io/styleguide/javaguide.html#s7.2-summary-fragment)
+  Did you mean '*Returns true if new state has been published during the current'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/ProcessorSource.java:[33,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(eventChannel != null, "Attempt to set state using disconnected source");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/ValueConstraint.java:[6,1] [MissingSummary] A summary line is required on public/protected Javadocs.
+    (see https://google.github.io/styleguide/javaguide.html#s7.2-summary-fragment)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/ValueConstraint.java:[22,29] [ReferenceEquality] Comparison using reference equality instead of value equality
+    (see https://errorprone.info/bugpattern/ReferenceEquality)
+  Did you mean 'if (!VALID.equals(valueCompliance)) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[394,25] [UnusedMethod] Method 'checkDependencies' is never used.
+    (see https://errorprone.info/bugpattern/UnusedMethod)
+  Did you mean to remove this line?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[656,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(stateChanges.add(source), source.getTreeComponent().getName() + " attempted to change the state of '" + source.ecd.getEventChannelName() + "' twice in the same state change cycle.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[682,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(executingStateChanges, "Processors can only be active during state change cycles.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[699,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(executingStateChanges, "Validators can only be active during state change cycles.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[768,44] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (endOfCycleRunnables.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[468,38] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (cycleStateChanges.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[496,38] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (transStateChanges.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[521,38] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (eventChannelFires.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[221,71] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean '} while (stateChanges.size() != 0 || !eventChannelFires.isEmpty() || processors.size() != 0);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[362,38] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (!delayedProcessors.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[287,33] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (stateChanges.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[221,38] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean '} while (!stateChanges.isEmpty() || eventChannelFires.size() != 0 || processors.size() != 0);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[345,31] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (processors.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[221,97] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean '} while (stateChanges.size() != 0 || eventChannelFires.size() != 0 || !processors.isEmpty());'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[24,35] [InvalidInlineTag] Curly braces should be used for inline Javadoc tags: {@link ...}
+    (see https://errorprone.info/bugpattern/InvalidInlineTag)
+  Did you mean '* <LI>State Change - any call to {@link #addStateChange(InitiatorSource[], Object[])}'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[27,4] [InvalidInlineTag] Curly braces should be used for inline Javadoc tags: {@link ...}
+    (see https://errorprone.info/bugpattern/InvalidInlineTag)
+  Did you mean '* {@link #addComponent(AddComponentRunnable, Throwable)} and'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[28,4] [InvalidInlineTag] Curly braces should be used for inline Javadoc tags: {@link ...}
+    (see https://errorprone.info/bugpattern/InvalidInlineTag)
+  Did you mean '* {@link #removeComponent(RemoveComponentRunnable, Throwable)} may or may not be'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[30,4] [InvalidInlineTag] Curly braces should be used for inline Javadoc tags: {@link ...}
+    (see https://errorprone.info/bugpattern/InvalidInlineTag)
+  Did you mean '* {@link #addStateChange(InitiatorSource[], Object[])} will cause the coalescing of'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[85,33] [ConstantNaming] Constant variables should adhere to the `UPPER_SNAKE_CASE` naming convention
+    (see https://error-prone.picnic.tech/bugpatterns/ConstantNaming)
+  Did you mean 'LOGGER.log(Level.INFO, "Unexpected Exception!", exception);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[236,19] [EmptyCatch] Caught exceptions should not be ignored
+    (see https://google.github.io/styleguide/javaguide.html#s6.2-caught-exceptions)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[604,52] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
+    (see https://errorprone.info/bugpattern/UnnecessaryParentheses)
+  Did you mean 'logger.log(Level.INFO, "  C" +  c++ + " : " + commitRollbackListeners[i].getName());'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TransactionMgr.java:[671,83] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'transactionState.getTransactionIdFuture().setResultAndRelease(id);' or '@SuppressWarnings("IdentityConversion") void addStateChange('?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[544,77] [UnusedVariable] The parameter 'parent' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean 'removeChildAndDescendents(rcr.child);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[446,33] [UnusedVariable] The parameter 'parent' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean 'addChildAndDescendents(acr.child, allDeferredAddRemoveSets);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[55,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(child.getParent() == this, "child, " + child.getName() + ", not connected to this component, '" + this.getFullyQualifiedName() + "'");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[236,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(this.getName().equals(state.getName()), "TreeState name does not match, expected <" + this.getName() + "> found <" + state.getName() + ">.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[300,17] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(immediateChildren.add(child), child.getFullyQualifiedName() + " is already a child of this Branch");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[312,17] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(immediateChildren != null && immediateChildren.remove(child), child.getFullyQualifiedName() + " is not a child of this Branch!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[556,13] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(child.immediateRoot == immediateRoot, child.getFullyQualifiedName() + " has " + child.immediateRoot + " Root!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[507,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(immediateChildren != null && immediateChildren.remove(child), child.getFullyQualifiedName() + " is not a child of this Branch!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[227,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(isRooted(), "This component (" + getName() + ") is not rooted and therefore it's state is undefined.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[163,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(getTransactionManager().isDispatchThread(), "This method can not be called from outside the transaction queue thread");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[232,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(getTransactionManager().isDispatchThread(), "This method can not be called from outside the transaction queue thread");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[47,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(!children.containsKey(child.getName()), "Attempt to add child with duplicate name, '" + child.getName() + "'");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[399,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(immediateChildren.add(child), child.getFullyQualifiedName() + " is already a child of this Branch");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[448,13] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(child.immediateRoot == null, child.getFullyQualifiedName() + " already has a Root!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[40,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(!child.isRooted(), "Child, '" + child.getName() + "' is rooted. Can't add a rooted tree!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[32,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(child.getParent() == null, "Child, '" + child.getName() + "', already has a parent.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[159,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(isRooted(), "This component is not rooted and therefore it's state is undefined.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[36,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(child != this, "child == this not allowed");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[510,38] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (immediateChildren.isEmpty()) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[74,22] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
+    (see https://errorprone.info/bugpattern/SynchronizeOnNonFinalField)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[106,22] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
+    (see https://errorprone.info/bugpattern/SynchronizeOnNonFinalField)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[332,26] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
+    (see https://errorprone.info/bugpattern/SynchronizeOnNonFinalField)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[414,26] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
+    (see https://errorprone.info/bugpattern/SynchronizeOnNonFinalField)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchComponent.java:[527,26] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
+    (see https://errorprone.info/bugpattern/SynchronizeOnNonFinalField)
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Processor.java:[69,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument((sourceEventChannel instanceof StatelessTriggerECD) || state != null, "Cannot set null on event channel " + sourceEventChannel.getEventChannelName());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Processor.java:[65,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(source != null, "Source event channel '" + sourceEventChannel + "' not found in " + getFullyQualifiedName());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Processor.java:[44,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(sink.eventChannel != null, sinkEventChannel + " is not connected to an event channel");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Processor.java:[40,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(sink != null, sinkEventChannel.getEventChannelName() + " not found");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/RollbackHandler.java:[33,26] [DoNotCallSuggester] Methods that always throw an exception should be annotated with @DoNotCall to prevent calls at compilation time vs. at runtime (note that adding @DoNotCall will break any existing callers of this API).
+    (see https://errorprone.info/bugpattern/DoNotCallSuggester)
+  Did you mean '@DoNotCall("Always throws tfw.tsm.RollbackException") protected final void rollback() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Validator.java:[92,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(sink.eventChannel != null, sinkEventChannel + " is not connected to an event channel");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Validator.java:[88,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(sink != null, sinkEventChannel.getEventChannelName() + " not found");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/DemultiplexedEventChannel.java:[106,21] [UnusedVariable] The field 'fireCount' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/DemultiplexedEventChannel.java:[96,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(state != null, "Demultiplexing error, attempt to set state to null in sub-channel '" + this.demultiplexSlotId + "' of multiplexed channel '" + parent.multiSink.ecd.getEventChannelName() + "'");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/DemultiplexedEventChannel.java:[64,17] [UnsynchronizedOverridesSynchronized] Unsynchronized method add overrides synchronized method in Terminator
+    (see https://errorprone.info/bugpattern/UnsynchronizedOverridesSynchronized)
+  Did you mean 'public synchronized void add(Port port) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/DemultiplexedEventChannel.java:[74,17] [UnsynchronizedOverridesSynchronized] Unsynchronized method remove overrides synchronized method in Terminator
+    (see https://errorprone.info/bugpattern/UnsynchronizedOverridesSynchronized)
+  Did you mean 'public synchronized void remove(Port port) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/DemultiplexedEventChannel.java:[114,20] [DirectReturn] Variable assignment is redundant; value can be returned directly
+    (see https://error-prone.picnic.tech/bugpatterns/DirectReturn)
+  Did you mean 'return super.getState();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Terminator.java:[133,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(this.component == null, "Terminator is already initialized!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Terminator.java:[235,43] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (uninitializedSinks.isEmpty()) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Terminator.java:[295,21] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
+    (see https://errorprone.info/bugpattern/UnnecessaryParentheses)
+  Did you mean '&& ! differentSlotChange(source, stateSource)) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Multiplexer.java:[209,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(slotId != null, "The specified port, '"'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Multiplexer.java:[188,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(demultiplexedEventChannels.remove(deMultiplexer.demultiplexSlotId) != null, "Demultiplexer not found attempting to remove demultiplexer for " + valueECD.getEventChannelName() + "[" + deMultiplexer.demultiplexSlotId + "]");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Multiplexer.java:[109,13] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(pendingStateChanges.size() != 0, "No pending state changes to fire.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Multiplexer.java:[145,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(slotId != null, "slotId == null not allowed");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/MultiplexedBranch.java:[90,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(slotId != null, "Attempt to remove '" + child.getName() + "(" + child + ")' for which no slot identifier exists");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/MultiplexedBranch.java:[96,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(subBranch != null, "Attempt to remove '" + child.getName() + "(" + child + ")' for which no sub-branch exists");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/MultiplexedBranch.java:[104,87] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (subBranch.immediateChildren == null || subBranch.immediateChildren.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[92,54] [Refaster Rule] FileRules.PathOfString: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/FileRules#PathOfString)
+  Did you mean 'final Path outputPath = Path.of(p.getParent().toString().replace("template", "java"), mappings[i], p.getName(p.getNameCount() - 1)'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[72,50] [Refaster Rule] FileRules.FilesReadStringWithCharset: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/FileRules#FilesReadStringWithCharset)
+  Did you mean 'final String mappingString = Files.readString(mappingPath, StandardCharsets.UTF_8);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[105,33] [Refaster Rule] FileRules.FilesReadStringWithCharset: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/FileRules#FilesReadStringWithCharset)
+  Did you mean 'Files.readString(outputPath, StandardCharsets.UTF_8);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[68,55] [Refaster Rule] FileRules.PathOfString: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/FileRules#PathOfString)
+  Did you mean 'final Path mappingPath = Path.of(p.getParent().toString(), mappings[i] + ".mapping");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[45,47] [Refaster Rule] FileRules.FilesReadStringWithCharset: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/FileRules#FilesReadStringWithCharset)
+  Did you mean 'final String templateString = Files.readString(p, StandardCharsets.UTF_8);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[36,41] [Refaster Rule] FileRules.PathOfString: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/FileRules#PathOfString)
+  Did you mean 'Files.find(Path.of(args[a]), Integer.MAX_VALUE, (p, basicFileAttributes) -> p.getFileName()'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[17,33] [Slf4jLoggerShouldBeNonStatic] Do not use static Logger field, use non-static one instead
+    (see https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_non_static)
+  Did you mean 'private final Logger logger;'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[39,56] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'templateList = paths.collect(toList());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[45,97] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'final String templateString = new String(Files.readAllBytes(p), UTF_8);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[63,56] [StringSplitter] String.split(String) has surprising behavior
+    (see https://errorprone.info/bugpattern/StringSplitter)
+  Did you mean 'final List<String> mappings = Splitter.on(',').splitToList(mapping);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[72,110] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'final String mappingString = new String(Files.readAllBytes(mappingPath), UTF_8);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[105,92] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'new String(Files.readAllBytes(outputPath), UTF_8);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[110,87] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'Files.write(outputPath, template.getBytes(UTF_8));'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/build/SearchAndReplace.java:[115,83] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'Files.write(outputPath, template.getBytes(UTF_8));'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/check/Argument.java:[106,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(argument > constant, argumentName + " (=" + argument + ") <= " + constant + " not allowed!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/check/Argument.java:[124,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(argument >= constant, argumentName + " (=" + argument + ") < " + constant + " not allowed!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/check/Argument.java:[142,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(argument >= constant, argumentName + " (=" + argument + ") < " + constant + " not allowed!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/check/Argument.java:[225,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(clazz.isInstance(object), objectName + " is not an instance of " + clazz.getName());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/check/Argument.java:[87,13] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(argument[i] != null, argumentName + "[" + i + "]" + "== null not allowed!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/check/Argument.java:[65,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(argument.length() != 0, argumentName + ".length() == 0 not allowed!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/check/Argument.java:[43,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(argument.length != 0, argumentName + ".length == 0 not allowed!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/check/Argument.java:[22,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(argument != null, argumentName + " == null not allowed!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/component/EventChannelCopyConverter.java:[18,13] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(outputECDs[i].getConstraint().isCompatible(inputECDs[i].getConstraint()) != false, "outputECD.getConstraint().isCompatible(" + "inputECD.getConstraint()) == false not allowed");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/component/TriggeredEventChannelCopy.java:[35,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(outputECD.getConstraint().isCompatible(inputECD.getConstraint()) != false, "outputECD.getConstraint().isCompatible(inputECD.getConstraint()) == false not allowed");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TriggeredConverter.java:[28,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(triggerDescription != null, "triggerEventChannel == null not allowed");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/demo/ButtonEnableHandler.java:[35,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(eventChannels1.length == eventChannels2.length, "eventChannels1.length != eventChannels2.length not allowed");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/demo/ColorButtonNB.java:[118,30] [ConstantNaming] Constant variables should adhere to the `UPPER_SNAKE_CASE` naming convention; consider renaming to 'GRAYS', though note that this is not a private constant
+    (see https://error-prone.picnic.tech/bugpatterns/ConstantNaming)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Synchronizer.java:[191,18] [UnusedMethod] Method 'throwBothSetsChangedException' is never used.
+    (see https://errorprone.info/bugpattern/UnusedMethod)
+  Did you mean to remove this line?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Synchronizer.java:[180,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(aPortDescriptions.length != 0, "aPortDescriptions.length == 0 not allowed");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Synchronizer.java:[184,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(bPortDescriptions.length != 0, "bPortDescriptions.length == 0 not allowed");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Synchronizer.java:[71,38] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'this.aEventList = unmodifiableList(Arrays.asList(aPortInputDescriptions));'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Synchronizer.java:[72,38] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'this.bEventList = unmodifiableList(Arrays.asList(bPortInputDescriptions));'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Synchronizer.java:[74,30] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean '? unmodifiableList(new ArrayList<ObjectECD>())'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Synchronizer.java:[75,30] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean ': unmodifiableList(Arrays.asList(additionalInputDescriptions));'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/IntegerConstraint.java:[13,45] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'super(Integer.class, min, Integer.valueOf(max), true, true);' or '@SuppressWarnings("IdentityConversion") public IntegerConstraint(int min, int max) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/IntegerConstraint.java:[13,67] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'super(Integer.class, Integer.valueOf(min), max, true, true);' or '@SuppressWarnings("IdentityConversion") public IntegerConstraint(int min, int max) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/value/RangeConstraint.java:[37,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(!(compare == 0) || minInclusive || maxInclusive, "Empty range, min == max and neither are inclusive");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/value/RangeConstraint.java:[33,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(compare <= 0, "min > max not allowed!");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/ClassValueConstraint.java:[47,65] [ConstantNaming] Constant variables should adhere to the `UPPER_SNAKE_CASE` naming convention
+    (see https://error-prone.picnic.tech/bugpatterns/ConstantNaming)
+  Did you mean 'private static final Map<Class<?>, ClassValueConstraint<?>> CONSTRAINTS = getInitialConstraints();'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/demo/RedGreenBlueECD.java:[8,1] [MissingSummary] A summary line is required on public/protected Javadocs.
+    (see https://google.github.io/styleguide/javaguide.html#s7.2-summary-fragment)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/iis/bitiis/BitIisFromBitIla.java:[38,20] [UnnecessaryLongToIntConversion] Converting a long or Long to an int to pass as a long parameter is usually not necessary. If this conversion is intentional, consider `Longs.constrainToRange()` instead.
+    (see https://errorprone.info/bugpattern/UnnecessaryLongToIntConversion)
+  Did you mean 'ila.get(array, offsetInBits, index, elementsToGet);' or 'ila.get(array, Longs.constrainToRange(offsetInBits, Integer.MIN_VALUE, Integer.MAX_VALUE), index, elementsToGet);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/bitila/BitIlaFind.java:[45,21] [Refaster Rule] PreconditionsRules.CheckArgument: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgument)
+  Did you mean 'checkArgument(l >= 0);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/bitila/BitIlaReverse.java:[95,9] [DirectReturn] Variable assignment is redundant; value can be returned directly
+    (see https://error-prone.picnic.tech/bugpatterns/DirectReturn)
+  Did you mean 'return (reverseValue & REVERSE_MASK_1) << 1 | (reverseValue & NOT_REVERSE_MASK_1) >>> 1;'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromFile.java:[12,33] [Slf4jLoggerShouldBeNonStatic] Do not use static Logger field, use non-static one instead
+    (see https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_non_static)
+  Did you mean 'private final Logger logger = LoggerFactory.getLogger(ByteIlaFromFile.class);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromFile.java:[12,33] [Slf4jLoggerDeclaration] SLF4J logger declarations should follow established best-practices
+    (see https://error-prone.picnic.tech/bugpatterns/Slf4jLoggerDeclaration)
+  Did you mean 'private static final Logger LOG = LoggerFactory.getLogger(ByteIlaFromFile.class);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromFile.java:[62,40] [ThreadPriorityCheck] Relying on the thread scheduler is discouraged.
+    (see https://errorprone.info/bugpattern/ThreadPriorityCheck)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromFile.java:[98,19] [EmptyCatch] Caught exceptions should not be ignored
+    (see https://google.github.io/styleguide/javaguide.html#s6.2-caught-exceptions)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/demo/OctalDump.java:[120,24] [SameNameButDifferent] The name `ObjectIlaImpl` refers to [tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromByteIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromShortIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromIntIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromLongIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromFloatIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromDoubleIla.ObjectIlaImpl] within this file. It may be confusing to have the same name refer to multiple types. Consider qualifying them for clarity.
+    (see https://errorprone.info/bugpattern/SameNameButDifferent)
+  Did you mean 'return new StringObjectIlaFromByteIla.ObjectIlaImpl(byteIla, type, bufferSize);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/demo/OctalDump.java:[179,24] [SameNameButDifferent] The name `ObjectIlaImpl` refers to [tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromByteIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromShortIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromIntIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromLongIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromFloatIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromDoubleIla.ObjectIlaImpl] within this file. It may be confusing to have the same name refer to multiple types. Consider qualifying them for clarity.
+    (see https://errorprone.info/bugpattern/SameNameButDifferent)
+  Did you mean 'return new StringObjectIlaFromByteIla.ObjectIlaImpl(byteIla, type, bufferSize);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/demo/OctalDump.java:[239,24] [SameNameButDifferent] The name `ObjectIlaImpl` refers to [tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromByteIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromShortIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromIntIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromLongIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromFloatIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromDoubleIla.ObjectIlaImpl] within this file. It may be confusing to have the same name refer to multiple types. Consider qualifying them for clarity.
+    (see https://errorprone.info/bugpattern/SameNameButDifferent)
+  Did you mean 'return new StringObjectIlaFromByteIla.ObjectIlaImpl(byteIla, type, bufferSize);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/demo/OctalDump.java:[296,24] [SameNameButDifferent] The name `ObjectIlaImpl` refers to [tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromByteIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromShortIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromIntIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromLongIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromFloatIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromDoubleIla.ObjectIlaImpl] within this file. It may be confusing to have the same name refer to multiple types. Consider qualifying them for clarity.
+    (see https://errorprone.info/bugpattern/SameNameButDifferent)
+  Did you mean 'return new StringObjectIlaFromByteIla.ObjectIlaImpl(byteIla, type, bufferSize);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/demo/OctalDump.java:[353,24] [SameNameButDifferent] The name `ObjectIlaImpl` refers to [tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromByteIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromShortIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromIntIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromLongIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromFloatIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromDoubleIla.ObjectIlaImpl] within this file. It may be confusing to have the same name refer to multiple types. Consider qualifying them for clarity.
+    (see https://errorprone.info/bugpattern/SameNameButDifferent)
+  Did you mean 'return new StringObjectIlaFromByteIla.ObjectIlaImpl(byteIla, type, bufferSize);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/demo/OctalDump.java:[399,24] [SameNameButDifferent] The name `ObjectIlaImpl` refers to [tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromByteIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromShortIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromIntIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromLongIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromFloatIla.ObjectIlaImpl, tfw.immutable.ila.demo.OctalDump.StringObjectIlaFromDoubleIla.ObjectIlaImpl] within this file. It may be confusing to have the same name refer to multiple types. Consider qualifying them for clarity.
+    (see https://errorprone.info/bugpattern/SameNameButDifferent)
+  Did you mean 'return new StringObjectIlaFromByteIla.ObjectIlaImpl(byteIla, type, bufferSize);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/demo/OctalDump.java:[152,42] [RedundantStringConversion] Avoid redundant string conversions when possible
+    (see https://error-prone.picnic.tech/bugpatterns/RedundantStringConversion)
+  Did you mean 'sb.append(bii.next());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/demo/OctalDump.java:[212,42] [RedundantStringConversion] Avoid redundant string conversions when possible
+    (see https://error-prone.picnic.tech/bugpatterns/RedundantStringConversion)
+  Did you mean 'sb.append(sii.next());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/demo/OctalDump.java:[271,42] [RedundantStringConversion] Avoid redundant string conversions when possible
+    (see https://error-prone.picnic.tech/bugpatterns/RedundantStringConversion)
+  Did you mean 'sb.append(iii.next());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/demo/OctalDump.java:[328,42] [RedundantStringConversion] Avoid redundant string conversions when possible
+    (see https://error-prone.picnic.tech/bugpatterns/RedundantStringConversion)
+  Did you mean 'sb.append(lii.next());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/demo/OctalDump.java:[382,34] [RedundantStringConversion] Avoid redundant string conversions when possible
+    (see https://error-prone.picnic.tech/bugpatterns/RedundantStringConversion)
+  Did you mean 'sb.append(fii.next());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/demo/OctalDump.java:[428,34] [RedundantStringConversion] Avoid redundant string conversions when possible
+    (see https://error-prone.picnic.tech/bugpatterns/RedundantStringConversion)
+  Did you mean 'sb.append(dii.next());'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/objectila/ObjectIlaFiltered.java:[6,38] [UnusedTypeParameter] This type parameter is unused and can be removed.
+    (see https://errorprone.info/bugpattern/UnusedTypeParameter)
+  Did you mean 'public final class ObjectIlaFiltered {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/objectila/ObjectIlaFromStridedObjectIla.java:[6,50] [UnusedTypeParameter] This type parameter is unused and can be removed.
+    (see https://errorprone.info/bugpattern/UnusedTypeParameter)
+  Did you mean 'public final class ObjectIlaFromStridedObjectIla {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ila/objectila/StridedObjectIlaFromObjectIla.java:[6,50] [UnusedTypeParameter] This type parameter is unused and can be removed.
+    (see https://errorprone.info/bugpattern/UnusedTypeParameter)
+  Did you mean 'public final class StridedObjectIlaFromObjectIla {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ilm/AbstractIlmCheck.java:[25,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(rowStart + rowCount <= height, "rowStart + rowCount > height" + " (=" + (rowStart + rowCount > height)'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ilm/AbstractIlmCheck.java:[29,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(colStart + colCount <= width, "colStart + colCount > width" + " (=" + (colStart + colCount > width) + ") > width not allowed!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ilm/AbstractStridedIlmCheck.java:[35,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(offset + (rowCount - 1) * rowStride + (colCount - 1) * colStride + 1 <= arrayLength, "offset+(rowCount-1)*rowStride+(colCount-1)*colStride+1" + " (="'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ilm/AbstractStridedIlmCheck.java:[41,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(offset + (rowCount - 1) * rowStride + (colCount - 1) * colStride + 1 >= 0, "offset+(rowCount-1)*rowStride+(colCount-1)*colStride+1" + " (="'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ilm/AbstractStridedIlmCheck.java:[45,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(rowStart + rowCount <= height, "rowStart + rowCount > height" + " (=" + (rowStart + rowCount > height)'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ilm/AbstractStridedIlmCheck.java:[49,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(colStart + colCount <= width, "colStart + colCount > width" + " (=" + (colStart + colCount > width) + ") > width not allowed!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ilm/AbstractStridedIlmCheck.java:[56,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(!overlaps(rowCount, colCount, rowStride, colStride), "Overlaps failed!");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ilm/objectilm/ObjectIlmFromStridedObjectIlm.java:[6,50] [UnusedTypeParameter] This type parameter is unused and can be removed.
+    (see https://errorprone.info/bugpattern/UnusedTypeParameter)
+  Did you mean 'public final class ObjectIlmFromStridedObjectIlm {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/immutable/ilm/objectilm/StridedObjectIlmFromObjectIlm.java:[7,50] [UnusedTypeParameter] This type parameter is unused and can be removed.
+    (see https://errorprone.info/bugpattern/UnusedTypeParameter)
+  Did you mean 'public final class StridedObjectIlmFromObjectIlm {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/state/StateMachine.java:[84,13] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(i != transitions.size(), "No transitions for event!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/state/StateMachine.java:[54,13] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(!processingEvent, "Already processing event!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/state/StateMachine.java:[34,66] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'this.actions = (actions == null) ? null : unmodifiableList(new ArrayList<Action>(actions));'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/state/StateMachine.java:[48,39] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'this.transitions = unmodifiableList(new ArrayList<Transition>(transitions));'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/swing/combobox/SelectionAndListCommit.java:[53,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(selectedItemECD != null || selectedIndexECD != null, "(selectedItemECD == null) && (selectedIndexECD == null) not allowed");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/swing/combobox/SelectionAndListCommit.java:[112,11] [EmptyCatch] Caught exceptions should not be ignored
+    (see https://google.github.io/styleguide/javaguide.html#s6.2-caught-exceptions)
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/swing/combobox/SelectionInitiator.java:[35,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(!list.isEmpty(), "(selectedItemECD == null)&&(selectedIndexECD == null) not allowed");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/swing/demo/AdditionDemo.java:[176,28] [Refaster Rule] StringRules.StringIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/StringRules#StringIsEmpty)
+  Did you mean 'if (s.isEmpty()) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/swing/demo/ByteInterleavedImagePanelDemo.java:[112,25] [UnusedVariable] The local variable 'h' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or 'Integer.parseInt(hTF.getText());'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/swing/demo/ByteInterleavedImagePanelDemo.java:[111,25] [UnusedVariable] The local variable 'w' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or 'Integer.parseInt(wTF.getText());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BaseBranchFactory.java:[107,13] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument((rule instanceof AlwaysChangeRule), "(eventChannelDescription instanceof " + (eventChannelDescription instanceof StatelessTriggerECD'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BaseBranchFactory.java:[150,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(isTerminated(ecd), "The event channel '"'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BaseBranchFactory.java:[101,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(eventChannelDescription.isFireOnConnect() || initialState == null, "Non-null 'initialState' is not permitted given"'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BaseBranchFactory.java:[95,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(!isTerminated(eventChannelDescription), "The event channel '" + eventChannelDescription.getEventChannelName() + "' is already exists");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BasicTransactionQueue.java:[156,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(!isDispatchThread(), "This method can not be called from within the queue's thread");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BasicTransactionQueue.java:[98,26] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (queue.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BasicTransactionQueue.java:[178,38] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (queue.isEmpty()) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BasicTransactionQueue.java:[163,15] [EmptyCatch] Caught exceptions should not be ignored
+    (see https://google.github.io/styleguide/javaguide.html#s6.2-caught-exceptions)
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchFactory.java:[73,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(childEventChannel.getConstraint().isCompatible(parentEventChannel.getConstraint()), "Incompatible event channels, values from the parent event channel '" + parentEventChannel.getEventChannelName() + "' are not assignable to the child event channel '" + childEventChannel.getEventChannelName() + "'");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchFactory.java:[79,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(parentEventChannel.getConstraint().isCompatible(childEventChannel.getConstraint()), "Incompatible event channels values from the child event channel '" + childEventChannel.getEventChannelName() + "' are not assignable to the parent event channel '" + parentEventChannel.getEventChannelName() + "'");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchFactory.java:[120,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(eventChannelDescription == null || !isTranslated(eventChannelDescription), "Attemp to terminate an event channel, '" + eventChannelDescription.getEventChannelName() + "', which is already transalated.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchFactory.java:[61,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(!isTerminated(childEventChannel), "Attempt to translate the event channel '" + childEventChannel.getEventChannelName() + "' which is already terminated.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchFactory.java:[67,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(!isTranslated(childEventChannel), "Attempt to translate the event channel '" + childEventChannel.getEventChannelName() + "' which is already translated.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/BranchFactory.java:[152,16] [DirectReturn] Variable assignment is redundant; value can be returned directly
+    (see https://error-prone.picnic.tech/bugpatterns/DirectReturn)
+  Did you mean 'return new Branch(name, getSinks(), getSources(), getTerminators());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Translator.java:[47,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(cvc.isCompatible(pvc), "The parent value constraint is not compatable with the child value constraint");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/Translator.java:[52,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(pvc.isCompatible(cvc), "The child value constraint is not compatable with the parent value constraint");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/EventChannelProxy.java:[26,17] [RedundantStringConversion] Avoid redundant string conversions when possible
+    (see https://error-prone.picnic.tech/bugpatterns/RedundantStringConversion)
+  Did you mean '+ eventChannel.getState();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/CdlFuture.java:[32,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(!done, "Result has already been set!");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/CdlFuture.java:[10,17] [WaitNotInLoop] Because of spurious wakeups, wait() must always be called in a loop
+    (see https://errorprone.info/bugpattern/WaitNotInLoop)
+  Did you mean 'while (!done) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/CdlFuture.java:[19,17] [WaitNotInLoop] Because of spurious wakeups, wait(long) must always be called in a loop
+    (see https://errorprone.info/bugpattern/WaitNotInLoop)
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/DefaultStateQueueFactory.java:[29,33] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'return queue.isEmpty();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/MultiplexedBranchFactory.java:[73,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(multiValueECDMap.put(multiValueECD.getEventChannelName(), multiValueECD) == null, "Attempt to add multiple multiplexers for multi event channel '" + multiValueECD.getEventChannelName() + "'");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/MultiplexedBranchFactory.java:[78,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(valueECDMap.put(valueECD.getEventChannelName(), multiValueECD) == null, "Attempt to add multiple multiplexers for value event channel '" + valueECD.getEventChannelName() + "'");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/MultiplexedBranchFactory.java:[69,9] [Refaster Rule] PreconditionsRules.CheckArgumentWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckArgumentWithMessage)
+  Did you mean 'checkArgument(!valueECD.getEventChannelName().equals(multiValueECD.getEventChannelName()), "valueECD.getEventChannelName().equals(multiValueECD.getEventChannelName()) not allowed");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TreeStateBuffer.java:[53,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(name != null, "The 'setName(String)' method must be called before this method.");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TsmFuture.java:[35,9] [Refaster Rule] PreconditionsRules.CheckStateWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/PreconditionsRules#CheckStateWithMessage)
+  Did you mean 'checkState(!done, "Result has already been set!");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TsmFuture.java:[14,17] [WaitNotInLoop] Because of spurious wakeups, wait() must always be called in a loop
+    (see https://errorprone.info/bugpattern/WaitNotInLoop)
+  Did you mean 'while (!done) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/tsm/TsmFuture.java:[23,17] [WaitNotInLoop] Because of spurious wakeups, wait(long) must always be called in a loop
+    (see https://errorprone.info/bugpattern/WaitNotInLoop)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/ByteConstraint.java:[13,39] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'super(Byte.class, min, Byte.valueOf(max), true, true);' or '@SuppressWarnings("IdentityConversion") public ByteConstraint(byte min, byte max) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/ByteConstraint.java:[13,58] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'super(Byte.class, Byte.valueOf(min), max, true, true);' or '@SuppressWarnings("IdentityConversion") public ByteConstraint(byte min, byte max) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/DoubleConstraint.java:[17,43] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'super(Double.class, min, Double.valueOf(max), minInclusive, maxInclusive);' or '@SuppressWarnings("IdentityConversion") public DoubleConstraint(double min, double max, boolean minInclusive, boolean maxInclusive) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/DoubleConstraint.java:[17,64] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'super(Double.class, Double.valueOf(min), max, minInclusive, maxInclusive);' or '@SuppressWarnings("IdentityConversion") public DoubleConstraint(double min, double max, boolean minInclusive, boolean maxInclusive) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/FloatConstraint.java:[17,41] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'super(Float.class, min, Float.valueOf(max), minInclusive, maxInclusive);' or '@SuppressWarnings("IdentityConversion") public FloatConstraint(float min, float max, boolean minInclusive, boolean maxInclusive) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/FloatConstraint.java:[17,61] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'super(Float.class, Float.valueOf(min), max, minInclusive, maxInclusive);' or '@SuppressWarnings("IdentityConversion") public FloatConstraint(float min, float max, boolean minInclusive, boolean maxInclusive) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/LongConstraint.java:[13,39] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'super(Long.class, min, Long.valueOf(max), true, true);' or '@SuppressWarnings("IdentityConversion") public LongConstraint(long min, long max) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/LongConstraint.java:[13,58] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'super(Long.class, Long.valueOf(min), max, true, true);' or '@SuppressWarnings("IdentityConversion") public LongConstraint(long min, long max) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/value/SetConstraint.java:[30,39] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'this.validValues = unmodifiableSet(new HashSet<>(Arrays.asList(validValues)));'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/ShortConstraint.java:[13,41] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'super(Short.class, min, Short.valueOf(max), true, true);' or '@SuppressWarnings("IdentityConversion") public ShortConstraint(short min, short max) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/value/ShortConstraint.java:[13,61] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'super(Short.class, Short.valueOf(min), max, true, true);' or '@SuppressWarnings("IdentityConversion") public ShortConstraint(short min, short max) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/EdgeToGraphicConverter.java:[16,29] [UnusedVariable] The field 'pixelNodeTLBRECD' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/MoveSelectionConverter.java:[17,29] [UnusedVariable] The field 'pixelNodeTLBRECD' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/NodeToGraphicConverter.java:[38,29] [UnusedVariable] The field 'pixelNodeTLBRECD' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/NormalXYDoubleIlmFromGraph.java:[39,25] [UnusedMethod] Method 'get' is never used.
+    (see https://errorprone.info/bugpattern/UnusedMethod)
+  Did you mean to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/NormalXYDoubleIlmFromGraph.java:[212,25] [UnusedMethod] Method 'get' is never used.
+    (see https://errorprone.info/bugpattern/UnusedMethod)
+  Did you mean to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/NormalXYDoubleIlmFromGraph.java:[212,66] [UnusedVariable] The parameter 'width' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean 'public double[] get(long rowStart, long columnStart, int height) throws IOException {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/NormalXYDoubleIlmFromGraph.java:[212,34] [UnusedVariable] The parameter 'rowStart' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean 'public double[] get(long columnStart, int width, int height) throws IOException {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/NormalXYDoubleIlmFromGraph.java:[212,49] [UnusedVariable] The parameter 'columnStart' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean 'public double[] get(long rowStart, int width, int height) throws IOException {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/NormalXYDoubleIlmFromGraph.java:[212,77] [UnusedVariable] The parameter 'height' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean 'public double[] get(long rowStart, long columnStart, int width) throws IOException {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/NormalXYDoubleIlmFromGraph.java:[204,39] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (!nextLevelNodes.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/NormalXYDoubleIlmFromGraph.java:[69,34] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'if (rootNodes.isEmpty()) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/NormalXYDoubleIlmFromGraph.java:[75,37] [Refaster Rule] CollectionRules.CollectionIsEmpty: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/CollectionRules#CollectionIsEmpty)
+  Did you mean 'while (!rootNodes.isEmpty()) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/PixelNodeBoundsFromNormalizedXYs.java:[60,22] [UnusedMethod] Method 'get' is never used.
+    (see https://errorprone.info/bugpattern/UnusedMethod)
+  Did you mean to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/PixelNodeBoundsFromNormalizedXYs.java:[95,22] [UnusedMethod] Method 'get' is never used.
+    (see https://errorprone.info/bugpattern/UnusedMethod)
+  Did you mean to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/PixelNodeBoundsFromNormalizedXYs.java:[95,31] [UnusedVariable] The parameter 'rowStart' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean 'public int[] get(long columnStart, int width, int height) throws IOException {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/PixelNodeBoundsFromNormalizedXYs.java:[95,74] [UnusedVariable] The parameter 'height' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean 'public int[] get(long rowStart, long columnStart, int width) throws IOException {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/PixelNodeBoundsFromNormalizedXYs.java:[95,63] [UnusedVariable] The parameter 'width' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean 'public int[] get(long rowStart, long columnStart, int height) throws IOException {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/PixelNodeBoundsFromNormalizedXYs.java:[95,46] [UnusedVariable] The parameter 'columnStart' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean 'public int[] get(long rowStart, int width, int height) throws IOException {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/SelectionConverter.java:[61,17] [UnusedVariable] The local variable 'y' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or '((Integer) get(yMouseECD)).intValue();'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/SelectionConverter.java:[63,19] [UnusedVariable] The local variable 'tlbr' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/SelectionConverter.java:[60,17] [UnusedVariable] The local variable 'x' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or '((Integer) get(xMouseECD)).intValue();'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/main/java/tfw/visualizer/SelectionToGraphicConverter.java:[40,15] [UnusedVariable] The local variable 'tlbr' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or to remove this line?
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-resources-plugin:2.6:testResources[m [1m(default-testResources)[m @ [36mtfw[0;1m ---[m
+[[1;34mINFO[m] Using 'UTF-8' encoding to copy filtered resources.
+[[1;34mINFO[m] skip non existing resourceDirectory /home/pi/git/tfw/src/test/resources
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-compiler-plugin:3.13.0:testCompile[m [1m(default-testCompile)[m @ [36mtfw[0;1m ---[m
+[[1;34mINFO[m] Recompiling the module because of [1mchanged dependency[m.
+[[1;34mINFO[m] Compiling 361 source files with javac [debug release 8] to target/test-classes
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/swing/JButtonBBTestApplication.java:[8,8] serializable class tfw.swing.JButtonBBTestApplication has no definition of serialVersionUID
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/swing/JTextFieldBBTestApplication.java:[8,8] serializable class tfw.swing.JTextFieldBBTestApplication has no definition of serialVersionUID
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/DocumentListenerFactoryTest.java:[84,20] serializable class tfw.swing.event.DocumentListenerFactoryTest.TestDocument has no definition of serialVersionUID
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/DocumentListenerFactoryTest.java:[90,20] serializable class tfw.swing.event.DocumentListenerFactoryTest.ExceptionDocument has no definition of serialVersionUID
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/component/TriggerRelayTest.java:[32,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(commit.executed).withFailMessage("Trigger not relayed!").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/component/TriggerRelayTest.java:[13,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class TriggerRelayTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/component/TriggerRelayTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void triggerRelay() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java:[158,41] [Refaster Rule] EqualityRules.Negation: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/EqualityRules#Negation)
+  Did you mean 'if (actualBase[ii] != targetBase[ii])'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java:[109,33] [Refaster Rule] EqualityRules.Negation: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/EqualityRules#Negation)
+  Did you mean 'if (four[ii] != five[ii])'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java:[35,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java:[41,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaUtilCheck.java:[59,29] [Refaster Rule] EqualityRules.Negation: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/EqualityRules#Negation)
+  Did you mean 'if (baseline[ii + (int) start] != subset[ii])'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaUtilCheck.java:[83,29] [Refaster Rule] EqualityRules.Negation: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/EqualityRules#Negation)
+  Did you mean 'if (four[ii] != two[ii])'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaCheck.java:[35,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaCheck.java:[41,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaFromCastIntIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaFromCastIntIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaFromCastIntIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaFromCastLongIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaFromCastLongIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaFromCastLongIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaFromCastShortIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaFromCastShortIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaFromCastShortIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromIntIlaTest.java:[36,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByWithFailMessageStringIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByWithFailMessageStringIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaFromIntIla.create(null, 100)).withFailMessage("ilm == null not checked for!").isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromIntIlaTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaFromIntIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromIntIlaTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void byteIlaFromIntIla() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromLongIlaTest.java:[36,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByWithFailMessageStringIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByWithFailMessageStringIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaFromLongIla.create(null, 100)).withFailMessage("ilm == null not checked for!").isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromLongIlaTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaFromLongIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromLongIlaTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void byteIlaFromLongIla() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaIteratorTest.java:[33,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator stopped at " + i + " not " + array.length);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaIteratorTest.java:[27,21] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator did not stop correctly");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaIteratorTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaIteratorTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaIteratorTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void byteIlaFill() throws IOException {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaMultiply.create(null, ila1, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaMultiplyTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaMultiply.create(ila1, null, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaMultiplyTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaMultiply.create(ila1, ila2, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaMultiplyTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaMultiply.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaMultiplyTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaNegateTest.java:[12,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaNegate.create(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaNegateTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaNegateTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaNegateTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaNegateTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaRampTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaRamp.create(start, increment, -1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaRampTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaRampTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaRampTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaRampTest.java:[20,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarAddTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaScalarAdd.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarAddTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaScalarAddTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarAddTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarAddTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaScalarMultiply.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaScalarMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarMultiplyTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaSubtractTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaSubtract.create(null, ila1, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaSubtractTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaSubtract.create(ila1, null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaSubtractTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaSubtract.create(ila1, ila2, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaSubtractTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaSubtract.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaSubtractTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaSubtractTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaSubtractTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaSubtractTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaSwapTest.java:[73,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByWithFailMessageStringIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByWithFailMessageStringIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ByteIlaSwap.create(null, 2, 100)).withFailMessage("ila == null not checked for!").isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaSwapTest.java:[8,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlaSwapTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/byteila/ByteIlaSwapTest.java:[10,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void byteIlaFromLongIla() throws Exception {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaCheck.java:[35,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaCheck.java:[41,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaCheck.java:[89,34] [ComparisonOutOfRange] chars may have a value in the range 0 to 65535; therefore, this comparison to 0.0 will always evaluate to false
+    (see https://errorprone.info/bugpattern/ComparisonOutOfRange)
+  Did you mean 'final char eps = false ? (char) -epsilon : epsilon;'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaCheck.java:[131,34] [ComparisonOutOfRange] chars may have a value in the range 0 to 65535; therefore, this comparison to 0.0 will always evaluate to false
+    (see https://errorprone.info/bugpattern/ComparisonOutOfRange)
+  Did you mean 'final char eps = false ? (char) -epsilon : epsilon;'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastIntIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaFromCastIntIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastIntIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaFromCastIntIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastIntIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CharIlaFromCastIntIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastIntIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastIntIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastLongIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaFromCastLongIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastLongIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaFromCastLongIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastLongIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CharIlaFromCastLongIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastLongIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastLongIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastShortIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaFromCastShortIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastShortIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaFromCastShortIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastShortIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CharIlaFromCastShortIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastShortIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastShortIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromUtf8ByteIlaTest.java:[39,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(charactersFromString, charactersFromCharIla)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromUtf8ByteIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CharIlaFromUtf8ByteIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromUtf8ByteIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void charIlaFromUTF8ByteIla() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromUtf8ByteIlaTest.java:[24,66] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'final byte[] utf8Bytes = string.getBytes(UTF_8);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaFromUtf8ByteIlaTest.java:[27,82] [StaticImport] Identifier should be statically imported
+    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
+  Did you mean 'final String stringFromUtf8Bytes = new String(utf8Bytes, UTF_8);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaIteratorTest.java:[33,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator stopped at " + i + " not " + array.length);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaIteratorTest.java:[27,21] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator did not stop correctly");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaIteratorTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CharIlaIteratorTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaIteratorTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void charIlaFill() throws IOException {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaMultiply.create(null, ila1, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaMultiplyTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaMultiply.create(ila1, null, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaMultiplyTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaMultiply.create(ila1, ila2, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaMultiplyTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaMultiply.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CharIlaMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaMultiplyTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaNegateTest.java:[12,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaNegate.create(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaNegateTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CharIlaNegateTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaNegateTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaNegateTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaRampTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaRamp.create(start, increment, -1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaRampTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CharIlaRampTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaRampTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaRampTest.java:[20,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaScalarAddTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaScalarAdd.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaScalarAddTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CharIlaScalarAddTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaScalarAddTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaScalarAddTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaScalarMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaScalarMultiply.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaScalarMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CharIlaScalarMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaScalarMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaScalarMultiplyTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaSubtractTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaSubtract.create(null, ila1, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaSubtractTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaSubtract.create(ila1, null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaSubtractTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaSubtract.create(ila1, ila2, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaSubtractTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> CharIlaSubtract.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaSubtractTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CharIlaSubtractTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaSubtractTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaSubtractTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaUtilCheck.java:[49,34] [ComparisonOutOfRange] chars may have a value in the range 0 to 65535; therefore, this comparison to 0.0 will always evaluate to false
+    (see https://errorprone.info/bugpattern/ComparisonOutOfRange)
+  Did you mean 'final char eps = false ? (char) -epsilon : epsilon;'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/charila/CharIlaUtilCheck.java:[73,34] [ComparisonOutOfRange] chars may have a value in the range 0 to 65535; therefore, this comparison to 0.0 will always evaluate to false
+    (see https://errorprone.info/bugpattern/ComparisonOutOfRange)
+  Did you mean 'final char eps = false ? (char) -epsilon : epsilon;'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaCheck.java:[35,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaCheck.java:[41,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaFromCastIntIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaFromCastIntIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaFromCastIntIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaFromCastLongIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaFromCastLongIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaFromCastLongIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaFromCastShortIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaFromCastShortIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaFromCastShortIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromLongIlaTest.java:[5,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaFromLongIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromLongIlaTest.java:[7,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void doubleIlaFromLongIla() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaInvertTest.java:[12,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaInvert.create(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaInvertTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaInvertTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaInvertTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaInvertTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaIteratorTest.java:[33,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator stopped at " + i + " not " + array.length);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaIteratorTest.java:[27,21] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator did not stop correctly");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaIteratorTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaIteratorTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaIteratorTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void doubleIlaFill() throws IOException {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaMultiply.create(null, ila1, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMultiplyTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaMultiply.create(ila1, null, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMultiplyTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaMultiply.create(ila1, ila2, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMultiplyTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaMultiply.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMultiplyTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaNegateTest.java:[12,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaNegate.create(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaNegateTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaNegateTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaNegateTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaNegateTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRampTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaRamp.create(start, increment, -1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRampTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaRampTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRampTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRampTest.java:[20,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRoundTest.java:[12,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaRound.create(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRoundTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaRoundTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRoundTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRoundTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarAddTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaScalarAdd.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarAddTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaScalarAddTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarAddTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarAddTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaScalarMultiply.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaScalarMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarMultiplyTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSubtractTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaSubtract.create(null, ila1, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSubtractTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaSubtract.create(ila1, null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSubtractTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaSubtract.create(ila1, ila2, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSubtractTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DoubleIlaSubtract.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSubtractTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlaSubtractTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSubtractTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSubtractTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaCheck.java:[35,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaCheck.java:[41,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaFromCastIntIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaFromCastIntIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlaFromCastIntIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaFromCastLongIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaFromCastLongIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlaFromCastLongIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaFromCastShortIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaFromCastShortIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlaFromCastShortIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaInvertTest.java:[12,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaInvert.create(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaInvertTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlaInvertTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaInvertTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaInvertTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaIteratorTest.java:[33,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator stopped at " + i + " not " + array.length);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaIteratorTest.java:[27,21] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator did not stop correctly");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaIteratorTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlaIteratorTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaIteratorTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void floatIlaFill() throws IOException {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaMultiply.create(null, ila1, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaMultiplyTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaMultiply.create(ila1, null, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaMultiplyTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaMultiply.create(ila1, ila2, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaMultiplyTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaMultiply.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlaMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaMultiplyTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaNegateTest.java:[12,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaNegate.create(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaNegateTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlaNegateTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaNegateTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaNegateTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaRampTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaRamp.create(start, increment, -1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaRampTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlaRampTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaRampTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaRampTest.java:[20,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaRoundTest.java:[12,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaRound.create(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaRoundTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlaRoundTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaRoundTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaRoundTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarAddTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaScalarAdd.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarAddTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlaScalarAddTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarAddTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarAddTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaScalarMultiply.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlaScalarMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarMultiplyTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaSubtractTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaSubtract.create(null, ila1, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaSubtractTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaSubtract.create(ila1, null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaSubtractTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaSubtract.create(ila1, ila2, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaSubtractTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> FloatIlaSubtract.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaSubtractTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlaSubtractTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaSubtractTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/floatila/FloatIlaSubtractTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaCheck.java:[35,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaCheck.java:[41,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastLongIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaFromCastLongIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastLongIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaFromCastLongIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastLongIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class IntIlaFromCastLongIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastLongIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastLongIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastShortIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaFromCastShortIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastShortIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaFromCastShortIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastShortIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class IntIlaFromCastShortIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastShortIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastShortIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaIteratorTest.java:[33,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator stopped at " + i + " not " + array.length);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaIteratorTest.java:[27,21] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator did not stop correctly");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaIteratorTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class IntIlaIteratorTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaIteratorTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void intIlaFill() throws IOException {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaMultiply.create(null, ila1, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaMultiplyTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaMultiply.create(ila1, null, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaMultiplyTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaMultiply.create(ila1, ila2, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaMultiplyTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaMultiply.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class IntIlaMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaMultiplyTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaNegateTest.java:[12,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaNegate.create(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaNegateTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class IntIlaNegateTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaNegateTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaNegateTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaRampTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaRamp.create(start, increment, -1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaRampTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class IntIlaRampTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaRampTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaRampTest.java:[20,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaScalarAddTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaScalarAdd.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaScalarAddTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class IntIlaScalarAddTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaScalarAddTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaScalarAddTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaScalarMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaScalarMultiply.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaScalarMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class IntIlaScalarMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaScalarMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaScalarMultiplyTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaSubtractTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaSubtract.create(null, ila1, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaSubtractTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaSubtract.create(ila1, null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaSubtractTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaSubtract.create(ila1, ila2, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaSubtractTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> IntIlaSubtract.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaSubtractTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class IntIlaSubtractTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaSubtractTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/intila/IntIlaSubtractTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaCheck.java:[35,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaCheck.java:[41,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastIntIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaFromCastIntIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastIntIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaFromCastIntIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastIntIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class LongIlaFromCastIntIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastIntIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastIntIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastShortIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaFromCastShortIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastShortIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaFromCastShortIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastShortIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class LongIlaFromCastShortIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastShortIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastShortIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaIteratorTest.java:[33,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator stopped at " + i + " not " + array.length);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaIteratorTest.java:[27,21] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator did not stop correctly");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaIteratorTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class LongIlaIteratorTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaIteratorTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void longIlaFill() throws IOException {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaMultiply.create(null, ila1, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaMultiplyTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaMultiply.create(ila1, null, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaMultiplyTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaMultiply.create(ila1, ila2, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaMultiplyTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaMultiply.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class LongIlaMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaMultiplyTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaNegateTest.java:[12,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaNegate.create(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaNegateTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class LongIlaNegateTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaNegateTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaNegateTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaRampTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaRamp.create(start, increment, -1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaRampTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class LongIlaRampTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaRampTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaRampTest.java:[20,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaScalarAddTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaScalarAdd.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaScalarAddTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class LongIlaScalarAddTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaScalarAddTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaScalarAddTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaScalarMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaScalarMultiply.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaScalarMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class LongIlaScalarMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaScalarMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaScalarMultiplyTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaSubtractTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaSubtract.create(null, ila1, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaSubtractTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaSubtract.create(ila1, null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaSubtractTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaSubtract.create(ila1, ila2, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaSubtractTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> LongIlaSubtract.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaSubtractTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class LongIlaSubtractTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaSubtractTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/longila/LongIlaSubtractTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java:[34,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java:[40,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java:[105,34] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
+    (see https://errorprone.info/bugpattern/UnnecessaryParentheses)
+  Did you mean 'if (! four[ii].equals(five[ii]))'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java:[153,42] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
+    (see https://errorprone.info/bugpattern/UnnecessaryParentheses)
+  Did you mean 'if (! actualBase[ii].equals(targetBase[ii]))'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/objectila/ObjectIlaInterleaveTest.java:[10,5] [LexicographicalAnnotationListing] Sort annotations lexicographically where possible
+    (see https://error-prone.picnic.tech/bugpatterns/LexicographicalAnnotationListing)
+  Did you mean '@SuppressWarnings("unchecked")'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/objectila/ObjectIlaInterleaveTest.java:[55,5] [LexicographicalAnnotationListing] Sort annotations lexicographically where possible
+    (see https://error-prone.picnic.tech/bugpatterns/LexicographicalAnnotationListing)
+  Did you mean '@SuppressWarnings("unchecked")'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/objectila/ObjectIlaIteratorTest.java:[31,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator stopped at " + i + " not " + array.length);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/objectila/ObjectIlaIteratorTest.java:[25,21] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator did not stop correctly");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/objectila/ObjectIlaIteratorTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ObjectIlaIteratorTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/objectila/ObjectIlaIteratorTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void objectIlaFill() throws IOException {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/objectila/ObjectIlaUtilTest.java:[7,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ObjectIlaUtilTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/objectila/ObjectIlaUtilTest.java:[9,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void toArrayTwoArgs() throws Exception {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaCheck.java:[35,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaCheck.java:[41,28] [FormatStringConcatenation] Defer string concatenation to the invoked method
+    (see https://error-prone.picnic.tech/bugpatterns/FormatStringConcatenation)
+  Did you mean '.hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaFromCastIntIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaFromCastIntIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ShortIlaFromCastIntIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIlaTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaFromCastLongIla.create(null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIlaTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaFromCastLongIla.create(ila, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIlaTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ShortIlaFromCastLongIlaTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIlaTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIlaTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaIteratorTest.java:[33,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator stopped at " + i + " not " + array.length);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaIteratorTest.java:[27,21] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Iterator did not stop correctly");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaIteratorTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ShortIlaIteratorTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaIteratorTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void shortIlaFill() throws IOException {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaMultiply.create(null, ila1, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaMultiplyTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaMultiply.create(ila1, null, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaMultiplyTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaMultiply.create(ila1, ila2, 10)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaMultiplyTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaMultiply.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ShortIlaMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaMultiplyTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaNegateTest.java:[12,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaNegate.create(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaNegateTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ShortIlaNegateTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaNegateTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaNegateTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaRampTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaRamp.create(start, increment, -1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaRampTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ShortIlaRampTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaRampTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaRampTest.java:[20,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarAddTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaScalarAdd.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarAddTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ShortIlaScalarAddTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarAddTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarAddTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarMultiplyTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaScalarMultiply.create(null, value)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarMultiplyTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ShortIlaScalarMultiplyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarMultiplyTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarMultiplyTest.java:[19,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaSubtractTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaSubtract.create(null, ila1, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaSubtractTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaSubtract.create(ila1, null, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaSubtractTest.java:[17,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaSubtract.create(ila1, ila2, 1)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaSubtractTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ShortIlaSubtract.create(ila1, ila1, 0)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaSubtractTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ShortIlaSubtractTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaSubtractTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ila/shortila/ShortIlaSubtractTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void all() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/booleanilm/BooleanIlmFromArrayTest.java:[21,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(array, BooleanIlmUtil.toArray(booleanIlm))).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/booleanilm/BooleanIlmFromArrayTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class BooleanIlmFromArrayTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/booleanilm/BooleanIlmFromArrayTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void booleanIlmFromArray() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/byteilm/ByteIlmFromArrayTest.java:[21,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(array, ByteIlmUtil.toArray(byteIlm))).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/byteilm/ByteIlmFromArrayTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ByteIlmFromArrayTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/byteilm/ByteIlmFromArrayTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void byteIlmFromArray() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/charilm/CharIlmFromArrayTest.java:[21,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(array, CharIlmUtil.toArray(charIlm))).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/charilm/CharIlmFromArrayTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CharIlmFromArrayTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/charilm/CharIlmFromArrayTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void charIlmFromArray() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/DoubleIlmFromArrayTest.java:[21,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(array, DoubleIlmUtil.toArray(doubleIlm))).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/DoubleIlmFromArrayTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DoubleIlmFromArrayTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/DoubleIlmFromArrayTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void doubleIlmFromArray() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/InterleavedMagnitudeDoubleIlmTest.java:[20,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test1Check, test1Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/InterleavedMagnitudeDoubleIlmTest.java:[25,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test2Check, test2Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/InterleavedMagnitudeDoubleIlmTest.java:[35,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test3Check, test3Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/InterleavedMagnitudeDoubleIlmTest.java:[40,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test4Check, test4Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/InterleavedMagnitudeDoubleIlmTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class InterleavedMagnitudeDoubleIlmTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/InterleavedMagnitudeDoubleIlmTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void interleavedMagnitudeDoubleIlm() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/MultiplyDoubleIlmTest.java:[27,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test1Check, test1Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/MultiplyDoubleIlmTest.java:[35,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test2Check, test2Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/MultiplyDoubleIlmTest.java:[46,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test3Check, test3Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/MultiplyDoubleIlmTest.java:[57,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test4Check, test4Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/MultiplyDoubleIlmTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class MultiplyDoubleIlmTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/MultiplyDoubleIlmTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void multiplyDoubleIlm() throws Exception {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/RealFftDoubleIlmTest.java:[19,18] [UnusedVariable] The local variable 'output' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or 'DoubleIlmUtil.toArray(outputIlm);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/RealFftDoubleIlmTest.java:[7,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class RealFftDoubleIlmTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/RealFftDoubleIlmTest.java:[9,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void realFftDoubleIlm() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/ReplicateDoubleIlmTest.java:[25,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test1Check, test1)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/ReplicateDoubleIlmTest.java:[36,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test2Check, test2)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/ReplicateDoubleIlmTest.java:[47,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test3Check, test3)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/ReplicateDoubleIlmTest.java:[58,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test4Check, test4)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/ReplicateDoubleIlmTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ReplicateDoubleIlmTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/ReplicateDoubleIlmTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void replicateDoubleIlm() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/RowConcatenateDoubleIlmTest.java:[31,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test1Check, test1Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/RowConcatenateDoubleIlmTest.java:[42,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test2Check, test2Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/RowConcatenateDoubleIlmTest.java:[53,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test3Check, test3Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/RowConcatenateDoubleIlmTest.java:[64,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test4Check, test4Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/RowConcatenateDoubleIlmTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class RowConcatenateDoubleIlmTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/RowConcatenateDoubleIlmTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void rowConcatenateDoubleIlmTest() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/SegmentDoubleIlmTest.java:[25,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test1Check, test1Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/SegmentDoubleIlmTest.java:[38,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test2Check, test2Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/SegmentDoubleIlmTest.java:[51,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test3Check, test3Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/SegmentDoubleIlmTest.java:[64,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(test4Check, test4Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/SegmentDoubleIlmTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class SegmentDoubleIlmTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/SegmentDoubleIlmTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void segmentDoubleIlm() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/TakeSkipDoubleIlmTest.java:[48,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(takeSkip4Array, DoubleIlmUtil.toArray(takeSkip4, 0, 1, 3, 3))).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/TakeSkipDoubleIlmTest.java:[30,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(takeSkip2Array, DoubleIlmUtil.toArray(takeSkip2))).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/TakeSkipDoubleIlmTest.java:[39,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(takeSkip3Array, DoubleIlmUtil.toArray(takeSkip3))).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/TakeSkipDoubleIlmTest.java:[64,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(takeSkip5Array, takeSkip5Test)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/TakeSkipDoubleIlmTest.java:[20,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(doubleArray, takeSkip1Array)).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/TakeSkipDoubleIlmTest.java:[12,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class TakeSkipDoubleIlmTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/doubleilm/TakeSkipDoubleIlmTest.java:[14,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void takeSkipDoubleIlm() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/floatilm/FloatIlmFromArrayTest.java:[21,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(array, FloatIlmUtil.toArray(floatIlm))).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/floatilm/FloatIlmFromArrayTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class FloatIlmFromArrayTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/floatilm/FloatIlmFromArrayTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void floatIlmFromArray() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/intilm/IntIlmFromArrayTest.java:[21,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(array, IntIlmUtil.toArray(intIlm))).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/intilm/IntIlmFromArrayTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class IntIlmFromArrayTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/intilm/IntIlmFromArrayTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void intIlmFromArray() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/longilm/LongIlmFromArrayTest.java:[21,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(array, LongIlmUtil.toArray(longIlm))).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/longilm/LongIlmFromArrayTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class LongIlmFromArrayTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/longilm/LongIlmFromArrayTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void longIlmFromArray() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/objectilm/ObjectIlmFromArrayTest.java:[19,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(array, ObjectIlmUtil.toArray(objectIlm, new Object[0]))).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/objectilm/ObjectIlmFromArrayTest.java:[8,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ObjectIlmFromArrayTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/objectilm/ObjectIlmFromArrayTest.java:[10,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void objectIlmFromArray() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/shortilm/ShortIlmFromArrayTest.java:[21,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsTrue)
+  Did you mean 'assertThat(Arrays.equals(array, ShortIlmUtil.toArray(shortIlm))).isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/shortilm/ShortIlmFromArrayTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ShortIlmFromArrayTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/immutable/ilm/shortilm/ShortIlmFromArrayTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void shortIlmFromArray() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/math/SMBigIntegerTest.java:[7,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class SMBigIntegerTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/math/SMBigIntegerTest.java:[9,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void sMBigIntegerValue() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JButtonBBTest.java:[197,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> GuiActionRunner.execute(() -> jButtonBB.removeActionListenerFromBoth(testActionListener))).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JButtonBBTest.java:[194,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> GuiActionRunner.execute(() -> jButtonBB.addActionListenerToBoth(testActionListener))).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JButtonBBTest.java:[37,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class JButtonBBTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JButtonBBTest.java:[71,24] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'static void beforeAll() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JButtonBBTest.java:[84,17] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void beforeEach() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JButtonBBTest.java:[92,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void jButtonBB() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JButtonBBTest.java:[175,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void emptyJButtonBuilder() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JButtonBBTest.java:[203,17] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void tearDown() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JTextFieldBBTest.java:[145,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> GuiActionRunner.execute(() -> jTextFieldBB.removeDocumentListenerFromBoth(testDocumentListener))).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JTextFieldBBTest.java:[117,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> GuiActionRunner.execute(() -> jTextFieldBB.removeActionListenerFromBoth(testActionListener))).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JTextFieldBBTest.java:[142,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> GuiActionRunner.execute(() -> jTextFieldBB.addDocumentListenerToBoth(testDocumentListener))).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JTextFieldBBTest.java:[114,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> GuiActionRunner.execute(() -> jTextFieldBB.addActionListenerToBoth(testActionListener))).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JTextFieldBBTest.java:[25,8] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class JTextFieldBBTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JTextFieldBBTest.java:[41,24] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'static void setUpOnce() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JTextFieldBBTest.java:[46,17] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void setUp() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JTextFieldBBTest.java:[54,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void jTextFieldBB() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JTextFieldBBTest.java:[95,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void actionListener() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/JTextFieldBBTest.java:[123,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void documentListener() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/ActionListenerFactoryTest.java:[28,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ActionListenerFactory.create(null, STATELESS_TRIGGER_ECD, stateQueueFactory)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/ActionListenerFactoryTest.java:[32,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ActionListenerFactory.create(TEST_NAME, null, stateQueueFactory)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/ActionListenerFactoryTest.java:[26,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ActionListenerFactory.create(null, STATELESS_TRIGGER_ECD, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/ActionListenerFactoryTest.java:[31,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> ActionListenerFactory.create(TEST_NAME, null, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/ActionListenerFactoryTest.java:[16,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ActionListenerFactoryTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/ActionListenerFactoryTest.java:[23,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/ActionListenerFactoryTest.java:[37,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void stateQueueFactoryNull() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/ActionListenerFactoryTest.java:[61,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void stateQueueFactoryNonNull() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/DocumentListenerFactoryTest.java:[36,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DocumentListenerFactory.create(TEST_NAME, null, stateQueueFactory)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/DocumentListenerFactoryTest.java:[32,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DocumentListenerFactory.create(null, TEXT_ECD, stateQueueFactory)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/DocumentListenerFactoryTest.java:[35,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DocumentListenerFactory.create(TEST_NAME, null, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/DocumentListenerFactoryTest.java:[31,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> DocumentListenerFactory.create(null, TEXT_ECD, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/DocumentListenerFactoryTest.java:[19,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DocumentListenerFactoryTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/DocumentListenerFactoryTest.java:[28,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/DocumentListenerFactoryTest.java:[42,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void stateQueueFactoryNull() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetBackgroundFactoryTest.java:[35,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetBackgroundFactory.create(TEST_NAME, COLOR_ECD, null, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetBackgroundFactoryTest.java:[33,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetBackgroundFactory.create(null, COLOR_ECD, jButton, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetBackgroundFactoryTest.java:[34,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetBackgroundFactory.create(TEST_NAME, null, jButton, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetBackgroundFactoryTest.java:[15,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class SetBackgroundFactoryTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetBackgroundFactoryTest.java:[22,24] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'static void setUpOnce() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetBackgroundFactoryTest.java:[27,17] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void setUp() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetBackgroundFactoryTest.java:[32,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetEnabledFactoryTest.java:[35,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetEnabledFactory.create(TEST_NAME, ENABLED_ECD, null, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetEnabledFactoryTest.java:[33,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetEnabledFactory.create(null, ENABLED_ECD, jButton, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetEnabledFactoryTest.java:[34,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetEnabledFactory.create(TEST_NAME, null, jButton, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetEnabledFactoryTest.java:[15,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class SetEnabledFactoryTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetEnabledFactoryTest.java:[22,24] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'static void setUpOnce() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetEnabledFactoryTest.java:[27,17] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void setUp() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetEnabledFactoryTest.java:[32,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetFontFactoryTest.java:[35,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetFontFactory.create(TEST_NAME, FONT_ECD, null, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetFontFactoryTest.java:[34,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetFontFactory.create(TEST_NAME, null, jButton, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetFontFactoryTest.java:[33,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetFontFactory.create(null, FONT_ECD, jButton, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetFontFactoryTest.java:[15,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class SetFontFactoryTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetFontFactoryTest.java:[22,24] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'static void setUpOnce() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetFontFactoryTest.java:[27,17] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void setUp() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetFontFactoryTest.java:[32,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetForegroundFactoryTest.java:[35,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetForegroundFactory.create(TEST_NAME, COLOR_ECD, null, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetForegroundFactoryTest.java:[33,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetForegroundFactory.create(null, COLOR_ECD, jButton, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetForegroundFactoryTest.java:[34,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetForegroundFactory.create(TEST_NAME, null, jButton, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetForegroundFactoryTest.java:[15,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class SetForegroundFactoryTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetForegroundFactoryTest.java:[22,24] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'static void setUpOnce() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetForegroundFactoryTest.java:[27,17] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void setUp() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetForegroundFactoryTest.java:[32,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetIconFactoryTest.java:[35,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetIconFactory.create(TEST_NAME, ICON_ECD, null, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetIconFactoryTest.java:[34,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetIconFactory.create(TEST_NAME, null, jButton, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetIconFactoryTest.java:[33,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetIconFactory.create(null, ICON_ECD, jButton, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetIconFactoryTest.java:[15,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class SetIconFactoryTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetIconFactoryTest.java:[22,24] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'static void setUpOnce() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetIconFactoryTest.java:[27,17] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void setUp() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetIconFactoryTest.java:[32,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetTextFactoryTest.java:[40,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetTextFactory.create(TEST_NAME, TEXT_ECD, (AbstractButton) null, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetTextFactoryTest.java:[45,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetTextFactory.create(TEST_NAME, TEXT_ECD, (JTextComponent) null, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetTextFactoryTest.java:[44,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetTextFactory.create(TEST_NAME, null, jTextField, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetTextFactoryTest.java:[43,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetTextFactory.create(null, TEXT_ECD, jTextField, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetTextFactoryTest.java:[39,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetTextFactory.create(TEST_NAME, null, jButton, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetTextFactoryTest.java:[38,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> SetTextFactory.create(null, TEXT_ECD, jButton, null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetTextFactoryTest.java:[18,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class SetTextFactoryTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetTextFactoryTest.java:[26,24] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'static void setUpOnce() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetTextFactoryTest.java:[31,17] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void setUp() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/swing/event/SetTextFactoryTest.java:[37,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void arguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BasicTransactionQueueTest.java:[57,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(ts.done).withFailMessage("Not done after waitTilEmpty()").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BasicTransactionQueueTest.java:[65,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("invokeAndWait() accepted null");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BasicTransactionQueueTest.java:[19,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("add() accepted null runnable");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BasicTransactionQueueTest.java:[12,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class BasicTransactionQueueTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BasicTransactionQueueTest.java:[14,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void add() {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BasicTransactionQueueTest.java:[44,17] [CatchAndPrintStackTrace] Logging or rethrowing exceptions should usually be preferred to catching and calling printStackTrace
+    (see https://errorprone.info/bugpattern/CatchAndPrintStackTrace)
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BasicTransactionQueueTest.java:[50,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void addNWait() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BasicTransactionQueueTest.java:[61,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void invokeAndWait() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[54,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addEventChannel() accepted non-null state on memory less event channel");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[21,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTerminator() accepted null event channel description");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[30,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTerminator() accepted null event channel description");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[37,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTerminator() accepted null event channel description");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[101,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addEventChannel() accepted translated event channel");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[78,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTranslator() accepted null parent event channel");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[71,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTranslator() accepted null child event channel");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[85,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTranslator() accepted terminated event channel");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[44,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTerminator() accepted null state change rule");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[94,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTranslator() accepted duplicate translation");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[61,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTerminator() accepted duplicate terminator");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[120,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTranslator() parent un-assignable to child");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[126,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTranslator() child un-assignable to parent");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[108,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("create() accepted null name");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[14,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class BranchFactoryTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/BranchFactoryTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void factory() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CascadeTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CascadeTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CascadeTest.java:[69,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void converter() throws InterruptedException, InvocationTargetException {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[151,23] [UnusedVariable] The field 'portBState' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[153,23] [UnusedVariable] The field 'portDState' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[152,23] [UnusedVariable] The field 'portCState' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or to remove this line?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[96,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsFalse: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsFalse)
+  Did you mean 'assertThat(testCommit.debugCommitFired).withFailMessage("debugCommit()  was called on an initiator sink!").isFalse();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[91,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsFalse: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsFalse)
+  Did you mean 'assertThat(testCommit.debugCommitFired).withFailMessage("debugCommit() was called on non-trigger sink!").isFalse();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[95,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsFalse: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsFalse)
+  Did you mean 'assertThat(testCommit.commitFired).withFailMessage("commit() was called on an initiator sink!").isFalse();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[90,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsFalse: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsFalse)
+  Did you mean 'assertThat(testCommit.commitFired).withFailMessage("commit() was called on non-trigger sink!").isFalse();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[102,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(testCommit.commitFired).withFailMessage("commit() was not called!").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[111,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(testCommit.commitFired).withFailMessage("commit() was not called!").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[59,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null nonTriggerSinks element");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[52,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null triggerSinks element");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[66,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null initiator element");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[45,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted empty triggerSinks");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[38,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null triggerSinks");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[31,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null name");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[15,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class CommitTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/CommitTest.java:[73,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void triggerBehavior() throws Exception {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ConverterTest.java:[78,20] [UnusedVariable] The parameter 'cDebugValue' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean 'checkAndClearValues(null, null, null, aValue, null, aValue, null, null);'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ConverterTest.java:[75,20] [UnusedVariable] The parameter 'cValue' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean 'checkAndClearValues(null, null, aValue, null, null, aValue, null, null);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ConverterTest.java:[122,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null element in non-triggering sinks");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ConverterTest.java:[114,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null element in triggering sinks");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ConverterTest.java:[130,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null element in sources");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ConverterTest.java:[106,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null triggering sinks");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ConverterTest.java:[138,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted duplicate sinks");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ConverterTest.java:[99,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null name");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ConverterTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ConverterTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ConverterTest.java:[40,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void converter() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ConverterTest.java:[96,17] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void constructor() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DefaultStateQueueFactoryTest.java:[8,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DefaultStateQueueFactoryTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DefaultStateQueueFactoryTest.java:[11,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void create() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DifferentObjectRuleTest.java:[19,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsFalse: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsFalse)
+  Did you mean 'assertThat(rule.isChange(currentState, currentState)).withFailMessage("Same state").isFalse();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DifferentObjectRuleTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(rule.isChange(currentState, newState)).withFailMessage("Different state").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DifferentObjectRuleTest.java:[20,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(rule.isChange(null, newState)).withFailMessage("Null currentState").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DifferentObjectRuleTest.java:[23,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("isChange() accepted null new state");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DifferentObjectRuleTest.java:[12,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DifferentObjectRuleTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DifferentObjectRuleTest.java:[14,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void isChange() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DotEqualsRuleTest.java:[19,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsFalse: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsFalse)
+  Did you mean 'assertThat(rule.isChange(currentState, currentState)).withFailMessage("Same state").isFalse();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DotEqualsRuleTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(rule.isChange(currentState, newState)).withFailMessage("Different state").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DotEqualsRuleTest.java:[20,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(rule.isChange(null, newState)).withFailMessage("Null currentState").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DotEqualsRuleTest.java:[23,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("isChange() accepted null new state");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DotEqualsRuleTest.java:[12,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class DotEqualsRuleTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/DotEqualsRuleTest.java:[14,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void isChange() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/EventChannelStateTest.java:[21,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("constructor accepted null ecd");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/EventChannelStateTest.java:[13,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class EventChannelStateTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/EventChannelStateTest.java:[15,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void eventChannelState() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/EventChannelStateTest.java:[32,10] [JUnitMethodDeclaration] This method's name should not redundantly start with `test` (but note that a method named `equals` is already defined in this class or a supertype)
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/GetPreviousStateTest.java:[22,21] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Test failed with an exception: " + e.getMessage());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/GetPreviousStateTest.java:[9,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class GetPreviousStateTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/GetPreviousStateTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void isStateChanged() {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[214,33] [UnusedVariable] The field 'exception' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[42,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(getStateRunnable.treeState).withFailMessage("getTreeState() returned null").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[94,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsNotNull)
+  Did you mean 'assertThat("setTreeState() accepted wrong child tree state name").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[80,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsNotNull)
+  Did you mean 'assertThat("setTreeState() accepted wrong event channel state").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[159,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(tsr.exception).withFailMessage("getTreeState() accepted null tag").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[32,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("getTreeState() accepted call outside transaction thread");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[165,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(tsr.treeState).withFailMessage("getTreeState() returned null").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[178,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(tsr.treeState).withFailMessage("getTreeState() returned null").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[75,9] [Refaster Rule] JUnitToAssertJRules.AssertThatIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatIsNotNull)
+  Did you mean 'assertThat("setTreeState() accepted null value").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[55,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(children).withFailMessage("children == null").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[69,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(children).withFailMessage("children == null").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[145,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addExportTag() accepted unknown ECD");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[139,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addExportTag() accepted empty tag");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[127,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addExportTag() accepted null ECD");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[133,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addExportTag() accepted null tag");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[46,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(ecds).withFailMessage("ecds == null").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[14,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ImportExportTreeStateTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void defaultExportTreeState() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ImportExportTreeStateTest.java:[116,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void customTagExportImportTreeState() {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InfiniteLoopTest.java:[15,24] [UnusedVariable] The field 'count' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InfiniteLoopTest.java:[108,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(cvalue).withFailMessage("initiator broke into the infinite transaction.").isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InfiniteLoopTest.java:[93,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsFalse: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsFalse)
+  Did you mean 'assertThat(isDebugCommit).withFailMessage("debugCommit was called").isFalse();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InfiniteLoopTest.java:[92,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsFalse: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsFalse)
+  Did you mean 'assertThat(isCommit).withFailMessage("commit was called").isFalse();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InfiniteLoopTest.java:[14,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class InfiniteLoopTest {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InfiniteLoopTest.java:[16,36] [ConstantNaming] Constant variables should adhere to the `UPPER_SNAKE_CASE` naming convention
+    (see https://error-prone.picnic.tech/bugpatterns/ConstantNaming)
+  Did you mean 'private static final StringECD PORTA = new StringECD("a");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InfiniteLoopTest.java:[17,36] [ConstantNaming] Constant variables should adhere to the `UPPER_SNAKE_CASE` naming convention
+    (see https://error-prone.picnic.tech/bugpatterns/ConstantNaming)
+  Did you mean 'private static final StringECD PORTB = new StringECD("b");'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InfiniteLoopTest.java:[18,36] [ConstantNaming] Constant variables should adhere to the `UPPER_SNAKE_CASE` naming convention
+    (see https://error-prone.picnic.tech/bugpatterns/ConstantNaming)
+  Did you mean 'private static final StringECD PORTC = new StringECD("c");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InfiniteLoopTest.java:[76,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void infiniteLoop() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[103,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(commit.debugCommitState).withFailMessage("debugCommit() was not called").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[60,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("set(eventChannelName, state) accepted null eventChannelName");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[112,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(commit.debugCommitState).withFailMessage("debugCommit() was called").isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[135,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(commit.debugCommitState).withFailMessage("debugCommit() was called").isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[152,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(commit.debugCommitState).withFailMessage("debugCommit() was called").isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[189,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(commit.debugCommitState).withFailMessage("debugCommit() was called").isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[108,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(commit.commitState).withFailMessage("commit() not called").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[131,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(commit.commitState).withFailMessage("commit() not called").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[185,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(commit.commitState).withFailMessage("commit() not called").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[53,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("set(channel, state) accepted null channel");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[67,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("set(channel, state) accepted null state");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[84,21] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Exception: " + exception.getMessage());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[195,21] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Exception: " + exception.getMessage());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[41,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null sources");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[34,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null source");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[27,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null name");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[74,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("set(state) accepted null state");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[16,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class InitiatorTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[24,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void initiatorConstruction() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/InitiatorTest.java:[48,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void initatorSetMehtods() {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexedBranchFactoryTest.java:[38,19] [UnusedVariable] The local variable 'newValueECD' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or 'new StringECD("differentValue");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexedBranchFactoryTest.java:[45,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addMultiplexer() accepted multiple multiplexer with the same valueECD");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexedBranchFactoryTest.java:[90,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addMultiplexer() accepted the same ECDs twice!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexedBranchFactoryTest.java:[33,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addMultiplexer() accepted null multiValueECD");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexedBranchFactoryTest.java:[96,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(branch).withFailMessage("create() returned null").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexedBranchFactoryTest.java:[26,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addMultiplexer() accepted null valueECD");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexedBranchFactoryTest.java:[57,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("create() accepted null value");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexedBranchFactoryTest.java:[16,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class MultiplexedBranchFactoryTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexedBranchFactoryTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void addMultiplexer() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexedBranchFactoryTest.java:[52,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void create() {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerConstructionTest.java:[79,16] [UnusedMethod] Constructor 'ComponentSwitchCommit' is never used.
+    (see https://errorprone.info/bugpattern/UnusedMethod)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerConstructionTest.java:[76,13] [UnusedNestedClass] This nested class is unused, and can be removed.
+    (see https://errorprone.info/bugpattern/UnusedNestedClass)
+  Did you mean to remove this line?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerConstructionTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class MultiplexerConstructionTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerConstructionTest.java:[23,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void dynamicConstruction() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerConstructionTest.java:[41,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void nameSpaceSeparation() {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerSynchronizerTest.java:[16,16] [UnusedMethod] Constructor 'MultiCommit' is never used.
+    (see https://errorprone.info/bugpattern/UnusedMethod)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerSynchronizerTest.java:[10,20] [UnusedNestedClass] This nested class is unused, and can be removed.
+    (see https://errorprone.info/bugpattern/UnusedNestedClass)
+  Did you mean to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerSynchronizerTest.java:[12,27] [UnusedVariable] The field 'objectIla' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or to remove this line?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerSynchronizerTest.java:[8,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class MultiplexerSynchronizerTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerSynchronizerTest.java:[29,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void multiplexedSynchronizer() throws Exception {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerTest.java:[331,9] [AlmostJavadoc] This comment contains Javadoc or HTML tags, but isn't started with a double asterisk (/**); is it meant to be Javadoc?
+    (see https://errorprone.info/bugpattern/AlmostJavadoc)
+  Did you mean '/**'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerTest.java:[122,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(exceptionHandler.exp).withFailMessage("Unexpected exception thrown during testing").isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerTest.java:[138,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(exceptionHandler.exp).withFailMessage("Unexpected exception thrown during testing").isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerTest.java:[15,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class MultiplexerTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerTest.java:[23,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void multiplexerWithIntermediateBranch() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerTest.java:[165,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void multiLayerMultiplexing() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerTest.java:[241,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void multipleMultiplexers() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/MultiplexerTest.java:[281,27] [DirectReturn] Variable assignment is redundant; value can be returned directly
+    (see https://error-prone.picnic.tech/bugpatterns/DirectReturn)
+  Did you mean 'return ObjectIlaFromArray.create(new Object[] {vmo0, vmo1});'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/OneDeepStateQueueFactoryTest.java:[33,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(queue.isEmpty()).withFailMessage("isEmpty() == false after pop()").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/OneDeepStateQueueFactoryTest.java:[31,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsFalse: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsFalse)
+  Did you mean 'assertThat(queue.isEmpty()).withFailMessage("isEmpty() == true when empty").isFalse();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/OneDeepStateQueueFactoryTest.java:[21,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(queue.isEmpty()).withFailMessage("isEmpty() == false when empty").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/OneDeepStateQueueFactoryTest.java:[24,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("pop() on an empty queue didn't throw exception!");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/OneDeepStateQueueFactoryTest.java:[20,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(queue).withFailMessage("factory return null").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/OneDeepStateQueueFactoryTest.java:[15,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class OneDeepStateQueueFactoryTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/OneDeepStateQueueFactoryTest.java:[17,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void factory() {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/PortTerminationTest.java:[38,17] [UnusedVariable] The local variable 'failed' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/PortTerminationTest.java:[50,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(expected).withFailMessage("Root.add() accepted child with un-terminated ports!").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/PortTerminationTest.java:[12,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class PortTerminationTest {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/PortTerminationTest.java:[13,22] [StaticAssignmentOfThrowable] Saving instances of Throwable in static fields is discouraged, prefer to create them on-demand when an exception is thrown
+    (see https://errorprone.info/bugpattern/StaticAssignmentOfThrowable)
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/PortTerminationTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void unTerminatedPort() {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/PortTerminationTest.java:[22,46] [StaticAssignmentOfThrowable] Saving instances of Throwable in static fields is discouraged, prefer to create them on-demand when an exception is thrown
+    (see https://errorprone.info/bugpattern/StaticAssignmentOfThrowable)
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/PortTerminationTest.java:[46,17] [CatchAndPrintStackTrace] Logging or rethrowing exceptions should usually be preferred to catching and calling printStackTrace
+    (see https://errorprone.info/bugpattern/CatchAndPrintStackTrace)
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RollbackTest.java:[322,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(errorCommit1.commitValue).withFailMessage("errorCommit1 received value on valid input").isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RollbackTest.java:[323,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(errorCommit2.commitValue).withFailMessage("errorCommit2 received value on valid input").isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RollbackTest.java:[148,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("rollback() accepted event channel state with null element");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RollbackTest.java:[126,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("rollback() accepted null event channel description");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RollbackTest.java:[140,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("rollback() accepted null event channel state");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RollbackTest.java:[133,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("rollback() accepted null state");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RollbackTest.java:[14,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class RollbackTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RollbackTest.java:[121,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void rollbackArguments() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RollbackTest.java:[155,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void converter() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RollbackTest.java:[212,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void simpleRollback() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RollbackTest.java:[243,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void daisyChainedMultiCycleRollback() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RollbackTest.java:[295,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void multiValueRollback() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RootTest.java:[15,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(root.isRooted()).withFailMessage("isRooted() returned false").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RootTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class RootTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/RootTest.java:[12,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void isRooted() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SetStateTest.java:[28,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(exceptionHandler.exp).withFailMessage("Double set failed to throw exception").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SetStateTest.java:[8,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class SetStateTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SetStateTest.java:[14,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void doubleSet() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/StateChangeCycleDelayTest.java:[154,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Unexpected exception: " + handler.exception.getMessage());'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/StateChangeCycleDelayTest.java:[12,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class StateChangeCycleDelayTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/StateChangeCycleDelayTest.java:[21,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void twoStage() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/StateChangeCycleDelayTest.java:[49,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void indirectDependency() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/StateChangeCycleDelayTest.java:[84,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void directIndirectDependency() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/StateChangeCycleDelayTest.java:[125,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void circularDependency() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/StateChangeCycleDelayTest.java:[159,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void threeWayDependency() {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/StateLessECDTest.java:[37,34] [UnusedVariable] The field 'getException' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/StateLessECDTest.java:[29,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(commit.setException).withFailMessage("set() of a statelessECD didn't throw an exception").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/StateLessECDTest.java:[30,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(commit.map).withFailMessage("get() returned null state map").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/StateLessECDTest.java:[14,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class StateLessECDTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/StateLessECDTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void getState() {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[76,23] [UnusedVariable] The local variable 'ch' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[24,18] [UnusedVariable] The field 'commitB2' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[25,21] [UnusedVariable] The field 'aToBFired' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[114,23] [UnusedVariable] The field 'rollback' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or '{ new Converter("rollback", new ObjectECD[] {a1Port}, new ObjectECD[] {b1Port}) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[21,18] [UnusedVariable] The field 'commitA1' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[26,21] [UnusedVariable] The field 'bToAFired' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[22,18] [UnusedVariable] The field 'commitA2' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[23,18] [UnusedVariable] The field 'commitB1' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[123,23] [UnusedVariable] The field 'exception' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[125,23] [UnusedVariable] The field 'causeAtoBtoAError' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or '{ new Converter("causeAtoBToAerror", new ObjectECD[] {source}, new ObjectECD[] {b1Port}) {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[140,23] [UnusedVariable] The field 'causeBtoAtoBError' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or '{ new Converter("causeAtoBToAerror", new ObjectECD[] {source}, new ObjectECD[] {a1Port}) {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[240,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted sources channel array with null value");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[233,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted sinks channel array with null value");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[205,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted 'A' channel array with null value");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[226,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted 'B' channel array with null value");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[198,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted empty 'A' channels");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[219,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted empty 'B' channels");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[191,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null 'A' channels");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[212,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null 'B' channels");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[184,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("Constructor accepted null name");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[10,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class SynchronizerTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/SynchronizerTest.java:[181,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void construction() {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TranslatorTest.java:[105,19] [UnusedVariable] The local variable 'stringECD' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or 'new StringECD("StringECD");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TranslatorTest.java:[130,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(handler.exception).withFailMessage("Exception - " + message).isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TranslatorTest.java:[110,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTranslation() accepted incompatible ecds");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TranslatorTest.java:[116,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addTranslation() accepted incompatible ecds");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TranslatorTest.java:[13,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class TranslatorTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TranslatorTest.java:[34,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void translation() throws InterruptedException, InvocationTargetException {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TreeStateBufferTest.java:[54,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(children).withFailMessage("getChildState() returned null").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TreeStateBufferTest.java:[58,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(ecds).withFailMessage("getEventChannels() returned null").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TreeStateBufferTest.java:[50,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(tstate).withFailMessage("toTreeState() returned null").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TreeStateBufferTest.java:[34,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addState() accepted null event channel state");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TreeStateBufferTest.java:[21,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("toTreeState() returned without a name");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TreeStateBufferTest.java:[41,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("addChild() accepted null child");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TreeStateBufferTest.java:[27,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("setName() accepted null value");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TreeStateBufferTest.java:[13,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class TreeStateBufferTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TreeStateBufferTest.java:[15,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void buffer() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TreeStateTest.java:[12,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class TreeStateTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TreeStateTest.java:[14,10] [JUnitMethodDeclaration] This method's name should not redundantly start with `test` (but note that a method named `equals` is already defined in this class or a supertype)
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TriggeredConverterTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class TriggeredConverterTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/TriggeredConverterTest.java:[41,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void converter() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ValidatorTest.java:[133,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNotNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNotNull)
+  Did you mean 'assertThat(errorHandler.errorMsg).withFailMessage("Trigger failed to cause validation").isNotNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ValidatorTest.java:[129,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(errorHandler.errorMsg).withFailMessage("Non triggered event cause validation").isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ValidatorTest.java:[138,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(errorHandler.errorMsg).withFailMessage("Non triggered event cause validation").isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ValidatorTest.java:[44,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("constructor accepted null element in non-triggering sinks");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ValidatorTest.java:[36,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("constructor accepted null element in sink event channels");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ValidatorTest.java:[125,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsNull: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsNull)
+  Did you mean 'assertThat(errorHandler.errorMsg).withFailMessage("Initialization failed").isNull();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ValidatorTest.java:[51,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("constructor accepted null sink event channels");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ValidatorTest.java:[28,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("constructor accepted null name");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ValidatorTest.java:[20,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ValidatorTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ValidatorTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void construction() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ValidatorTest.java:[62,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void validator() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ValidatorTest.java:[97,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void triggeredValidation() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ecd/EventChannelDescriptionTest.java:[41,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("constructor did not accept a null codec");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ecd/EventChannelDescriptionTest.java:[26,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("constructor accepted empty name");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ecd/EventChannelDescriptionTest.java:[33,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("constructor accepted constraint");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ecd/EventChannelDescriptionTest.java:[19,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("constructor accepted null name");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ecd/EventChannelDescriptionTest.java:[14,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class EventChannelDescriptionTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ecd/EventChannelDescriptionTest.java:[16,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void construction() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/tsm/ecd/EventChannelDescriptionTest.java:[46,10] [JUnitMethodDeclaration] This method's name should not redundantly start with `test` (but note that a method named `equals` is already defined in this class or a supertype)
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/NullConstraintTest.java:[16,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> nc.isCompatible(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/NullConstraintTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(nc.isCompatible(nc)).withFailMessage("isCompatible() rejected itself").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/NullConstraintTest.java:[27,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> nc.checkValue(v)).isInstanceOf(ValueException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/NullConstraintTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class NullConstraintTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/NullConstraintTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void isCompatable() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/NullConstraintTest.java:[22,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void getValueCompliance() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[18,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> new TestIntegerRangeConstraint(Integer.class, null, ten, true, true)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[25,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> new TestIntegerRangeConstraint(Integer.class, 0, null, true, true)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[38,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> new TestIntegerRangeConstraint(Integer.class, 0, 0, false, false)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[32,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> new TestIntegerRangeConstraint(Integer.class, 10, 0, true, true)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[55,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(rc.isCompatible(rcMiddle)).withFailMessage("isCompatible(rcMiddle) returned false").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[52,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsFalse: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsFalse)
+  Did you mean 'assertThat(rc.isCompatible(rcHigh)).withFailMessage("isCompatible(rcHigh) returned true").isFalse();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[49,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsFalse: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsFalse)
+  Did you mean 'assertThat(rc.isCompatible(rcLow)).withFailMessage("isCompatible(rcLow) returned true").isFalse();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[46,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsFalse: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsFalse)
+  Did you mean 'assertThat(rc.isCompatible(null)).withFailMessage("isCompatible(null) returned true").isFalse();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[57,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(rc.isCompatible(rc)).withFailMessage("isCompatible(rc) returned false").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[13,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class RangeConstraintTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[15,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void constructionNullMinimum() {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[16,44] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
+    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
+  Did you mean 'final Integer ten = 10;' or '@SuppressWarnings("IdentityConversion") final Integer ten = Integer.valueOf(10);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[24,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void constructionNullMaximum() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[31,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void constructorMinGreaterThanMax() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[37,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void constructorMinEqualMaxNeitherInclusive() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[44,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void isCompatibles() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/RangeConstraintTest.java:[61,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void valueCompliance() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/ValueConstraintTest.java:[24,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> new TestConstraint(null)).isInstanceOf(IllegalArgumentException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/ValueConstraintTest.java:[50,9] [Refaster Rule] JUnitToAssertJRules.AssertThatThrownByIsInstanceOf: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatThrownByIsInstanceOf)
+  Did you mean 'assertThatThrownBy(() -> vc.checkValue(v)).isInstanceOf(ValueException.class);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/ValueConstraintTest.java:[55,17] [Refaster Rule] JUnitToAssertJRules.FailWithMessage: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#FailWithMessage)
+  Did you mean 'Assertions.fail("checkValue() threw exception on valid value");'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/ValueConstraintTest.java:[41,9] [Refaster Rule] JUnitToAssertJRules.AssertThatWithFailMessageStringIsTrue: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/JUnitToAssertJRules#AssertThatWithFailMessageStringIsTrue)
+  Did you mean 'assertThat(vc.isValid(1)).withFailMessage("rejected valid value!").isTrue();'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/ValueConstraintTest.java:[15,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class ValueConstraintTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/ValueConstraintTest.java:[23,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void nullValueType() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/ValueConstraintTest.java:[28,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void getValueCompliance() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/ValueConstraintTest.java:[39,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void isValid() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/value/ValueConstraintTest.java:[45,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void checkValue() {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/visualizer/IndexedEdgesFromNodesAndEdgesTest.java:[11,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class IndexedEdgesFromNodesAndEdgesTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/visualizer/IndexedEdgesFromNodesAndEdgesTest.java:[13,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void indexedEdgesFromNodesAndEdges() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/visualizer/NodeAndEdgesFromRootProxyTest.java:[40,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class NodeAndEdgesFromRootProxyTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/visualizer/NodeAndEdgesFromRootProxyTest.java:[42,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void nodeAndEdgesFromRootProxy() throws Exception {'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/visualizer/NormalXYDoubleIlmFromGraphTest.java:[142,19] [UnusedVariable] The local variable 'normalXYs1' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or 'NormalXYDoubleIlmFromGraph.create('?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/visualizer/NormalXYDoubleIlmFromGraphTest.java:[155,19] [UnusedVariable] The local variable 'normalXYs2' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or 'NormalXYDoubleIlmFromGraph.create(GraphNodeClassFilter.create(sortedGraph, EventChannelProxy.class));'?
+[[1;33mWARNING[m] /home/pi/git/tfw/src/test/java/tfw/visualizer/NormalXYDoubleIlmFromGraphTest.java:[124,19] [UnusedVariable] The local variable 'normalXYs' is never read.
+    (see https://errorprone.info/bugpattern/UnusedVariable)
+  Did you mean to remove this line or 'NormalXYDoubleIlmFromGraph.create(sortedGraph);'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/visualizer/NormalXYDoubleIlmFromGraphTest.java:[34,1] [JUnitClassModifiers] Non-abstract JUnit test classes should be declared package-private and final
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitClassModifiers)
+  Did you mean 'final class NormalXYDoubleIlmFromGraphTest {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/visualizer/NormalXYDoubleIlmFromGraphTest.java:[37,10] [JUnitMethodDeclaration] JUnit method declaration can likely be improved
+    (see https://error-prone.picnic.tech/bugpatterns/JUnitMethodDeclaration)
+  Did you mean 'void normalXYDoubleIlmFromGraph() throws Exception {'?
+[[1;34mINFO[m] /home/pi/git/tfw/src/test/java/tfw/visualizer/NormalXYDoubleIlmFromGraphTest.java:[35,5] [LexicographicalAnnotationListing] Sort annotations lexicographically where possible
+    (see https://error-prone.picnic.tech/bugpatterns/LexicographicalAnnotationListing)
+  Did you mean '@Disabled'?
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-surefire-plugin:3.5.2:test[m [1m(default-test)[m @ [36mtfw[0;1m ---[m
+[[1;34mINFO[m] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
+[[1;34mINFO[m] 
+[[1;34mINFO[m] -------------------------------------------------------
+[[1;34mINFO[m]  T E S T S
+[[1;34mINFO[m] -------------------------------------------------------
+OpenJDK 64-Bit Server VM warning: Ignoring option --illegal-access=permit; support was removed in 17.0
+[[1;34mINFO[m] ├─ [1mtfw.value.ValueConstraintTest[m - 0.289 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testNullValueType[m - 0.152 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testCheckValue[m - 0.008 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testGetValueCompliance[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testIsValid[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.value.RangeConstraintTest[m - 0.070 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testConstructorMinGreaterThanMax[m - 0.006 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testConstructorMinEqualMaxNeitherInclusive[m - 0.008 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testIsCompatibles[m - 0.004 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testValueCompliance[m - 0.011 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testConstructionNullMaximum[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testConstructionNullMinimum[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.value.NullConstraintTest[m - 0.024 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testIsCompatable[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testgetValueCompliance[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.audio.AuAudioDataTest[m - 0.268 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ muLawAuAudioDataTest[m - 0.245 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ aLawAuAudioDataTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ eightBitLinearAuAudioDataTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.audio.ALawTest[m - 0.078 s
+[[1;34mINFO[m] │  └─ [1;32m✔ alawTest[m - 0.073 s
+[[1;34mINFO[m] ├─ [1mtfw.audio.AuTest[m - 0.014 s
+[[1;34mINFO[m] │  └─ [1;32m✔ auTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.audio.MuLawTest[m - 0.075 s
+[[1;34mINFO[m] │  └─ [1;32m✔ muLawTest[m - 0.068 s
+[[1;34mINFO[m] ├─ [1mtfw.math.SMBigIntegerTest[m - 0.017 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testSMBigIntegerValue[m - 0.011 s
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    ******** Begin transaction: 1 *********
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange      Add/Remove Component
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange        add Component Frame to JTextFieldBBTest
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles    Cycle 0
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      State Changes:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Validators:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Processors:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction           Commit:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    End transaction: 1
+
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    ******** Begin transaction: 2 *********
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange      Add/Remove Component
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange        add Component JTextFieldBB[TestTextField] to Frame
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles    Cycle 0
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      State Changes:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Validators:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Processors:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction           Commit:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    End transaction: 2
+
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    ******** Begin transaction: 3 *********
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange      Add/Remove Component
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange        add Component SetEnabledCommit[TestTextField] to JTextFieldBB[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles    Cycle 0
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      State Changes:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeEventChannelFires        S0 : TextFieldEnabled : true
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Validators:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Processors:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction           Commit:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction             C0 : SetEnabledCommit[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    End transaction: 3
+
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    ******** Begin transaction: 4 *********
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange      Add/Remove Component
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange        add Component TestTextField to JTextFieldBB[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles    Cycle 0
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      State Changes:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Validators:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Processors:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction           Commit:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    End transaction: 4
+
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    ******** Begin transaction: 5 *********
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange      Add/Remove Component
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange        add Component SetTextCommit[TestTextField] to JTextFieldBB[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles    Cycle 0
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      State Changes:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeEventChannelFires        S0 : TextFieldText : 
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Validators:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Processors:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction           Commit:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction             C0 : SetTextCommit[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    End transaction: 5
+
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    ******** Begin transaction: 6 *********
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange      Add/Remove Component
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange        add Component Initiator[TestTextField] to JTextFieldBBTest
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles    Cycle 0
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      State Changes:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Validators:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Processors:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction           Commit:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    End transaction: 6
+
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    ******** Begin transaction: 7 *********
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange      Add/Remove Component
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeComponentChange        add Component TestCommit[TestTextField] to JTextFieldBBTest
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles    Cycle 0
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      State Changes:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeEventChannelFires        S0 : TextFieldEnabled : true
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeEventChannelFires        S1 : TextFieldText : 
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Validators:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Processors:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction           Commit:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction             C0 : TestCommit[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    End transaction: 7
+
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    ******** Begin transaction: 8 *********
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles    Cycle 0
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      State Changes:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeStateChanges             S0 : TestTextField : TextFieldText = WidgetText
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Validators:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Processors:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction           Commit:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction             C0 : TestCommit[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    End transaction: 8
+
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    ******** Begin transaction: 9 *********
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles    Cycle 0
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      State Changes:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeStateChanges             S0 : Initiator[TestTextField] : TextFieldText = InitiatorText
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Validators:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Processors:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction           Commit:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction             C0 : SetTextCommit[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction             C1 : TestCommit[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    End transaction: 9
+
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    ******** Begin transaction: 10 *********
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles    Cycle 0
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      State Changes:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeStateChanges             S0 : TestTextField : TextFieldText = 
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Validators:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Processors:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction           Commit:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction             C0 : TestCommit[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    End transaction: 10
+
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    ******** Begin transaction: 11 *********
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles    Cycle 0
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      State Changes:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeStateChanges             S0 : TestTextField : TextFieldText = InitiatorText
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Validators:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Processors:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction           Commit:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction             C0 : TestCommit[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    End transaction: 11
+
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    ******** Begin transaction: 12 *********
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles    Cycle 0
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      State Changes:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeStateChanges             S0 : Initiator[TestTextField] : TextFieldEnabled = false
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Validators:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionCycles      Processors:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction           Commit:
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction             C0 : SetEnabledCommit[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr commitTransaction             C1 : TestCommit[TestTextField]
+2025-01-07 19:23:58 INFO   tfw.tsm.TransactionMgr executeTransactionHelper    End transaction: 12
+
+[[1;34mINFO[m] ├─ [1mtfw.swing.JTextFieldBBTest[m - 2.715 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testDocumentListener[m - 1.382 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testActionListener[m - 0.171 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testJTextFieldBB[m - 0.697 s
+[[1;34mINFO[m] ├─ [1mtfw.swing.JButtonBBTest[m - 1.321 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testEmptyJButtonBuilder[m - 0.211 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testJButtonBB[m - 1.033 s
+[[1;34mINFO[m] ├─ [1mtfw.swing.event.SetForegroundFactoryTest[m - 0.032 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.014 s
+[[1;34mINFO[m] ├─ [1mtfw.swing.event.SetIconFactoryTest[m - 0.017 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.swing.event.DocumentListenerFactoryTest[m - 0.030 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testArguments[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testStateQueueFactoryNull[m - 0.016 s
+[[1;34mINFO[m] ├─ [1mtfw.swing.event.SetBackgroundFactoryTest[m - 0.019 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.014 s
+[[1;34mINFO[m] ├─ [1mtfw.swing.event.SetFontFactoryTest[m - 0.021 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.swing.event.SetEnabledFactoryTest[m - 0.020 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.012 s
+[[1;34mINFO[m] ├─ [1mtfw.swing.event.SetTextFactoryTest[m - 0.030 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.021 s
+[[1;34mINFO[m] ├─ [1mtfw.swing.event.ActionListenerFactoryTest[m - 0.041 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testStateQueueFactoryNonNull[m - 0.015 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testArguments[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testStateQueueFactoryNull[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.longiis.LongIisFromLongIlaTest[m - 0.051 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ read2Test[m - 0.023 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ readTest[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ skipTest[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.longiis.AbstractLongIisTest[m - 0.028 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ closedTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.010 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.longiis.LongIisFactoryFromLongIlaTest[m - 0.015 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ factoryTest[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.shortiis.ShortIisFromShortIlaTest[m - 0.026 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ read2Test[m - 0.007 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ readTest[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] │  └─ [1;32m✔ skipTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.shortiis.AbstractShortIisTest[m - 0.024 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ closedTest[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.shortiis.ShortIisFactoryFromShortIlaTest[m - 0.019 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ factoryTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.objectiis.ObjectIisFactoryFromObjectIlaTest[m - 0.051 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ factoryTest[m - 0.026 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.objectiis.ObjectIisFromObjectIlaTest[m - 0.027 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ read2Test[m - 0.005 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ readTest[m - 0.004 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] │  └─ [1;32m✔ skipTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.objectiis.AbstractObjectIisTest[m - 0.019 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ closedTest[m - 0.003 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.intiis.IntIisFactoryFromIntIlaTest[m - 0.026 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ factoryTest[m - 0.010 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.intiis.IntIisFromIntIlaTest[m - 0.026 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ read2Test[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ readTest[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ skipTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.intiis.AbstractIntIisTest[m - 0.020 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ closedTest[m - 0.004 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.floatiis.FloatIisFromFloatIlaTest[m - 0.062 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ read2Test[m - 0.040 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ readTest[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ skipTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.floatiis.AbstractFloatIisTest[m - 0.013 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ closedTest[m - 0.003 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.floatiis.FloatIisFactoryFromFloatIlaTest[m - 0.020 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ factoryTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.chariis.AbstractCharIisTest[m - 0.021 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ closedTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.chariis.CharIisFromCharIlaTest[m - 0.028 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ read2Test[m - 0.009 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ readTest[m - 0.002 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ skipTest[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.chariis.CharIisFactoryFromCharIlaTest[m - 0.016 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ factoryTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.bitiis.BitIisFactoryFromBitIlaTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ factoryTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.bitiis.AbstractBitIisTest[m - 0.029 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ closedTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.010 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.bitiis.BitIisFromBitIlaTest[m - 0.036 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ read2Test[m - 0.004 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ readTest[m - 0.007 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ skipTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.doubleiis.DoubleIisFromDoubleIlaTest[m - 0.032 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ read2Test[m - 0.011 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ readTest[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] │  └─ [1;32m✔ skipTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.doubleiis.AbstractDoubleIisTest[m - 0.021 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ closedTest[m - 0.004 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.doubleiis.DoubleIisFactoryFromDoubleIlaTest[m - 0.017 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ factoryTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.booleaniis.AbstractBooleanIisTest[m - 0.017 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ closedTest[m - 0.003 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.booleaniis.BooleanIisFactoryFromBooleanIlaTest[m - 0.025 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ factoryTest[m - 0.010 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.booleaniis.BooleanIisFromBooleanIlaTest[m - 0.028 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ read2Test[m - 0.005 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ readTest[m - 0.004 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ skipTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.byteiis.ByteIisFactoryFromInputStreamFactoryTest[m - 0.019 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ createTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.byteiis.ByteIisFromByteIlaTest[m - 0.028 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ read2Test[m - 0.006 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ readTest[m - 0.004 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ skipTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.byteiis.AbstractByteIisTest[m - 0.021 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ closedTest[m - 0.004 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.byteiis.ByteIisFactoryFromByteIlaTest[m - 0.019 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ factoryTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.iis.byteiis.ByteIisFromInputStreamTest[m - 0.028 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ methodsTest[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ exceptionsTest[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.shortilm.ShortIlmFromArrayTest[m - 0.016 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testShortIlmFromArray[m - 0.012 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.intilm.IntIlmFromArrayTest[m - 0.013 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testIntIlmFromArray[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.doubleilm.InterleavedMagnitudeDoubleIlmTest[m - 0.024 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testInterleavedMagnitudeDoubleIlm[m - 0.019 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.doubleilm.RealFftDoubleIlmTest[m - 0.036 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testRealFftDoubleIlm[m - 0.032 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.doubleilm.MultiplyDoubleIlmTest[m - 0.021 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testMultiplyDoubleIlm[m - 0.018 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.doubleilm.SegmentDoubleIlmTest[m - 0.025 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testSegmentDoubleIlm[m - 0.022 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.doubleilm.DoubleIlmFromArrayTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testDoubleIlmFromArray[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.doubleilm.RowConcatenateDoubleIlmTest[m - 0.017 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testRowConcatenateDoubleIlmTest[m - 0.010 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.doubleilm.TakeSkipDoubleIlmTest[m - 0.018 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testTakeSkipDoubleIlm[m - 0.011 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.doubleilm.ReplicateDoubleIlmTest[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testReplicateDoubleIlm[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.objectilm.ObjectIlmFromArrayTest[m - 0.021 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testObjectIlmFromArray[m - 0.013 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.floatilm.FloatIlmFromArrayTest[m - 0.020 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testFloatIlmFromArray[m - 0.014 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.charilm.CharIlmFromArrayTest[m - 0.017 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testCharIlmFromArray[m - 0.011 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.booleanilm.BooleanIlmFromArrayTest[m - 0.018 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testBooleanIlmFromArray[m - 0.010 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.byteilm.ByteIlmFromArrayTest[m - 0.019 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testByteIlmFromArray[m - 0.012 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ilm.longilm.LongIlmFromArrayTest[m - 0.020 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testLongIlmFromArray[m - 0.015 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.booleanila.BooleanIlaFillTest[m - 0.118 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.080 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.010 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.booleanila.BooleanIlaDecimateTest[m - 0.055 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.031 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.017 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.booleanila.BooleanIlaInterleaveTest[m - 3.569 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 3.556 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.booleanila.BooleanIlaReverseTest[m - 0.035 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.026 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.booleanila.BooleanIlaFromArrayTest[m - 0.094 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ immutabililtyTest[m - 0.021 s
+[[1;34mINFO[m] │  └─ [1;32m✔ valueCorrectnessTest[m - 0.064 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.booleanila.BooleanIlaConcatenateTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.booleanila.BooleanIlaRemoveTest[m - 0.051 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.032 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.013 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.booleanila.BooleanIlaInsertTest[m - 0.062 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.039 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.018 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.booleanila.BooleanIlaSegmentTest[m - 0.629 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.617 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.booleanila.BooleanIlaMutateTest[m - 0.049 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.037 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.booleanila.BooleanIlaIteratorTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ booleanIlaIteratorTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.objectila.ObjectIlaFromArrayTest[m - 0.195 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ immutabililtyTest[m - 0.038 s
+[[1;34mINFO[m] │  └─ [1;32m✔ valueCorrectnessTest[m - 0.146 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.objectila.ObjectIlaMutateTest[m - 0.096 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.077 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.012 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.objectila.ObjectIlaSegmentTest[m - 0.615 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.604 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.objectila.ObjectIlaDecimateTest[m - 0.020 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.013 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.004 s
+2025-01-07 19:24:07 WARNING org.assertj.swing.monitor.ProtectingTimerTask hand Exception thrown by a TimerTask
+java.lang.reflect.InaccessibleObjectException: Unable to make field int java.util.TimerTask.state accessible: module java.base does not "opens java.util" to unnamed module @34521b60
+	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
+	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
+	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
+	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles$SetAccessibleAction.run(Accessibles.java:70)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles$SetAccessibleAction.run(Accessibles.java:60)
+	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles.setAccessible(Accessibles.java:57)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles.makeAccessible(Accessibles.java:46)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.verifyCorrectType(Invoker.java:98)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.createInvoker(Invoker.java:74)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.newInvoker(Invoker.java:68)
+	at org.assertj.swing.dependency.fest_reflect.field.FieldType.in(FieldType.java:74)
+	at org.assertj.swing.monitor.ProtectingTimerTask.isCanceled(ProtectingTimerTask.java:54)
+	at org.assertj.swing.monitor.ProtectingTimerTask.run(ProtectingTimerTask.java:41)
+	at java.base/java.util.TimerThread.mainLoop(Timer.java:566)
+	at java.base/java.util.TimerThread.run(Timer.java:516)
+
+2025-01-07 19:24:07 WARNING org.assertj.swing.monitor.ProtectingTimerTask hand Exception thrown by a TimerTask
+java.lang.reflect.InaccessibleObjectException: Unable to make field int java.util.TimerTask.state accessible: module java.base does not "opens java.util" to unnamed module @34521b60
+	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
+	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
+	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
+	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles$SetAccessibleAction.run(Accessibles.java:70)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles$SetAccessibleAction.run(Accessibles.java:60)
+	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles.setAccessible(Accessibles.java:57)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles.makeAccessible(Accessibles.java:46)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.verifyCorrectType(Invoker.java:98)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.createInvoker(Invoker.java:74)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.newInvoker(Invoker.java:68)
+	at org.assertj.swing.dependency.fest_reflect.field.FieldType.in(FieldType.java:74)
+	at org.assertj.swing.monitor.ProtectingTimerTask.isCanceled(ProtectingTimerTask.java:54)
+	at org.assertj.swing.monitor.ProtectingTimerTask.run(ProtectingTimerTask.java:41)
+	at java.base/java.util.TimerThread.mainLoop(Timer.java:566)
+	at java.base/java.util.TimerThread.run(Timer.java:516)
+
+2025-01-07 19:24:08 WARNING org.assertj.swing.monitor.ProtectingTimerTask hand Exception thrown by a TimerTask
+java.lang.reflect.InaccessibleObjectException: Unable to make field int java.util.TimerTask.state accessible: module java.base does not "opens java.util" to unnamed module @34521b60
+	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
+	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
+	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
+	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles$SetAccessibleAction.run(Accessibles.java:70)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles$SetAccessibleAction.run(Accessibles.java:60)
+	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles.setAccessible(Accessibles.java:57)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles.makeAccessible(Accessibles.java:46)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.verifyCorrectType(Invoker.java:98)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.createInvoker(Invoker.java:74)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.newInvoker(Invoker.java:68)
+	at org.assertj.swing.dependency.fest_reflect.field.FieldType.in(FieldType.java:74)
+	at org.assertj.swing.monitor.ProtectingTimerTask.isCanceled(ProtectingTimerTask.java:54)
+	at org.assertj.swing.monitor.ProtectingTimerTask.run(ProtectingTimerTask.java:41)
+	at java.base/java.util.TimerThread.mainLoop(Timer.java:566)
+	at java.base/java.util.TimerThread.run(Timer.java:516)
+
+2025-01-07 19:24:08 WARNING org.assertj.swing.monitor.ProtectingTimerTask hand Exception thrown by a TimerTask
+java.lang.reflect.InaccessibleObjectException: Unable to make field int java.util.TimerTask.state accessible: module java.base does not "opens java.util" to unnamed module @34521b60
+	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
+	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
+	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
+	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles$SetAccessibleAction.run(Accessibles.java:70)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles$SetAccessibleAction.run(Accessibles.java:60)
+	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles.setAccessible(Accessibles.java:57)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles.makeAccessible(Accessibles.java:46)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.verifyCorrectType(Invoker.java:98)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.createInvoker(Invoker.java:74)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.newInvoker(Invoker.java:68)
+	at org.assertj.swing.dependency.fest_reflect.field.FieldType.in(FieldType.java:74)
+	at org.assertj.swing.monitor.ProtectingTimerTask.isCanceled(ProtectingTimerTask.java:54)
+	at org.assertj.swing.monitor.ProtectingTimerTask.run(ProtectingTimerTask.java:41)
+	at java.base/java.util.TimerThread.mainLoop(Timer.java:566)
+	at java.base/java.util.TimerThread.run(Timer.java:516)
+
+2025-01-07 19:24:09 WARNING org.assertj.swing.monitor.ProtectingTimerTask hand Exception thrown by a TimerTask
+java.lang.reflect.InaccessibleObjectException: Unable to make field int java.util.TimerTask.state accessible: module java.base does not "opens java.util" to unnamed module @34521b60
+	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
+	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
+	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
+	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles$SetAccessibleAction.run(Accessibles.java:70)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles$SetAccessibleAction.run(Accessibles.java:60)
+	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles.setAccessible(Accessibles.java:57)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles.makeAccessible(Accessibles.java:46)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.verifyCorrectType(Invoker.java:98)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.createInvoker(Invoker.java:74)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.newInvoker(Invoker.java:68)
+	at org.assertj.swing.dependency.fest_reflect.field.FieldType.in(FieldType.java:74)
+	at org.assertj.swing.monitor.ProtectingTimerTask.isCanceled(ProtectingTimerTask.java:54)
+	at org.assertj.swing.monitor.ProtectingTimerTask.run(ProtectingTimerTask.java:41)
+	at java.base/java.util.TimerThread.mainLoop(Timer.java:566)
+	at java.base/java.util.TimerThread.run(Timer.java:516)
+
+2025-01-07 19:24:09 WARNING org.assertj.swing.monitor.ProtectingTimerTask hand Exception thrown by a TimerTask
+java.lang.reflect.InaccessibleObjectException: Unable to make field int java.util.TimerTask.state accessible: module java.base does not "opens java.util" to unnamed module @34521b60
+	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
+	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
+	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
+	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles$SetAccessibleAction.run(Accessibles.java:70)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles$SetAccessibleAction.run(Accessibles.java:60)
+	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles.setAccessible(Accessibles.java:57)
+	at org.assertj.swing.dependency.fest_reflect.util.Accessibles.makeAccessible(Accessibles.java:46)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.verifyCorrectType(Invoker.java:98)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.createInvoker(Invoker.java:74)
+	at org.assertj.swing.dependency.fest_reflect.field.Invoker.newInvoker(Invoker.java:68)
+	at org.assertj.swing.dependency.fest_reflect.field.FieldType.in(FieldType.java:74)
+	at org.assertj.swing.monitor.ProtectingTimerTask.isCanceled(ProtectingTimerTask.java:54)
+	at org.assertj.swing.monitor.ProtectingTimerTask.run(ProtectingTimerTask.java:41)
+	at java.base/java.util.TimerThread.mainLoop(Timer.java:566)
+	at java.base/java.util.TimerThread.run(Timer.java:516)
+
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.objectila.ObjectIlaInterleaveTest[m - 4.234 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 4.224 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.objectila.ObjectIlaUtilTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testToArrayTwoArgs[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.objectila.ObjectIlaFillTest[m - 0.016 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.objectila.ObjectIlaRemoveTest[m - 0.047 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.037 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.objectila.ObjectIlaConcatenateTest[m - 0.017 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.objectila.ObjectIlaIteratorTest[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testObjectIlaFill[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.objectila.ObjectIlaInsertTest[m - 0.050 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.040 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.objectila.ObjectIlaReverseTest[m - 0.034 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.023 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaReverseTest[m - 0.098 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.087 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaBoundTest[m - 0.021 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaMultiplyTest[m - 0.029 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.016 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaScalarMultiplyTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaFromCastDoubleIlaTest[m - 0.030 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.018 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaIteratorTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testLongIlaFill[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaScalarAddTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaDivideTest[m - 0.052 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.018 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.015 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaMutateTest[m - 0.095 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.058 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.017 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaRampTest[m - 0.262 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.249 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaNegateTest[m - 0.018 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaFromCastFloatIlaTest[m - 0.039 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.027 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaFromCastShortIlaTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.013 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaSegmentTest[m - 2.868 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 2.856 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaFromCastIntIlaTest[m - 0.038 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.029 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaRemoveTest[m - 0.039 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.028 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaFromArrayTest[m - 0.140 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ immutabililtyTest[m - 0.013 s
+[[1;34mINFO[m] │  └─ [1;32m✔ valueCorrectnessTest[m - 0.117 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaInsertTest[m - 0.040 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.029 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaInterleaveTest[m - 7.578 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 7.564 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaAddTest[m - 0.032 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaFromCastByteIlaTest[m - 0.023 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.013 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaConcatenateTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaSubtractTest[m - 0.025 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.012 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaDecimateTest[m - 0.029 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.015 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaFromCastCharIlaTest[m - 0.030 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.020 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.longila.LongIlaFillTest[m - 0.015 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaReverseTest[m - 0.075 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.066 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaConcatenateTest[m - 0.020 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaBoundTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaDivideTest[m - 0.028 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.015 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaRemoveTest[m - 0.060 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.046 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaFromLongIlaTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testDoubleIlaFromLongIla[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaAddTest[m - 0.034 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.018 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaIteratorTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testDoubleIlaFill[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaRampTest[m - 0.342 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.316 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.020 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaFromCastByteIlaTest[m - 0.030 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaNegateTest[m - 0.025 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.011 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaFromCastCharIlaTest[m - 0.021 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaMultiplyTest[m - 0.037 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.018 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.012 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaSegmentTest[m - 3.731 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 3.719 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaFromCastIntIlaTest[m - 0.015 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaDecimateTest[m - 0.027 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.014 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.010 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaSubtractTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.012 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaMutateTest[m - 0.058 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.033 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.021 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaFromCastLongIlaTest[m - 0.014 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaRoundTest[m - 0.010 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaInterleaveTest[m - 7.463 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 7.451 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaFromCastFloatIlaTest[m - 0.013 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaInsertTest[m - 0.029 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.021 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaFromArrayTest[m - 0.118 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ immutabililtyTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ valueCorrectnessTest[m - 0.101 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaScalarMultiplyTest[m - 0.012 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.004 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaScalarAddTest[m - 0.012 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaFillTest[m - 0.013 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaInvertTest[m - 0.013 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.doubleila.DoubleIlaFromCastShortIlaTest[m - 0.013 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaRemoveTest[m - 0.062 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.051 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaFromCastDoubleIlaTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.012 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaFromCastFloatIlaTest[m - 0.023 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaFromCastIntIlaTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaInterleaveTest[m - 3.745 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 3.736 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaConcatenateTest[m - 0.012 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaDecimateTest[m - 0.021 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaSegmentTest[m - 2.053 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 2.041 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaScalarAddTest[m - 0.015 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaIteratorTest[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testCharIlaFill[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaNegateTest[m - 0.016 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaSubtractTest[m - 0.023 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.013 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaAddTest[m - 0.021 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaFromCastByteIlaTest[m - 0.017 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaFromUtf8ByteIlaTest[m - 0.492 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testCharIlaFromUTF8ByteIla[m - 0.491 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaFromCastShortIlaTest[m - 0.018 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaMultiplyTest[m - 0.021 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaRampTest[m - 0.153 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.143 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaDivideTest[m - 0.023 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaReverseTest[m - 0.030 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.019 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaFillTest[m - 0.019 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaScalarMultiplyTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaInsertTest[m - 0.050 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.035 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaMutateTest[m - 0.045 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.033 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaBoundTest[m - 0.020 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaFromCastLongIlaTest[m - 0.026 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.012 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.charila.CharIlaFromArrayTest[m - 0.124 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ immutabililtyTest[m - 0.015 s
+[[1;34mINFO[m] │  └─ [1;32m✔ valueCorrectnessTest[m - 0.091 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.bitila.BitIlaReverseTest[m - 0.046 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ getArgumentsTest[m - 0.020 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ reverseArgumentsTest[m - 0.010 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ lengthTest[m - 0.002 s
+[[1;34mINFO[m] │  └─ [1;32m✔ createArgumentsTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.bitila.BitIlaNotTest[m - 0.029 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ getArgumentsTest[m - 0.006 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ lengthTest[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ createArgumentsTest[m - 0.004 s
+[[1;34mINFO[m] │  └─ [1;32m✔ notArgumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.bitila.BitIlaOrTest[m - 0.038 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ orArgumentsTest[m - 0.016 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ getArgumentsTest[m - 0.005 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ lengthTest[m - 0.002 s
+[[1;34mINFO[m] │  └─ [1;32m✔ createArgumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.bitila.BitIlaFromLongIlaTest[m - 44.46 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ getArgumentsTest[m - 0.004 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ exhaustiveTest[m - 44.44 s
+[[1;34mINFO[m] │  └─ [1;32m✔ createArgumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.bitila.BitIlaSegmentTest[m - 0.014 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ getArgumentsTest[m - 0.004 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ lengthTest[m - 0.002 s
+[[1;34mINFO[m] │  └─ [1;32m✔ createArgumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.bitila.BitIlaAndTest[m - 0.034 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ oneTest[m - 0.004 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ getArgumentsTest[m - 0.010 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ lengthTest[m - 0.002 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ createArgumentsTest[m - 0.004 s
+[[1;34mINFO[m] │  └─ [1;32m✔ andArgumentsTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.bitila.BitIlaXorTest[m - 0.040 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ getArgumentsTest[m - 0.005 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ lengthTest[m - 0.014 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ createArgumentsTest[m - 0.004 s
+[[1;34mINFO[m] │  └─ [1;32m✔ xorArgumentsTest[m - 0.011 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.bitila.BitIlaFillTest[m - 0.024 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ getArgumentsTest[m - 0.005 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ fillArgumentsTest[m - 0.006 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ lengthTest[m - 0.003 s
+[[1;34mINFO[m] │  └─ [1;32m✔ createArgumentsTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.bitila.LongIlaFromBitIlaTest[m - 0.018 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ getArgumentsTest[m - 0.006 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ lengthTest[m - 0.002 s
+[[1;34mINFO[m] │  └─ [1;32m✔ createArgumentsTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.bitila.BitIlaFindTest[m - 0.033 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ bitIlaFindInvalidParametersTest[m - 0.016 s
+[[1;34mINFO[m] │  └─ [1;32m✔ bitArrayFindInvalidParametersTest[m - 0.012 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.bitila.BitIlaConcatenateTest[m - 0.024 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ getArgumentsTest[m - 0.005 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ lengthTest[m - 0.002 s
+[[1;34mINFO[m] │  └─ [1;32m✔ createArgumentsTest[m - 0.011 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.bitila.BItIlaUtilTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ getPartialLongArgumentsTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaFromCastDoubleIlaTest[m - 0.056 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.033 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaRemoveTest[m - 0.076 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.058 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.010 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaFromCastIntIlaTest[m - 0.023 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.012 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaInsertTest[m - 0.084 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.059 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.020 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaFromCastFloatIlaTest[m - 0.024 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.012 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaRampTest[m - 0.177 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.165 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaDivideTest[m - 0.032 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.014 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.011 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaMutateTest[m - 0.067 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.049 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaScalarMultiplyTest[m - 0.023 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaIteratorTest[m - 0.033 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testShortIlaFill[m - 0.020 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaDecimateTest[m - 0.073 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.043 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.024 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaSegmentTest[m - 1.885 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 1.869 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.010 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaInterleaveTest[m - 3.393 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 3.385 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaSubtractTest[m - 0.015 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaFillTest[m - 0.010 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaNegateTest[m - 0.011 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaFromCastByteIlaTest[m - 0.015 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaFromCastCharIlaTest[m - 0.015 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaFromCastLongIlaTest[m - 0.016 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaAddTest[m - 0.020 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaReverseTest[m - 0.025 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.016 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaScalarAddTest[m - 0.014 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaMultiplyTest[m - 0.019 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaConcatenateTest[m - 0.028 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaBoundTest[m - 0.018 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.shortila.ShortIlaFromArrayTest[m - 0.087 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ immutabililtyTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ valueCorrectnessTest[m - 0.068 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.ImmutableLongArrayUtilTest[m - 0.019 s
+[[1;34mINFO[m] │  └─ [1;32m✔ boundsCheckTest[m - 0.016 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaScalarMultiplyTest[m - 0.039 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.030 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaSubtractTest[m - 0.032 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.018 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaMutateTest[m - 0.069 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.053 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.011 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaRemoveTest[m - 0.065 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.049 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.010 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaReverseTest[m - 0.054 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.041 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaMultiplyTest[m - 0.030 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.013 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.011 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaFromCastDoubleIlaTest[m - 0.024 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaFromCastByteIlaTest[m - 0.025 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaSegmentTest[m - 2.223 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 2.210 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaIteratorTest[m - 0.004 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testIntIlaFill[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaFromCastCharIlaTest[m - 0.013 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaInsertTest[m - 0.034 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.025 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaDivideTest[m - 0.020 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaFromCastShortIlaTest[m - 0.016 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaDecimateTest[m - 0.021 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.012 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaRampTest[m - 0.118 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.109 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaScalarAddTest[m - 0.017 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaFromCastLongIlaTest[m - 0.027 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.017 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaFromCastFloatIlaTest[m - 0.041 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.020 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.017 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaAddTest[m - 0.041 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.023 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.012 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaNegateTest[m - 0.020 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaBoundTest[m - 0.021 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaFromArrayTest[m - 0.221 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ immutabililtyTest[m - 0.020 s
+[[1;34mINFO[m] │  └─ [1;32m✔ valueCorrectnessTest[m - 0.189 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaInterleaveTest[m - 4.697 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 4.686 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaConcatenateTest[m - 0.012 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.intila.IntIlaFillTest[m - 0.010 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaBoundTest[m - 0.038 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.029 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaInvertTest[m - 0.018 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaRampTest[m - 0.258 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.245 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaAddTest[m - 0.025 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaInterleaveTest[m - 4.389 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 4.377 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaInsertTest[m - 0.057 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.033 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.019 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaFromCastLongIlaTest[m - 0.017 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaFillTest[m - 0.014 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaFromArrayTest[m - 0.092 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ immutabililtyTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ valueCorrectnessTest[m - 0.073 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaScalarMultiplyTest[m - 0.017 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaDivideTest[m - 0.026 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.011 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaConcatenateTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaReverseTest[m - 0.050 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.038 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaSubtractTest[m - 0.023 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.012 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaDecimateTest[m - 0.027 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.013 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaMutateTest[m - 0.040 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.030 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaFromCastByteIlaTest[m - 0.017 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaScalarAddTest[m - 0.016 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaRemoveTest[m - 0.035 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.024 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaFromCastIntIlaTest[m - 0.023 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaFromCastDoubleIlaTest[m - 0.020 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaFromCastCharIlaTest[m - 0.027 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaSegmentTest[m - 1.784 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 1.771 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaIteratorTest[m - 0.003 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testFloatIlaFill[m - 0.001 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaMultiplyTest[m - 0.022 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaRoundTest[m - 0.023 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.015 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaNegateTest[m - 0.013 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.floatila.FloatIlaFromCastShortIlaTest[m - 0.017 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaSubtractTest[m - 0.035 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.025 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaRampTest[m - 0.159 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.150 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaFromCastLongIlaTest[m - 0.028 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.013 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaInsertTest[m - 0.116 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.066 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.011 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaFromArrayTest[m - 0.081 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ immutabililtyTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ valueCorrectnessTest[m - 0.057 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaIteratorTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testByteIlaFill[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaFromIntIlaTest[m - 0.836 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testByteIlaFromIntIla[m - 0.832 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaRemoveTest[m - 0.037 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.028 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaInterleaveTest[m - 2.151 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 2.142 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaDivideTest[m - 0.014 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaReverseTest[m - 0.023 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.015 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaSwapTest[m - 1.783 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testByteIlaFromLongIla[m - 1.780 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaNegateTest[m - 0.012 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaConcatenateTest[m - 0.014 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaAddTest[m - 0.019 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaFromCastIntIlaTest[m - 0.018 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaMutateTest[m - 0.036 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.026 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaSegmentTest[m - 0.951 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.941 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaFromCastDoubleIlaTest[m - 0.013 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaMultiplyTest[m - 0.019 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaBoundTest[m - 0.015 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaScalarAddTest[m - 0.013 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaFromLongIlaTest[m - 0.640 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testByteIlaFromLongIla[m - 0.638 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaScalarMultiplyTest[m - 0.016 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaFromCastShortIlaTest[m - 0.017 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAll[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testArguments[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaFromCastCharIlaTest[m - 0.017 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaFillTest[m - 0.013 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaFromCastFloatIlaTest[m - 0.021 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.immutable.ila.byteila.ByteIlaDecimateTest[m - 0.028 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ allTest[m - 0.015 s
+[[1;34mINFO[m] │  └─ [1;32m✔ argumentsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.visualizer.NormalXYDoubleIlmFromGraphTest[m - 0.016 s
+[[1;34mINFO[m] │  └─ [1;33m↷ testNormalXYDoubleIlmFromGraph[0;1;33m (void tfw.visualizer.NormalXYDoubleIlmFromGraphTest.testNormalXYDoubleIlmFromGraph() throws java.lang.Exception is @Disabled)[m - 0 s
+[[1;34mINFO[m] ├─ [1mtfw.visualizer.NodeAndEdgesFromRootProxyTest[m - 0.471 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testNodeAndEdgesFromRootProxy[m - 0.467 s
+[[1;34mINFO[m] ├─ [1mtfw.visualizer.IndexedEdgesFromNodesAndEdgesTest[m - 0.057 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testIndexedEdgesFromNodesAndEdges[m - 0.042 s
+[[1;34mINFO[m] ├─ [1mtfw.array.ArrayUtilTest[m - 0.011 s
+[[1;34mINFO[m] │  └─ [1;32m✔ unorderedEqualsTest[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.component.TriggerRelayTest[m - 0.014 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testTriggerRelay[m - 0.011 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.BasicTransactionQueueTest[m - 0.539 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAdd[m - 0.001 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAddNWait[m - 0.504 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testInvokeAndWait[m - 0.029 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.PortTerminationTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testUnTerminatedPort[m - 0.006 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.ConverterTest[m - 0.017 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testConverter[m - 0.013 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testConstructor[m - 0.001 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.MultiplexedBranchFactoryTest[m - 0.007 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testAddMultiplexer[m - 0.002 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testCreate[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.SynchronizerTest[m - 0.006 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testConstruction[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.ecd.EventChannelDescriptionTest[m - 0.006 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testConstruction[m - 0.002 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testEquals[m - 0.001 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.MultiplexerSynchronizerTest[m - 0.003 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testMultiplexedSynchronizer[m - 0.001 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.DefaultStateQueueFactoryTest[m - 0.003 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testCreate[m - 0.001 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.TranslatorTest[m - 0.023 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testTranslation[m - 0.021 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.ImportExportTreeStateTest[m - 0.031 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testDefaultExportTreeState[m - 0.020 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testCustomTagExportImportTreeState[m - 0.009 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.ValidatorTest[m - 0.031 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testConstruction[m - 0.003 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testValidator[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testTriggeredValidation[m - 0.014 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.MultiplexerConstructionTest[m - 0.020 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testDynamicConstruction[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testNameSpaceSeparation[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.TriggeredConverterTest[m - 0.015 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testConverter[m - 0.012 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.EventChannelStateTest[m - 0.005 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testEventChannelState[m - 0.002 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testEquals[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.OneDeepStateQueueFactoryTest[m - 0.003 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testFactory[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.InfiniteLoopTest[m - 0.067 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testInfiniteLoop[m - 0.065 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.TreeStateBufferTest[m - 0.005 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testBuffer[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.BranchFactoryTest[m - 0.007 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testFactory[m - 0.004 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.GetPreviousStateTest[m - 0.015 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testIsStateChanged[m - 0.012 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.DifferentObjectRuleTest[m - 0.004 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testIsChange[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.TreeStateTest[m - 0.003 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testEquals[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.RollbackTest[m - 0.058 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testMultiValueRollback[m - 0.011 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testSimpleRollback[m - 0.014 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testConverter[m - 0.012 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testDaisyChainedMultiCycleRollback[m - 0.010 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testRollbackArguments[m - 0.003 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.MultiplexerTest[m - 0.063 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testMultiLayerMultiplexing[m - 0.012 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testMultipleMultiplexers[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testMultiplexerWithIntermediateBranch[m - 0.035 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.SetStateTest[m - 0.015 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testDoubleSet[m - 0.013 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.InitiatorTest[m - 0.028 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testInitatorSetMehtods[m - 0.023 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testInitiatorConstruction[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.StateLessECDTest[m - 0.009 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testGetState[m - 0.007 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.StateChangeCycleDelayTest[m - 0.048 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testTwoStage[m - 0.010 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testDirectIndirectDependency[m - 0.008 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testThreeWayDependency[m - 0.008 s
+[[1;34mINFO[m] │  ├─ [1;32m✔ testCircularDependency[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testIndirectDependency[m - 0.008 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.DotEqualsRuleTest[m - 0.004 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testIsChange[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.RootTest[m - 0.003 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testIsRooted[m - 0.002 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.CascadeTest[m - 0.008 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testConverter[m - 0.005 s
+[[1;34mINFO[m] ├─ [1mtfw.tsm.CommitTest[m - 0.019 s
+[[1;34mINFO[m] │  └─ [1;32m✔ testTriggerBehavior[m - 0.015 s
+[[1;34mINFO[m] 
+[[1;34mINFO[m] Results:
+[[1;34mINFO[m] 
+[[1;33mWARNING[m] [1;33mTests run: 656, Failures: 0, Errors: 0, Skipped: 1[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-jar-plugin:2.4:jar[m [1m(default-jar)[m @ [36mtfw[0;1m ---[m
+[[1;34mINFO[m] Building jar: /home/pi/git/tfw/target/tfw-2024.5-SNAPSHOT.jar
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-javadoc-plugin:3.11.2:jar[m [1m(attach-javadocs)[m @ [36mtfw[0;1m ---[m
+[[1;34mINFO[m] No previous run data found, generating javadoc.
+[[1;34mINFO[m] Building jar: /home/pi/git/tfw/target/tfw-2024.5-SNAPSHOT-javadoc.jar
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-source-plugin:3.3.1:jar-no-fork[m [1m(attach-sources)[m @ [36mtfw[0;1m ---[m
+[[1;34mINFO[m] Building jar: /home/pi/git/tfw/target/tfw-2024.5-SNAPSHOT-sources.jar
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mspotless-maven-plugin:2.43.0:check[m [1m(default)[m @ [36mtfw[0;1m ---[m
+[[1;34mINFO[m] Index file does not exist. Fallback to an empty index
+[[1;34mINFO[m] Spotless.Java is keeping 1119 files clean - 0 needs changes to be clean, 1119 were already clean, 0 were skipped because caching determined they were already clean
+[[1;34mINFO[m] Sorting file /tmp/pom7064324325587830167.xml
+[[1;34mINFO[m] Pom file is already sorted, exiting
+[[1;34mINFO[m] Spotless.Pom is keeping 1 files clean - 0 needs changes to be clean, 1 were already clean, 0 were skipped because caching determined they were already clean
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m>>> [0;32mmaven-pmd-plugin:3.26.0:check[m [1m(default)[0;1m > [0;1m:pmd[m @ [36mtfw[0;1m >>>[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-pmd-plugin:3.26.0:pmd[m [1m(pmd)[m @ [36mtfw[0;1m ---[m
+[[1;34mINFO[m] PMD version: 7.7.0
+[[1;34mINFO[m] Rendering content with [1morg.apache.maven.skins:maven-fluido-skin:jar:2.0.0-M9 skin[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m<<< [0;32mmaven-pmd-plugin:3.26.0:check[m [1m(default)[0;1m < [0;1m:pmd[m @ [36mtfw[0;1m <<<[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-pmd-plugin:3.26.0:check[m [1m(default)[m @ [36mtfw[0;1m ---[m
+[[1;33mWARNING[m] PMD 7.7.0 has issued 76 warnings. For more details see: /home/pi/git/tfw/target/pmd.xml
+[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
+[[1;34mINFO[m] [1;32mBUILD SUCCESS[m
+[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
+[[1;34mINFO[m] Total time:  12:58 min
+[[1;34mINFO[m] Finished at: 2025-01-07T19:28:13-05:00
+[[1;34mINFO[m] [1m------------------------------------------------------------------------[m

--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java
@@ -32,13 +32,13 @@ public final class BooleanIlaCheck {
                 .hasMessage("offset (=10) >= array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);
         assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);
     }
 
     public static void checkGetExhaustively(BooleanIla ila1, BooleanIla ila2) throws IOException {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaCheck.java
@@ -32,13 +32,13 @@ public final class ByteIlaCheck {
                 .hasMessage("offset (=10) >= array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);
         assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);
     }
 
     public static void checkGetExhaustively(final ByteIla ila1, final ByteIla ila2) throws IOException {

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-class ByteIlaFromCastIntIlaTest {
+final class ByteIlaFromCastIntIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final IntIla ila = IntIlaFromArray.create(new int[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaFromCastIntIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaFromCastIntIla.create(ila, 0));
+        assertThatThrownBy(() -> ByteIlaFromCastIntIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaFromCastIntIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] array = new int[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-class ByteIlaFromCastLongIlaTest {
+final class ByteIlaFromCastLongIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final LongIla ila = LongIlaFromArray.create(new long[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaFromCastLongIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaFromCastLongIla.create(ila, 0));
+        assertThatThrownBy(() -> ByteIlaFromCastLongIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaFromCastLongIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] array = new long[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-class ByteIlaFromCastShortIlaTest {
+final class ByteIlaFromCastShortIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ShortIla ila = ShortIlaFromArray.create(new short[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaFromCastShortIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaFromCastShortIla.create(ila, 0));
+        assertThatThrownBy(() -> ByteIlaFromCastShortIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaFromCastShortIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] array = new short[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromIntIlaTest.java
@@ -1,15 +1,15 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-class ByteIlaFromIntIlaTest {
+final class ByteIlaFromIntIlaTest {
     @Test
-    void testByteIlaFromIntIla() throws Exception {
+    void byteIlaFromIntIlaTest() throws Exception {
         byte[] byteArray = new byte[] {
             (byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03,
             (byte) 0x04, (byte) 0x05, (byte) 0x06, (byte) 0x07,
@@ -33,10 +33,9 @@ class ByteIlaFromIntIlaTest {
         ByteIla targetIla = ByteIlaFromArray.create(byteArray);
         IntIla intIla = IntIlaFromArray.create(intArray);
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> ByteIlaFromIntIla.create(null, 100),
-                "ilm == null not checked for!");
+        assertThatThrownBy(() -> ByteIlaFromIntIla.create(null, 100))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIla == null not allowed!");
 
         ByteIla actualIla = ByteIlaFromIntIla.create(intIla, 100);
         final byte epsilon = (byte) 0;

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaFromLongIlaTest.java
@@ -1,15 +1,15 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-class ByteIlaFromLongIlaTest {
+final class ByteIlaFromLongIlaTest {
     @Test
-    void testByteIlaFromLongIla() throws Exception {
+    void byteIlaFromLongIlaTest() throws Exception {
         byte[] byteArray = new byte[] {
             (byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03,
             (byte) 0x04, (byte) 0x05, (byte) 0x06, (byte) 0x07,
@@ -33,10 +33,9 @@ class ByteIlaFromLongIlaTest {
         ByteIla targetIla = ByteIlaFromArray.create(byteArray);
         LongIla longIla = LongIlaFromArray.create(longArray);
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> ByteIlaFromLongIla.create(null, 100),
-                "ilm == null not checked for!");
+        assertThatThrownBy(() -> ByteIlaFromLongIla.create(null, 100))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIla == null not allowed!");
 
         ByteIla actualIla = ByteIlaFromLongIla.create(longIla, 100);
         final byte epsilon = (byte) 0;

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaIteratorTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaIteratorTest.java
@@ -1,15 +1,14 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-class ByteIlaIteratorTest {
+final class ByteIlaIteratorTest {
     @Test
-    void testByteIlaFill() throws IOException {
+    void byteIlaIteratorTest() throws IOException {
         final Random random = new Random();
         final int LENGTH = 29;
         byte[] array = new byte[LENGTH];
@@ -23,14 +22,10 @@ class ByteIlaIteratorTest {
 
         int i = 0;
         for (; ii.hasNext(); i++) {
-            if (i == array.length) {
-                fail("Iterator did not stop correctly");
-            }
-            assertEquals(ii.next(), array[i], "element " + i + " not equal!");
+            assertThat(i).isNotEqualTo(array.length);
+            assertThat(ii.next()).isEqualTo(array[i]);
         }
 
-        if (i != array.length) {
-            fail("Iterator stopped at " + i + " not " + array.length);
-        }
+        assertThat(i).isEqualTo(array.length);
     }
 }

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaMultiplyTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaMultiplyTest {
+final class ByteIlaMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ByteIla ila1 = ByteIlaFromArray.create(new byte[10]);
         final ByteIla ila2 = ByteIlaFromArray.create(new byte[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaMultiply.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaMultiply.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaMultiply.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaMultiply.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> ByteIlaMultiply.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaMultiply.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaMultiply.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> ByteIlaMultiply.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] leftArray = new byte[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaNegateTest.java
@@ -1,19 +1,21 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaNegateTest {
+final class ByteIlaNegateTest {
     @Test
-    void testArguments() {
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaNegate.create(null));
+    void argumentsTest() {
+        assertThatThrownBy(() -> ByteIlaNegate.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] array = new byte[length];

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaRampTest.java
@@ -1,23 +1,25 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaRampTest {
+final class ByteIlaRampTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final byte start = (byte) random.nextInt();
         final byte increment = (byte) random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaRamp.create(start, increment, -1));
+        assertThatThrownBy(() -> ByteIlaRamp.create(start, increment, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final byte startValue = (byte) random.nextInt();
         final byte increment = (byte) random.nextInt();

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarAddTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaScalarAddTest {
+final class ByteIlaScalarAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final byte value = (byte) random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaScalarAdd.create(null, value));
+        assertThatThrownBy(() -> ByteIlaScalarAdd.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte scalar = (byte) random.nextInt();

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaScalarMultiplyTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaScalarMultiplyTest {
+final class ByteIlaScalarMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final byte value = (byte) random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaScalarMultiply.create(null, value));
+        assertThatThrownBy(() -> ByteIlaScalarMultiply.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte scalar = (byte) random.nextInt();

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaSubtractTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaSubtractTest {
+final class ByteIlaSubtractTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ByteIla ila1 = ByteIlaFromArray.create(new byte[10]);
         final ByteIla ila2 = ByteIlaFromArray.create(new byte[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaSubtract.create(null, ila1, 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaSubtract.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaSubtract.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> ByteIlaSubtract.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> ByteIlaSubtract.create(null, ila1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaSubtract.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaSubtract.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> ByteIlaSubtract.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final byte[] leftArray = new byte[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaCheck.java
@@ -32,13 +32,13 @@ public final class CharIlaCheck {
                 .hasMessage("offset (=10) >= array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);
         assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);
     }
 
     public static void checkGetExhaustively(final CharIla ila1, final CharIla ila2) throws IOException {

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastIntIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-class CharIlaFromCastIntIlaTest {
+final class CharIlaFromCastIntIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final IntIla ila = IntIlaFromArray.create(new int[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaFromCastIntIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaFromCastIntIla.create(ila, 0));
+        assertThatThrownBy(() -> CharIlaFromCastIntIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaFromCastIntIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] array = new int[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastLongIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-class CharIlaFromCastLongIlaTest {
+final class CharIlaFromCastLongIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final LongIla ila = LongIlaFromArray.create(new long[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaFromCastLongIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaFromCastLongIla.create(ila, 0));
+        assertThatThrownBy(() -> CharIlaFromCastLongIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaFromCastLongIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] array = new long[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastShortIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromCastShortIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-class CharIlaFromCastShortIlaTest {
+final class CharIlaFromCastShortIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ShortIla ila = ShortIlaFromArray.create(new short[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaFromCastShortIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaFromCastShortIla.create(ila, 0));
+        assertThatThrownBy(() -> CharIlaFromCastShortIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaFromCastShortIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] array = new short[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaMultiplyTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaMultiplyTest {
+final class CharIlaMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final CharIla ila1 = CharIlaFromArray.create(new char[10]);
         final CharIla ila2 = CharIlaFromArray.create(new char[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaMultiply.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaMultiply.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaMultiply.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaMultiply.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> CharIlaMultiply.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaMultiply.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaMultiply.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> CharIlaMultiply.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] leftArray = new char[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaNegateTest.java
@@ -1,19 +1,21 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaNegateTest {
+final class CharIlaNegateTest {
     @Test
-    void testArguments() {
-        assertThrows(IllegalArgumentException.class, () -> CharIlaNegate.create(null));
+    void argumentsTest() {
+        assertThatThrownBy(() -> CharIlaNegate.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] array = new char[length];

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaRampTest.java
@@ -1,23 +1,25 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaRampTest {
+final class CharIlaRampTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final char start = (char) random.nextInt();
         final char increment = (char) random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaRamp.create(start, increment, -1));
+        assertThatThrownBy(() -> CharIlaRamp.create(start, increment, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final char startValue = (char) random.nextInt();
         final char increment = (char) random.nextInt();

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaScalarAddTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaScalarAddTest {
+final class CharIlaScalarAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final char value = (char) random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaScalarAdd.create(null, value));
+        assertThatThrownBy(() -> CharIlaScalarAdd.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char scalar = (char) random.nextInt();

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaScalarMultiplyTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaScalarMultiplyTest {
+final class CharIlaScalarMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final char value = (char) random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaScalarMultiply.create(null, value));
+        assertThatThrownBy(() -> CharIlaScalarMultiply.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char scalar = (char) random.nextInt();

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaSubtractTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class CharIlaSubtractTest {
+final class CharIlaSubtractTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final CharIla ila1 = CharIlaFromArray.create(new char[10]);
         final CharIla ila2 = CharIlaFromArray.create(new char[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> CharIlaSubtract.create(null, ila1, 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaSubtract.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaSubtract.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> CharIlaSubtract.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> CharIlaSubtract.create(null, ila1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaSubtract.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> CharIlaSubtract.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> CharIlaSubtract.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final char[] leftArray = new char[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaCheck.java
@@ -32,13 +32,13 @@ public final class DoubleIlaCheck {
                 .hasMessage("offset (=10) >= array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);
         assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);
     }
 
     public static void checkGetExhaustively(final DoubleIla ila1, final DoubleIla ila2) throws IOException {

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-class DoubleIlaFromCastIntIlaTest {
+final class DoubleIlaFromCastIntIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final IntIla ila = IntIlaFromArray.create(new int[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaFromCastIntIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaFromCastIntIla.create(ila, 0));
+        assertThatThrownBy(() -> DoubleIlaFromCastIntIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaFromCastIntIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] array = new int[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-class DoubleIlaFromCastLongIlaTest {
+final class DoubleIlaFromCastLongIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final LongIla ila = LongIlaFromArray.create(new long[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaFromCastLongIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaFromCastLongIla.create(ila, 0));
+        assertThatThrownBy(() -> DoubleIlaFromCastLongIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaFromCastLongIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] array = new long[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-class DoubleIlaFromCastShortIlaTest {
+final class DoubleIlaFromCastShortIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ShortIla ila = ShortIlaFromArray.create(new short[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaFromCastShortIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaFromCastShortIla.create(ila, 0));
+        assertThatThrownBy(() -> DoubleIlaFromCastShortIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaFromCastShortIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] array = new short[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaMultiplyTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaMultiplyTest {
+final class DoubleIlaMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final DoubleIla ila1 = DoubleIlaFromArray.create(new double[10]);
         final DoubleIla ila2 = DoubleIlaFromArray.create(new double[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaMultiply.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaMultiply.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaMultiply.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaMultiply.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> DoubleIlaMultiply.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaMultiply.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaMultiply.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> DoubleIlaMultiply.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] leftArray = new double[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaNegateTest.java
@@ -1,19 +1,21 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaNegateTest {
+final class DoubleIlaNegateTest {
     @Test
-    void testArguments() {
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaNegate.create(null));
+    void argumentsTest() {
+        assertThatThrownBy(() -> DoubleIlaNegate.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRampTest.java
@@ -1,23 +1,25 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaRampTest {
+final class DoubleIlaRampTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final double start = random.nextDouble();
         final double increment = random.nextDouble();
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaRamp.create(start, increment, -1));
+        assertThatThrownBy(() -> DoubleIlaRamp.create(start, increment, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final double startValue = random.nextDouble();
         final double increment = random.nextDouble();

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarAddTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaScalarAddTest {
+final class DoubleIlaScalarAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final double value = random.nextDouble();
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaScalarAdd.create(null, value));
+        assertThatThrownBy(() -> DoubleIlaScalarAdd.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double scalar = random.nextDouble();

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaScalarMultiplyTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaScalarMultiplyTest {
+final class DoubleIlaScalarMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final double value = random.nextDouble();
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaScalarMultiply.create(null, value));
+        assertThatThrownBy(() -> DoubleIlaScalarMultiply.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double scalar = random.nextDouble();

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaSubtractTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaSubtractTest {
+final class DoubleIlaSubtractTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final DoubleIla ila1 = DoubleIlaFromArray.create(new double[10]);
         final DoubleIla ila2 = DoubleIlaFromArray.create(new double[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaSubtract.create(null, ila1, 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaSubtract.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaSubtract.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaSubtract.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> DoubleIlaSubtract.create(null, ila1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaSubtract.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaSubtract.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> DoubleIlaSubtract.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] leftArray = new double[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaCheck.java
@@ -32,13 +32,13 @@ public final class FloatIlaCheck {
                 .hasMessage("offset (=10) >= array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);
         assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);
     }
 
     public static void checkGetExhaustively(final FloatIla ila1, final FloatIla ila2) throws IOException {

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-class FloatIlaFromCastIntIlaTest {
+final class FloatIlaFromCastIntIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final IntIla ila = IntIlaFromArray.create(new int[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaFromCastIntIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaFromCastIntIla.create(ila, 0));
+        assertThatThrownBy(() -> FloatIlaFromCastIntIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaFromCastIntIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] array = new int[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-class FloatIlaFromCastLongIlaTest {
+final class FloatIlaFromCastLongIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final LongIla ila = LongIlaFromArray.create(new long[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaFromCastLongIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaFromCastLongIla.create(ila, 0));
+        assertThatThrownBy(() -> FloatIlaFromCastLongIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaFromCastLongIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] array = new long[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-class FloatIlaFromCastShortIlaTest {
+final class FloatIlaFromCastShortIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ShortIla ila = ShortIlaFromArray.create(new short[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaFromCastShortIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaFromCastShortIla.create(ila, 0));
+        assertThatThrownBy(() -> FloatIlaFromCastShortIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaFromCastShortIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] array = new short[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaMultiplyTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaMultiplyTest {
+final class FloatIlaMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final FloatIla ila1 = FloatIlaFromArray.create(new float[10]);
         final FloatIla ila2 = FloatIlaFromArray.create(new float[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaMultiply.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaMultiply.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaMultiply.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaMultiply.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> FloatIlaMultiply.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaMultiply.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaMultiply.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> FloatIlaMultiply.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] leftArray = new float[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaNegateTest.java
@@ -1,19 +1,21 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaNegateTest {
+final class FloatIlaNegateTest {
     @Test
-    void testArguments() {
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaNegate.create(null));
+    void argumentsTest() {
+        assertThatThrownBy(() -> FloatIlaNegate.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaRampTest.java
@@ -1,23 +1,25 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaRampTest {
+final class FloatIlaRampTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final float start = random.nextFloat();
         final float increment = random.nextFloat();
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaRamp.create(start, increment, -1));
+        assertThatThrownBy(() -> FloatIlaRamp.create(start, increment, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final float startValue = random.nextFloat();
         final float increment = random.nextFloat();

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarAddTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaScalarAddTest {
+final class FloatIlaScalarAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final float value = random.nextFloat();
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaScalarAdd.create(null, value));
+        assertThatThrownBy(() -> FloatIlaScalarAdd.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float scalar = random.nextFloat();

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaScalarMultiplyTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaScalarMultiplyTest {
+final class FloatIlaScalarMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final float value = random.nextFloat();
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaScalarMultiply.create(null, value));
+        assertThatThrownBy(() -> FloatIlaScalarMultiply.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float scalar = random.nextFloat();

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaSubtractTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaSubtractTest {
+final class FloatIlaSubtractTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final FloatIla ila1 = FloatIlaFromArray.create(new float[10]);
         final FloatIla ila2 = FloatIlaFromArray.create(new float[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaSubtract.create(null, ila1, 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaSubtract.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaSubtract.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaSubtract.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> FloatIlaSubtract.create(null, ila1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaSubtract.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaSubtract.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> FloatIlaSubtract.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] leftArray = new float[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaCheck.java
@@ -32,13 +32,13 @@ public final class IntIlaCheck {
                 .hasMessage("offset (=10) >= array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);
         assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);
     }
 
     public static void checkGetExhaustively(final IntIla ila1, final IntIla ila2) throws IOException {

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastLongIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-class IntIlaFromCastLongIlaTest {
+final class IntIlaFromCastLongIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final LongIla ila = LongIlaFromArray.create(new long[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaFromCastLongIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaFromCastLongIla.create(ila, 0));
+        assertThatThrownBy(() -> IntIlaFromCastLongIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaFromCastLongIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] array = new long[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastShortIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaFromCastShortIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-class IntIlaFromCastShortIlaTest {
+final class IntIlaFromCastShortIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ShortIla ila = ShortIlaFromArray.create(new short[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaFromCastShortIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaFromCastShortIla.create(ila, 0));
+        assertThatThrownBy(() -> IntIlaFromCastShortIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaFromCastShortIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] array = new short[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaMultiplyTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaMultiplyTest {
+final class IntIlaMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final IntIla ila1 = IntIlaFromArray.create(new int[10]);
         final IntIla ila2 = IntIlaFromArray.create(new int[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaMultiply.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaMultiply.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaMultiply.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaMultiply.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> IntIlaMultiply.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaMultiply.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaMultiply.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> IntIlaMultiply.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] leftArray = new int[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaNegateTest.java
@@ -1,19 +1,21 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaNegateTest {
+final class IntIlaNegateTest {
     @Test
-    void testArguments() {
-        assertThrows(IllegalArgumentException.class, () -> IntIlaNegate.create(null));
+    void argumentsTest() {
+        assertThatThrownBy(() -> IntIlaNegate.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] array = new int[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaRampTest.java
@@ -1,23 +1,25 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaRampTest {
+final class IntIlaRampTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final int start = random.nextInt();
         final int increment = random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaRamp.create(start, increment, -1));
+        assertThatThrownBy(() -> IntIlaRamp.create(start, increment, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int startValue = random.nextInt();
         final int increment = random.nextInt();

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaScalarAddTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaScalarAddTest {
+final class IntIlaScalarAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final int value = random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaScalarAdd.create(null, value));
+        assertThatThrownBy(() -> IntIlaScalarAdd.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int scalar = random.nextInt();

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaScalarMultiplyTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaScalarMultiplyTest {
+final class IntIlaScalarMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final int value = random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaScalarMultiply.create(null, value));
+        assertThatThrownBy(() -> IntIlaScalarMultiply.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int scalar = random.nextInt();

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaSubtractTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class IntIlaSubtractTest {
+final class IntIlaSubtractTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final IntIla ila1 = IntIlaFromArray.create(new int[10]);
         final IntIla ila2 = IntIlaFromArray.create(new int[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> IntIlaSubtract.create(null, ila1, 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaSubtract.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaSubtract.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> IntIlaSubtract.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> IntIlaSubtract.create(null, ila1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaSubtract.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> IntIlaSubtract.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> IntIlaSubtract.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] leftArray = new int[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaCheck.java
@@ -32,13 +32,13 @@ public final class LongIlaCheck {
                 .hasMessage("offset (=10) >= array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);
         assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);
     }
 
     public static void checkGetExhaustively(final LongIla ila1, final LongIla ila2) throws IOException {

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastIntIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-class LongIlaFromCastIntIlaTest {
+final class LongIlaFromCastIntIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final IntIla ila = IntIlaFromArray.create(new int[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaFromCastIntIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaFromCastIntIla.create(ila, 0));
+        assertThatThrownBy(() -> LongIlaFromCastIntIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaFromCastIntIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] array = new int[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastShortIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaFromCastShortIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-class LongIlaFromCastShortIlaTest {
+final class LongIlaFromCastShortIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ShortIla ila = ShortIlaFromArray.create(new short[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaFromCastShortIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaFromCastShortIla.create(ila, 0));
+        assertThatThrownBy(() -> LongIlaFromCastShortIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaFromCastShortIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] array = new short[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaMultiplyTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaMultiplyTest {
+final class LongIlaMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final LongIla ila1 = LongIlaFromArray.create(new long[10]);
         final LongIla ila2 = LongIlaFromArray.create(new long[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaMultiply.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaMultiply.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaMultiply.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaMultiply.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> LongIlaMultiply.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaMultiply.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaMultiply.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> LongIlaMultiply.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] leftArray = new long[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaNegateTest.java
@@ -1,19 +1,21 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaNegateTest {
+final class LongIlaNegateTest {
     @Test
-    void testArguments() {
-        assertThrows(IllegalArgumentException.class, () -> LongIlaNegate.create(null));
+    void argumentsTest() {
+        assertThatThrownBy(() -> LongIlaNegate.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] array = new long[length];

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaRampTest.java
@@ -1,23 +1,25 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaRampTest {
+final class LongIlaRampTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final long start = random.nextLong();
         final long increment = random.nextLong();
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaRamp.create(start, increment, -1));
+        assertThatThrownBy(() -> LongIlaRamp.create(start, increment, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final long startValue = random.nextLong();
         final long increment = random.nextLong();

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaScalarAddTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaScalarAddTest {
+final class LongIlaScalarAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final long value = random.nextLong();
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaScalarAdd.create(null, value));
+        assertThatThrownBy(() -> LongIlaScalarAdd.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long scalar = random.nextLong();

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaScalarMultiplyTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaScalarMultiplyTest {
+final class LongIlaScalarMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final long value = random.nextLong();
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaScalarMultiply.create(null, value));
+        assertThatThrownBy(() -> LongIlaScalarMultiply.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long scalar = random.nextLong();

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaSubtractTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class LongIlaSubtractTest {
+final class LongIlaSubtractTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final LongIla ila1 = LongIlaFromArray.create(new long[10]);
         final LongIla ila2 = LongIlaFromArray.create(new long[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> LongIlaSubtract.create(null, ila1, 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaSubtract.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaSubtract.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> LongIlaSubtract.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> LongIlaSubtract.create(null, ila1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaSubtract.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> LongIlaSubtract.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> LongIlaSubtract.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] leftArray = new long[length];

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java
@@ -31,13 +31,13 @@ public final class ObjectIlaCheck {
                 .hasMessage("offset (=10) >= array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);
         assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);
     }
 
     public static void checkGetExhaustively(ObjectIla<Object> ila1, ObjectIla<Object> ila2) throws IOException {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaCheck.java
@@ -32,13 +32,13 @@ public final class ShortIlaCheck {
                 .hasMessage("offset (=10) >= array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);
         assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);
     }
 
     public static void checkGetExhaustively(final ShortIla ila1, final ShortIla ila2) throws IOException {

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-class ShortIlaFromCastIntIlaTest {
+final class ShortIlaFromCastIntIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final IntIla ila = IntIlaFromArray.create(new int[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaFromCastIntIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaFromCastIntIla.create(ila, 0));
+        assertThatThrownBy(() -> ShortIlaFromCastIntIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaFromCastIntIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final int[] array = new int[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIlaTest.java
@@ -1,6 +1,6 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -8,17 +8,21 @@ import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-class ShortIlaFromCastLongIlaTest {
+final class ShortIlaFromCastLongIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final LongIla ila = LongIlaFromArray.create(new long[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaFromCastLongIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaFromCastLongIla.create(ila, 0));
+        assertThatThrownBy(() -> ShortIlaFromCastLongIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaFromCastLongIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final long[] array = new long[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaMultiplyTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaMultiplyTest {
+final class ShortIlaMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ShortIla ila1 = ShortIlaFromArray.create(new short[10]);
         final ShortIla ila2 = ShortIlaFromArray.create(new short[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaMultiply.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaMultiply.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaMultiply.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaMultiply.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> ShortIlaMultiply.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaMultiply.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaMultiply.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> ShortIlaMultiply.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] leftArray = new short[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaNegateTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaNegateTest.java
@@ -1,19 +1,21 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaNegateTest {
+final class ShortIlaNegateTest {
     @Test
-    void testArguments() {
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaNegate.create(null));
+    void argumentsTest() {
+        assertThatThrownBy(() -> ShortIlaNegate.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] array = new short[length];

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaRampTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaRampTest.java
@@ -1,23 +1,25 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaRampTest {
+final class ShortIlaRampTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final short start = (short) random.nextInt();
         final short increment = (short) random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaRamp.create(start, increment, -1));
+        assertThatThrownBy(() -> ShortIlaRamp.create(start, increment, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final short startValue = (short) random.nextInt();
         final short increment = (short) random.nextInt();

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarAddTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarAddTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaScalarAddTest {
+final class ShortIlaScalarAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final short value = (short) random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaScalarAdd.create(null, value));
+        assertThatThrownBy(() -> ShortIlaScalarAdd.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short scalar = (short) random.nextInt();

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarMultiplyTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaScalarMultiplyTest.java
@@ -1,22 +1,24 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaScalarMultiplyTest {
+final class ShortIlaScalarMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final Random random = new Random(0);
         final short value = (short) random.nextInt();
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaScalarMultiply.create(null, value));
+        assertThatThrownBy(() -> ShortIlaScalarMultiply.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short scalar = (short) random.nextInt();

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaSubtractTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaSubtractTest.java
@@ -1,25 +1,33 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ShortIlaSubtractTest {
+final class ShortIlaSubtractTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ShortIla ila1 = ShortIlaFromArray.create(new short[10]);
         final ShortIla ila2 = ShortIlaFromArray.create(new short[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaSubtract.create(null, ila1, 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaSubtract.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaSubtract.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> ShortIlaSubtract.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> ShortIlaSubtract.create(null, ila1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaSubtract.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaSubtract.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> ShortIlaSubtract.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final short[] leftArray = new short[length];

--- a/src/test/template/tfw/immutable/ila/__IlaCheck..NonNumeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaCheck..NonNumeric.template
@@ -31,13 +31,13 @@ import java.io.IOException;
                 .hasMessage("offset (=10) >= array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);
         assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);
     }
 
     public static void checkGetExhaustively(%%NAME%%Ila%%TEMPLATE%% ila1, %%NAME%%Ila%%TEMPLATE%% ila2) throws IOException {

--- a/src/test/template/tfw/immutable/ila/__IlaCheck..Numeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaCheck..Numeric.template
@@ -32,13 +32,13 @@ public final class %%NAME%%IlaCheck {
                 .hasMessage("offset (=10) >= array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start (=" + ilaLength + ") >= ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start (=%s) >= ila.length() (=%s) not allowed!", ilaLength, ilaLength);
         assertThatThrownBy(() -> ila.get(array, array.length - 1, 0, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("offset+length (=11) > array.length (=10) not allowed!");
         assertThatThrownBy(() -> ila.get(array, 0, ilaLength - 1, 2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("start+length (=" + (ilaLength + 1) + ") > ila.length() (=" + ilaLength + ") not allowed!");
+                .hasMessage("start+length (=%s) > ila.length() (=%s) not allowed!", ilaLength + 1, ilaLength);
     }
 
     public static void checkGetExhaustively(final %%NAME%%Ila ila1, final %%NAME%%Ila ila2) throws IOException {

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastIntIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastIntIlaTest.template
@@ -1,24 +1,28 @@
 // byteila,charila,doubleila,floatila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.intila.IntIla;
 import tfw.immutable.ila.intila.IntIlaFromArray;
 
-class %%NAME%%IlaFromCastIntIlaTest {
+final class %%NAME%%IlaFromCastIntIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final IntIla ila = IntIlaFromArray.create(new int[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastIntIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastIntIla.create(ila, 0));
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastIntIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastIntIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final int[] array = new int[length];
         final %%TYPE%%[] target = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastLongIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastLongIlaTest.template
@@ -1,24 +1,28 @@
 // byteila,charila,doubleila,floatila,intila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.longila.LongIla;
 import tfw.immutable.ila.longila.LongIlaFromArray;
 
-class %%NAME%%IlaFromCastLongIlaTest {
+final class %%NAME%%IlaFromCastLongIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final LongIla ila = LongIlaFromArray.create(new long[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastLongIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastLongIla.create(ila, 0));
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastLongIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastLongIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final long[] array = new long[length];
         final %%TYPE%%[] target = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaFromCastShortIlaTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaFromCastShortIlaTest.template
@@ -1,24 +1,28 @@
 // byteila,charila,doubleila,floatila,intila,longila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 import tfw.immutable.ila.shortila.ShortIla;
 import tfw.immutable.ila.shortila.ShortIlaFromArray;
 
-class %%NAME%%IlaFromCastShortIlaTest {
+final class %%NAME%%IlaFromCastShortIlaTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final ShortIla ila = ShortIlaFromArray.create(new short[10]);
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastShortIla.create(null, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaFromCastShortIla.create(ila, 0));
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastShortIla.create(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaFromCastShortIla.create(ila, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final short[] array = new short[length];
         final %%TYPE%%[] target = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaMultiplyTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaMultiplyTest.template
@@ -1,25 +1,33 @@
 // byteila,charila,doubleila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaMultiplyTest {
+final class %%NAME%%IlaMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final %%NAME%%Ila ila1 = %%NAME%%IlaFromArray.create(new %%TYPE%%[10]);
         final %%NAME%%Ila ila2 = %%NAME%%IlaFromArray.create(new %%TYPE%%[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaMultiply.create(null, ila1, 10));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaMultiply.create(ila1, null, 10));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaMultiply.create(ila1, ila1, 0));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaMultiply.create(ila1, ila2, 10));
+        assertThatThrownBy(() -> %%NAME%%IlaMultiply.create(null, ila1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaMultiply.create(ila1, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaMultiply.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaMultiply.create(ila1, ila2, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%%[] leftArray = new %%TYPE%%[length];
         final %%TYPE%%[] rightArray = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaNegateTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaNegateTest.template
@@ -1,19 +1,21 @@
 // byteila,charila,doubleila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaNegateTest {
+final class %%NAME%%IlaNegateTest {
     @Test
-    void testArguments() {
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaNegate.create(null));
+    void argumentsTest() {
+        assertThatThrownBy(() -> %%NAME%%IlaNegate.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%%[] array = new %%TYPE%%[length];
         final %%TYPE%%[] target = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaRampTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaRampTest.template
@@ -1,22 +1,24 @@
 // byteila,charila,doubleila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaRampTest {
+final class %%NAME%%IlaRampTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         %%RANDOM_INIT%%final %%TYPE%% start = %%RANDOM_VALUE%%;
         final %%TYPE%% increment = %%RANDOM_VALUE%%;
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaRamp.create(start, increment, -1));
+        assertThatThrownBy(() -> %%NAME%%IlaRamp.create(start, increment, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("length (=-1) < 0 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final %%TYPE%% startValue = %%RANDOM_VALUE%%;
         final %%TYPE%% increment = %%RANDOM_VALUE%%;
         final int length = IlaTestDimensions.defaultIlaLength();

--- a/src/test/template/tfw/immutable/ila/__IlaScalarAddTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaScalarAddTest.template
@@ -1,21 +1,23 @@
 // byteila,charila,doubleila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaScalarAddTest {
+final class %%NAME%%IlaScalarAddTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         %%RANDOM_INIT%%final %%TYPE%% value = %%RANDOM_VALUE%%;
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaScalarAdd.create(null, value));
+        assertThatThrownBy(() -> %%NAME%%IlaScalarAdd.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%% scalar = %%RANDOM_VALUE%%;
         final %%TYPE%%[] array = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaScalarMultiplyTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaScalarMultiplyTest.template
@@ -1,21 +1,23 @@
 // byteila,charila,doubleila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaScalarMultiplyTest {
+final class %%NAME%%IlaScalarMultiplyTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         %%RANDOM_INIT%%final %%TYPE%% value = %%RANDOM_VALUE%%;
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaScalarMultiply.create(null, value));
+        assertThatThrownBy(() -> %%NAME%%IlaScalarMultiply.create(null, value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%% scalar = %%RANDOM_VALUE%%;
         final %%TYPE%%[] array = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaSubtractTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaSubtractTest.template
@@ -1,25 +1,33 @@
 // byteila,charila,doubleila,floatila,intila,longila,shortila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaSubtractTest {
+final class %%NAME%%IlaSubtractTest {
     @Test
-    void testArguments() {
+    void argumentsTest() {
         final %%NAME%%Ila ila1 = %%NAME%%IlaFromArray.create(new %%TYPE%%[10]);
         final %%NAME%%Ila ila2 = %%NAME%%IlaFromArray.create(new %%TYPE%%[20]);
 
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaSubtract.create(null, ila1, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaSubtract.create(ila1, null, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaSubtract.create(ila1, ila2, 1));
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaSubtract.create(ila1, ila1, 0));
+        assertThatThrownBy(() -> %%NAME%%IlaSubtract.create(null, ila1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaSubtract.create(ila1, null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightIla == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaSubtract.create(ila1, ila2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftIla.length() (=10) != rightIla.length() (=20) not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaSubtract.create(ila1, ila1, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bufferSize (=0) < 1 not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%%[] leftArray = new %%TYPE%%[length];
         final %%TYPE%%[] rightArray = new %%TYPE%%[length];


### PR DESCRIPTION
This PR updates the ila tests to use AssertJ.

## Summary by Sourcery

Tests:
- Migrated from JUnit assertions to AssertJ assertions in ILA tests.