### PR TITLE
Update ila tests to use AssertJ - Part 5.

### DIFF
--- a/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/booleanila/BooleanIlaCheck.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.Random;
+import tfw.check.Argument;
 
 public final class BooleanIlaCheck {
     private BooleanIlaCheck() {
@@ -85,37 +86,33 @@ public final class BooleanIlaCheck {
 
     public static void checkFourFiveEquivalence(final BooleanIla ila, final int offsetLength, boolean epsilon)
             throws Exception {
-        if (epsilon != false) {
-            throw new IllegalArgumentException("epsilon != " + false + " not allowed");
-        } else {
-            if (offsetLength < 0) throw new Exception("offsetLength < 0 not allowed");
+        Argument.assertNotLessThan(offsetLength, 0, "offsetLength");
 
-            final StridedBooleanIla stridedBooleanIla = StridedBooleanIlaFromBooleanIla.create(ila, new boolean[10]);
-            final Random random = new Random(0);
-            final int ilaLength = ila.length() + offsetLength <= Integer.MAX_VALUE
-                    ? (int) ila.length()
-                    : Integer.MAX_VALUE - offsetLength;
-            for (int offset = 0; offset < offsetLength; ++offset) {
-                final boolean[] four = new boolean[ilaLength + offsetLength];
-                final boolean[] five = new boolean[ilaLength + offsetLength];
-                for (int length = 1; length <= ilaLength; ++length) {
-                    for (long start = 0; start < ilaLength - length + 1; ++start) {
-                        for (int ii = 0; ii < four.length; ++ii) {
-                            five[ii] = four[ii] = random.nextBoolean();
-                        }
-                        ila.get(four, offset, start, length);
-                        stridedBooleanIla.get(five, offset, 1, start, length);
-                        for (int ii = 0; ii < length; ++ii) {
-                            if (!(four[ii] == five[ii]))
-                                throw new Exception("four[" + ii + "] ("
-                                        + four[ii] + ") !~ five["
-                                        + ii + "] ("
-                                        + five[ii]
-                                        + ") {length=" + length
-                                        + ",start=" + start
-                                        + ",offset=" + offset
-                                        + "}");
-                        }
+        final StridedBooleanIla stridedBooleanIla = StridedBooleanIlaFromBooleanIla.create(ila, new boolean[10]);
+        final Random random = new Random(0);
+        final int ilaLength = ila.length() + offsetLength <= Integer.MAX_VALUE
+                ? (int) ila.length()
+                : Integer.MAX_VALUE - offsetLength;
+        for (int offset = 0; offset < offsetLength; ++offset) {
+            final boolean[] four = new boolean[ilaLength + offsetLength];
+            final boolean[] five = new boolean[ilaLength + offsetLength];
+            for (int length = 1; length <= ilaLength; ++length) {
+                for (long start = 0; start < ilaLength - length + 1; ++start) {
+                    for (int ii = 0; ii < four.length; ++ii) {
+                        five[ii] = four[ii] = random.nextBoolean();
+                    }
+                    ila.get(four, offset, start, length);
+                    stridedBooleanIla.get(five, offset, 1, start, length);
+                    for (int ii = 0; ii < length; ++ii) {
+                        if (!(four[ii] == five[ii]))
+                            throw new Exception("four[" + ii + "] ("
+                                    + four[ii] + ") !~ five["
+                                    + ii + "] ("
+                                    + five[ii]
+                                    + ") {length=" + length
+                                    + ",start=" + start
+                                    + ",offset=" + offset
+                                    + "}");
                     }
                 }
             }
@@ -125,52 +122,48 @@ public final class BooleanIlaCheck {
     public static void checkCorrectness(
             BooleanIla target, BooleanIla actual, int addlOffsetLength, int maxAbsStride, boolean epsilon)
             throws Exception {
-        if (epsilon != false) {
-            throw new IllegalArgumentException("epsilon != " + false + " not allowed");
-        } else {
-            if (addlOffsetLength < 0) throw new Exception("addlOffsetLength < 0 not allowed");
-            if (maxAbsStride < 1) throw new Exception("maxAbsStride < 1 not allowed");
-            if (target.length() != actual.length()) throw new Exception("target.length() != actual.length()");
+        Argument.assertNotLessThan(addlOffsetLength, 0, "addlOffsetLength");
+        Argument.assertNotLessThan(maxAbsStride, 1, "maxAbsStride");
+        Argument.assertEquals(target.length(), actual.length(), "target.length()", "actual.length()");
 
-            final StridedBooleanIla stridedTarget = StridedBooleanIlaFromBooleanIla.create(target, new boolean[10]);
-            final StridedBooleanIla stridedActual = StridedBooleanIlaFromBooleanIla.create(target, new boolean[10]);
-            final Random random = new Random(0);
-            final int ilaLength = target.length() + addlOffsetLength <= Integer.MAX_VALUE
-                    ? (int) target.length()
-                    : Integer.MAX_VALUE - addlOffsetLength;
-            for (int stride = -maxAbsStride; stride <= maxAbsStride; ++stride) {
-                if (stride != 0) {
-                    int absStride = stride < 0 ? -stride : stride;
-                    int offsetStart = stride < 0 ? (ilaLength - 1) * absStride : 0;
-                    int offsetEnd = offsetStart + addlOffsetLength;
-                    for (int offset = offsetStart; offset < offsetEnd; ++offset) {
-                        final int arraySize = (ilaLength - 1) * absStride + 1 + addlOffsetLength;
-                        final boolean[] targetBase = new boolean[arraySize];
-                        final boolean[] actualBase = new boolean[arraySize];
-                        for (int length = 1; length <= ilaLength; ++length) {
-                            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                                for (int ii = 0; ii < targetBase.length; ++ii) {
-                                    targetBase[ii] = actualBase[ii] = random.nextBoolean();
-                                }
-                                stridedTarget.get(targetBase, offset, stride, start, length);
-                                stridedActual.get(actualBase, offset, stride, start, length);
-                                for (int ii = 0; ii < arraySize; ++ii) {
-                                    if (!(actualBase[ii] == targetBase[ii]))
-                                        throw new Exception("actual[" + ii
-                                                + "] ("
-                                                + actualBase[ii]
-                                                + ") !~ target["
-                                                + ii + "] ("
-                                                + targetBase[ii]
-                                                + ") {length="
-                                                + length
-                                                + ",start=" + start
-                                                + ",offset="
-                                                + offset
-                                                + ",stride="
-                                                + stride
-                                                + "}");
-                                }
+        final StridedBooleanIla stridedTarget = StridedBooleanIlaFromBooleanIla.create(target, new boolean[10]);
+        final StridedBooleanIla stridedActual = StridedBooleanIlaFromBooleanIla.create(target, new boolean[10]);
+        final Random random = new Random(0);
+        final int ilaLength = target.length() + addlOffsetLength <= Integer.MAX_VALUE
+                ? (int) target.length()
+                : Integer.MAX_VALUE - addlOffsetLength;
+        for (int stride = -maxAbsStride; stride <= maxAbsStride; ++stride) {
+            if (stride != 0) {
+                int absStride = stride < 0 ? -stride : stride;
+                int offsetStart = stride < 0 ? (ilaLength - 1) * absStride : 0;
+                int offsetEnd = offsetStart + addlOffsetLength;
+                for (int offset = offsetStart; offset < offsetEnd; ++offset) {
+                    final int arraySize = (ilaLength - 1) * absStride + 1 + addlOffsetLength;
+                    final boolean[] targetBase = new boolean[arraySize];
+                    final boolean[] actualBase = new boolean[arraySize];
+                    for (int length = 1; length <= ilaLength; ++length) {
+                        for (long start = 0; start < ilaLength - length + 1; ++start) {
+                            for (int ii = 0; ii < targetBase.length; ++ii) {
+                                targetBase[ii] = actualBase[ii] = random.nextBoolean();
+                            }
+                            stridedTarget.get(targetBase, offset, stride, start, length);
+                            stridedActual.get(actualBase, offset, stride, start, length);
+                            for (int ii = 0; ii < arraySize; ++ii) {
+                                if (!(actualBase[ii] == targetBase[ii]))
+                                    throw new Exception("actual[" + ii
+                                            + "] ("
+                                            + actualBase[ii]
+                                            + ") !~ target["
+                                            + ii + "] ("
+                                            + targetBase[ii]
+                                            + ") {length="
+                                            + length
+                                            + ",start=" + start
+                                            + ",offset="
+                                            + offset
+                                            + ",stride="
+                                            + stride
+                                            + "}");
                             }
                         }
                     }

--- a/src/test/java/tfw/immutable/ila/byteila/ByteIlaSwapTest.java
+++ b/src/test/java/tfw/immutable/ila/byteila/ByteIlaSwapTest.java
@@ -1,13 +1,13 @@
 package tfw.immutable.ila.byteila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class ByteIlaSwapTest {
+final class ByteIlaSwapTest {
     @Test
-    void testByteIlaFromLongIla() throws Exception {
+    void byteIlaFromLongIlaTest() throws Exception {
         byte[] byteArray = new byte[] {
             (byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03,
             (byte) 0x04, (byte) 0x05, (byte) 0x06, (byte) 0x07,
@@ -70,8 +70,9 @@ class ByteIlaSwapTest {
         ByteIla swap4Ila = ByteIlaFromArray.create(swap4Array);
         ByteIla swap8Ila = ByteIlaFromArray.create(swap8Array);
 
-        assertThrows(
-                IllegalArgumentException.class, () -> ByteIlaSwap.create(null, 2, 100), "ila == null not checked for!");
+        assertThatThrownBy(() -> ByteIlaSwap.create(null, 2, 100))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIla == null not allowed!");
 
         ByteIla actualIla = ByteIlaSwap.create(byteIla, 2, 100);
         final byte epsilon = (byte) 0;

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaFromUtf8ByteIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaFromUtf8ByteIlaTest.java
@@ -1,16 +1,15 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.byteila.ByteIla;
 import tfw.immutable.ila.byteila.ByteIlaFromArray;
 
-class CharIlaFromUtf8ByteIlaTest {
+final class CharIlaFromUtf8ByteIlaTest {
     @Test
-    void testCharIlaFromUTF8ByteIla() throws Exception {
+    void charIlaFromUTF8ByteIlaTest() throws Exception {
         // Create all unicode characters, valid and invalid.
         final int unicodeSpace = 1 << 21;
         final char[] characters = new char[unicodeSpace];
@@ -21,10 +20,10 @@ class CharIlaFromUtf8ByteIlaTest {
 
         // Create UTF-8 bytes from full unicode character space.
         final String string = new String(characters);
-        final byte[] utf8Bytes = string.getBytes(StandardCharsets.UTF_8);
+        final byte[] utf8Bytes = string.getBytes(UTF_8);
 
         // Create characters from UTF-8 bytes using java.lang.String.
-        final String stringFromUtf8Bytes = new String(utf8Bytes, StandardCharsets.UTF_8);
+        final String stringFromUtf8Bytes = new String(utf8Bytes, UTF_8);
         final char[] charactersFromString = stringFromUtf8Bytes.toCharArray();
 
         // Create characters from UTF-8 bytes using CharIlaFromUTF8Bytes.
@@ -36,6 +35,6 @@ class CharIlaFromUtf8ByteIlaTest {
         charIlaFromUtf8ByteIla.get(charactersFromCharIla, 0, 0, charIlaLength);
 
         // Compare the two arrays.
-        assertTrue(Arrays.equals(charactersFromString, charactersFromCharIla));
+        assertThat(charactersFromString).isEqualTo(charactersFromCharIla);
     }
 }

--- a/src/test/java/tfw/immutable/ila/charila/CharIlaIteratorTest.java
+++ b/src/test/java/tfw/immutable/ila/charila/CharIlaIteratorTest.java
@@ -1,15 +1,14 @@
 package tfw.immutable.ila.charila;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-class CharIlaIteratorTest {
+final class CharIlaIteratorTest {
     @Test
-    void testCharIlaFill() throws IOException {
+    void charIlaFillTest() throws IOException {
         final Random random = new Random();
         final int LENGTH = 29;
         char[] array = new char[LENGTH];
@@ -23,14 +22,10 @@ class CharIlaIteratorTest {
 
         int i = 0;
         for (; ii.hasNext(); i++) {
-            if (i == array.length) {
-                fail("Iterator did not stop correctly");
-            }
-            assertEquals(ii.next(), array[i], "element " + i + " not equal!");
+            assertThat(i).isNotEqualTo(array.length);
+            assertThat(ii.next()).isEqualTo(array[i]);
         }
 
-        if (i != array.length) {
-            fail("Iterator stopped at " + i + " not " + array.length);
-        }
+        assertThat(i).isEqualTo(array.length);
     }
 }

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromLongIlaTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaFromLongIlaTest.java
@@ -2,9 +2,9 @@ package tfw.immutable.ila.doubleila;
 
 import org.junit.jupiter.api.Test;
 
-class DoubleIlaFromLongIlaTest {
+final class DoubleIlaFromLongIlaTest {
     @Test
-    void testDoubleIlaFromLongIla() throws Exception {
+    void doubleIlaFromLongIlaTest() throws Exception {
         /*
         		final int LENGTH = 64;
         		final long SKIP = Long.MAX_VALUE / LENGTH * 2;

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaInvertTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaInvertTest.java
@@ -1,19 +1,21 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaInvertTest {
+final class DoubleIlaInvertTest {
     @Test
-    void testArguments() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaInvert.create(null));
+    void argumentsTest() throws Exception {
+        assertThatThrownBy(() -> DoubleIlaInvert.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaIteratorTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaIteratorTest.java
@@ -1,15 +1,14 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-class DoubleIlaIteratorTest {
+final class DoubleIlaIteratorTest {
     @Test
-    void testDoubleIlaFill() throws IOException {
+    void doubleIlaIteratorTest() throws IOException {
         final Random random = new Random();
         final int LENGTH = 29;
         double[] array = new double[LENGTH];
@@ -23,14 +22,10 @@ class DoubleIlaIteratorTest {
 
         int i = 0;
         for (; ii.hasNext(); i++) {
-            if (i == array.length) {
-                fail("Iterator did not stop correctly");
-            }
-            assertEquals(ii.next(), array[i], 0, "element " + i + " not equal!");
+            assertThat(i).isNotEqualTo(array.length);
+            assertThat(ii.next()).isEqualTo(array[i]);
         }
 
-        if (i != array.length) {
-            fail("Iterator stopped at " + i + " not " + array.length);
-        }
+        assertThat(i).isEqualTo(array.length);
     }
 }

--- a/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRoundTest.java
+++ b/src/test/java/tfw/immutable/ila/doubleila/DoubleIlaRoundTest.java
@@ -1,19 +1,21 @@
 package tfw.immutable.ila.doubleila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class DoubleIlaRoundTest {
+final class DoubleIlaRoundTest {
     @Test
-    void testArguments() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> DoubleIlaRound.create(null));
+    void argumentsTest() throws Exception {
+        assertThatThrownBy(() -> DoubleIlaRound.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final double[] array = new double[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaInvertTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaInvertTest.java
@@ -1,19 +1,21 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaInvertTest {
+final class FloatIlaInvertTest {
     @Test
-    void testArguments() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaInvert.create(null));
+    void argumentsTest() throws Exception {
+        assertThatThrownBy(() -> FloatIlaInvert.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaIteratorTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaIteratorTest.java
@@ -1,15 +1,14 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-class FloatIlaIteratorTest {
+final class FloatIlaIteratorTest {
     @Test
-    void testFloatIlaFill() throws IOException {
+    void floatIlaIteratorTest() throws IOException {
         final Random random = new Random();
         final int LENGTH = 29;
         float[] array = new float[LENGTH];
@@ -23,14 +22,10 @@ class FloatIlaIteratorTest {
 
         int i = 0;
         for (; ii.hasNext(); i++) {
-            if (i == array.length) {
-                fail("Iterator did not stop correctly");
-            }
-            assertEquals(ii.next(), array[i], 0f, "element " + i + " not equal!");
+            assertThat(i).isNotEqualTo(array.length);
+            assertThat(ii.next()).isEqualTo(array[i]);
         }
 
-        if (i != array.length) {
-            fail("Iterator stopped at " + i + " not " + array.length);
-        }
+        assertThat(i).isEqualTo(array.length);
     }
 }

--- a/src/test/java/tfw/immutable/ila/floatila/FloatIlaRoundTest.java
+++ b/src/test/java/tfw/immutable/ila/floatila/FloatIlaRoundTest.java
@@ -1,19 +1,21 @@
 package tfw.immutable.ila.floatila;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class FloatIlaRoundTest {
+final class FloatIlaRoundTest {
     @Test
-    void testArguments() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> FloatIlaRound.create(null));
+    void argumentsTest() throws Exception {
+        assertThatThrownBy(() -> FloatIlaRound.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         final Random random = new Random(0);
         final int length = IlaTestDimensions.defaultIlaLength();
         final float[] array = new float[length];

--- a/src/test/java/tfw/immutable/ila/intila/IntIlaIteratorTest.java
+++ b/src/test/java/tfw/immutable/ila/intila/IntIlaIteratorTest.java
@@ -1,15 +1,14 @@
 package tfw.immutable.ila.intila;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-class IntIlaIteratorTest {
+final class IntIlaIteratorTest {
     @Test
-    void testIntIlaFill() throws IOException {
+    void intIlaIteratorTest() throws IOException {
         final Random random = new Random();
         final int LENGTH = 29;
         int[] array = new int[LENGTH];
@@ -23,14 +22,10 @@ class IntIlaIteratorTest {
 
         int i = 0;
         for (; ii.hasNext(); i++) {
-            if (i == array.length) {
-                fail("Iterator did not stop correctly");
-            }
-            assertEquals(ii.next(), array[i], "element " + i + " not equal!");
+            assertThat(i).isNotEqualTo(array.length);
+            assertThat(ii.next()).isEqualTo(array[i]);
         }
 
-        if (i != array.length) {
-            fail("Iterator stopped at " + i + " not " + array.length);
-        }
+        assertThat(i).isEqualTo(array.length);
     }
 }

--- a/src/test/java/tfw/immutable/ila/longila/LongIlaIteratorTest.java
+++ b/src/test/java/tfw/immutable/ila/longila/LongIlaIteratorTest.java
@@ -1,15 +1,14 @@
 package tfw.immutable.ila.longila;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-class LongIlaIteratorTest {
+final class LongIlaIteratorTest {
     @Test
-    void testLongIlaFill() throws IOException {
+    void longIlaIteratorTest() throws IOException {
         final Random random = new Random();
         final int LENGTH = 29;
         long[] array = new long[LENGTH];
@@ -23,14 +22,10 @@ class LongIlaIteratorTest {
 
         int i = 0;
         for (; ii.hasNext(); i++) {
-            if (i == array.length) {
-                fail("Iterator did not stop correctly");
-            }
-            assertEquals(ii.next(), array[i], "element " + i + " not equal!");
+            assertThat(i).isNotEqualTo(array.length);
+            assertThat(ii.next()).isEqualTo(array[i]);
         }
 
-        if (i != array.length) {
-            fail("Iterator stopped at " + i + " not " + array.length);
-        }
+        assertThat(i).isEqualTo(array.length);
     }
 }

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaCheck.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import tfw.check.Argument;
 
 public final class ObjectIlaCheck {
     private ObjectIlaCheck() {
@@ -82,36 +83,32 @@ public final class ObjectIlaCheck {
 
     public static void checkFourFiveEquivalence(final ObjectIla<Object> ila, final int offsetLength, Object epsilon)
             throws Exception {
-        if (epsilon != Object.class) {
-            throw new IllegalArgumentException("epsilon != " + Object.class + " not allowed");
-        } else {
-            if (offsetLength < 0) throw new Exception("offsetLength < 0 not allowed");
+        Argument.assertNotLessThan(offsetLength, 0, "offsetLength");
 
-            final StridedObjectIla<Object> stridedObjectIla = StridedObjectIlaFromObjectIla.create(ila, new Object[10]);
-            final int ilaLength = ila.length() + offsetLength <= Integer.MAX_VALUE
-                    ? (int) ila.length()
-                    : Integer.MAX_VALUE - offsetLength;
-            for (int offset = 0; offset < offsetLength; ++offset) {
-                final Object[] four = new Object[ilaLength + offsetLength];
-                final Object[] five = new Object[ilaLength + offsetLength];
-                for (int length = 1; length <= ilaLength; ++length) {
-                    for (long start = 0; start < ilaLength - length + 1; ++start) {
-                        for (int ii = 0; ii < four.length; ++ii) {
-                            five[ii] = four[ii] = new Object();
-                        }
-                        ila.get(four, offset, start, length);
-                        stridedObjectIla.get(five, offset, 1, start, length);
-                        for (int ii = 0; ii < length; ++ii) {
-                            if (!(four[ii].equals(five[ii])))
-                                throw new Exception("four[" + ii + "] ("
-                                        + four[ii] + ") !~ five["
-                                        + ii + "] ("
-                                        + five[ii]
-                                        + ") {length=" + length
-                                        + ",start=" + start
-                                        + ",offset=" + offset
-                                        + "}");
-                        }
+        final StridedObjectIla<Object> stridedObjectIla = StridedObjectIlaFromObjectIla.create(ila, new Object[10]);
+        final int ilaLength = ila.length() + offsetLength <= Integer.MAX_VALUE
+                ? (int) ila.length()
+                : Integer.MAX_VALUE - offsetLength;
+        for (int offset = 0; offset < offsetLength; ++offset) {
+            final Object[] four = new Object[ilaLength + offsetLength];
+            final Object[] five = new Object[ilaLength + offsetLength];
+            for (int length = 1; length <= ilaLength; ++length) {
+                for (long start = 0; start < ilaLength - length + 1; ++start) {
+                    for (int ii = 0; ii < four.length; ++ii) {
+                        five[ii] = four[ii] = new Object();
+                    }
+                    ila.get(four, offset, start, length);
+                    stridedObjectIla.get(five, offset, 1, start, length);
+                    for (int ii = 0; ii < length; ++ii) {
+                        if (!(four[ii].equals(five[ii])))
+                            throw new Exception("four[" + ii + "] ("
+                                    + four[ii] + ") !~ five["
+                                    + ii + "] ("
+                                    + five[ii]
+                                    + ") {length=" + length
+                                    + ",start=" + start
+                                    + ",offset=" + offset
+                                    + "}");
                     }
                 }
             }
@@ -121,51 +118,47 @@ public final class ObjectIlaCheck {
     public static void checkCorrectness(
             ObjectIla<Object> target, ObjectIla<Object> actual, int addlOffsetLength, int maxAbsStride, Object epsilon)
             throws Exception {
-        if (epsilon != Object.class) {
-            throw new IllegalArgumentException("epsilon != " + Object.class + " not allowed");
-        } else {
-            if (addlOffsetLength < 0) throw new Exception("addlOffsetLength < 0 not allowed");
-            if (maxAbsStride < 1) throw new Exception("maxAbsStride < 1 not allowed");
-            if (target.length() != actual.length()) throw new Exception("target.length() != actual.length()");
+        Argument.assertNotLessThan(addlOffsetLength, 0, "addlOffsetLength");
+        Argument.assertNotLessThan(maxAbsStride, 1, "maxAbsStride");
+        Argument.assertEquals(target.length(), actual.length(), "target.length()", "actual.length()");
 
-            final StridedObjectIla<Object> stridedTarget = StridedObjectIlaFromObjectIla.create(target, new Object[10]);
-            final StridedObjectIla<Object> stridedActual = StridedObjectIlaFromObjectIla.create(target, new Object[10]);
-            final int ilaLength = target.length() + addlOffsetLength <= Integer.MAX_VALUE
-                    ? (int) target.length()
-                    : Integer.MAX_VALUE - addlOffsetLength;
-            for (int stride = -maxAbsStride; stride <= maxAbsStride; ++stride) {
-                if (stride != 0) {
-                    int absStride = stride < 0 ? -stride : stride;
-                    int offsetStart = stride < 0 ? (ilaLength - 1) * absStride : 0;
-                    int offsetEnd = offsetStart + addlOffsetLength;
-                    for (int offset = offsetStart; offset < offsetEnd; ++offset) {
-                        final int arraySize = (ilaLength - 1) * absStride + 1 + addlOffsetLength;
-                        final Object[] targetBase = new Object[arraySize];
-                        final Object[] actualBase = new Object[arraySize];
-                        for (int length = 1; length <= ilaLength; ++length) {
-                            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                                for (int ii = 0; ii < targetBase.length; ++ii) {
-                                    targetBase[ii] = actualBase[ii] = new Object();
-                                }
-                                stridedTarget.get(targetBase, offset, stride, start, length);
-                                stridedActual.get(actualBase, offset, stride, start, length);
-                                for (int ii = 0; ii < arraySize; ++ii) {
-                                    if (!(actualBase[ii].equals(targetBase[ii])))
-                                        throw new Exception("actual[" + ii
-                                                + "] ("
-                                                + actualBase[ii]
-                                                + ") !~ target["
-                                                + ii + "] ("
-                                                + targetBase[ii]
-                                                + ") {length="
-                                                + length
-                                                + ",start=" + start
-                                                + ",offset="
-                                                + offset
-                                                + ",stride="
-                                                + stride
-                                                + "}");
-                                }
+        final StridedObjectIla<Object> stridedTarget = StridedObjectIlaFromObjectIla.create(target, new Object[10]);
+        final StridedObjectIla<Object> stridedActual = StridedObjectIlaFromObjectIla.create(target, new Object[10]);
+        final int ilaLength = target.length() + addlOffsetLength <= Integer.MAX_VALUE
+                ? (int) target.length()
+                : Integer.MAX_VALUE - addlOffsetLength;
+        for (int stride = -maxAbsStride; stride <= maxAbsStride; ++stride) {
+            if (stride != 0) {
+                int absStride = stride < 0 ? -stride : stride;
+                int offsetStart = stride < 0 ? (ilaLength - 1) * absStride : 0;
+                int offsetEnd = offsetStart + addlOffsetLength;
+                for (int offset = offsetStart; offset < offsetEnd; ++offset) {
+                    final int arraySize = (ilaLength - 1) * absStride + 1 + addlOffsetLength;
+                    final Object[] targetBase = new Object[arraySize];
+                    final Object[] actualBase = new Object[arraySize];
+                    for (int length = 1; length <= ilaLength; ++length) {
+                        for (long start = 0; start < ilaLength - length + 1; ++start) {
+                            for (int ii = 0; ii < targetBase.length; ++ii) {
+                                targetBase[ii] = actualBase[ii] = new Object();
+                            }
+                            stridedTarget.get(targetBase, offset, stride, start, length);
+                            stridedActual.get(actualBase, offset, stride, start, length);
+                            for (int ii = 0; ii < arraySize; ++ii) {
+                                if (!(actualBase[ii].equals(targetBase[ii])))
+                                    throw new Exception("actual[" + ii
+                                            + "] ("
+                                            + actualBase[ii]
+                                            + ") !~ target["
+                                            + ii + "] ("
+                                            + targetBase[ii]
+                                            + ") {length="
+                                            + length
+                                            + ",start=" + start
+                                            + ",offset="
+                                            + offset
+                                            + ",stride="
+                                            + stride
+                                            + "}");
                             }
                         }
                     }

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaInterleaveTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaInterleaveTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
 final class ObjectIlaInterleaveTest {
-    @Test
     @SuppressWarnings("unchecked")
+    @Test
     void argumentsTest() {
         final ObjectIla<Object> ila1 = ObjectIlaFromArray.create(new Object[10]);
         final ObjectIla<Object> ila2 = ObjectIlaFromArray.create(new Object[20]);
@@ -52,8 +52,8 @@ final class ObjectIlaInterleaveTest {
                 .hasMessage("ilas[0].length() (=20) != ilas[1].length() (=10) not allowed!");
     }
 
-    @Test
     @SuppressWarnings("unchecked")
+    @Test
     void allTest() throws Exception {
         final int length = IlaTestDimensions.defaultIlaLength();
         for (int jj = 2; jj < 6; ++jj) {

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaIteratorTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaIteratorTest.java
@@ -1,14 +1,13 @@
 package tfw.immutable.ila.objectila;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
-class ObjectIlaIteratorTest {
+final class ObjectIlaIteratorTest {
     @Test
-    void testObjectIlaFill() throws IOException {
+    void objectIlaIteratorTest() throws IOException {
         final int LENGTH = 29;
         Object[] array = new Object[LENGTH];
 
@@ -21,14 +20,10 @@ class ObjectIlaIteratorTest {
 
         int i = 0;
         for (; ii.hasNext(); i++) {
-            if (i == array.length) {
-                fail("Iterator did not stop correctly");
-            }
-            assertEquals(ii.next(), array[i], "element " + i + " not equal!");
+            assertThat(i).isNotEqualTo(array.length);
+            assertThat(ii.next()).isEqualTo(array[i]);
         }
 
-        if (i != array.length) {
-            fail("Iterator stopped at " + i + " not " + array.length);
-        }
+        assertThat(i).isEqualTo(array.length);
     }
 }

--- a/src/test/java/tfw/immutable/ila/objectila/ObjectIlaUtilTest.java
+++ b/src/test/java/tfw/immutable/ila/objectila/ObjectIlaUtilTest.java
@@ -1,27 +1,27 @@
 package tfw.immutable.ila.objectila;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-class ObjectIlaUtilTest {
+final class ObjectIlaUtilTest {
     @Test
-    void testToArrayTwoArgs() throws Exception {
+    void toArrayTwoArgsTest() throws Exception {
         final String[] expectedStrings = new String[] {"Zero", "One", "Two", "Three", "Four"};
         final ObjectIla<String> stringsIla = ObjectIlaFromArray.create(expectedStrings);
         final String[] actualStringsShorter = ObjectIlaUtil.toArray(stringsIla, new String[0]);
 
-        assertArrayEquals(expectedStrings, actualStringsShorter);
+        assertThat(expectedStrings).isEqualTo(actualStringsShorter);
 
         final String[] actualStringsEqualLength =
                 ObjectIlaUtil.toArray(stringsIla, new String[(int) stringsIla.length()]);
 
-        assertArrayEquals(expectedStrings, actualStringsEqualLength);
+        assertThat(expectedStrings).isEqualTo(actualStringsEqualLength);
 
         final String[] expectedStrings2 = new String[] {"Zero", "One", "Two", "Three", "Four", null, "Six"};
         final String[] actualStringsLonger =
                 ObjectIlaUtil.toArray(stringsIla, new String[] {null, null, null, null, null, "Five", "Six"});
 
-        assertArrayEquals(expectedStrings2, actualStringsLonger);
+        assertThat(expectedStrings2).isEqualTo(actualStringsLonger);
     }
 }

--- a/src/test/java/tfw/immutable/ila/shortila/ShortIlaIteratorTest.java
+++ b/src/test/java/tfw/immutable/ila/shortila/ShortIlaIteratorTest.java
@@ -1,15 +1,14 @@
 package tfw.immutable.ila.shortila;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-class ShortIlaIteratorTest {
+final class ShortIlaIteratorTest {
     @Test
-    void testShortIlaFill() throws IOException {
+    void shortIlaIteratorTest() throws IOException {
         final Random random = new Random();
         final int LENGTH = 29;
         short[] array = new short[LENGTH];
@@ -23,14 +22,10 @@ class ShortIlaIteratorTest {
 
         int i = 0;
         for (; ii.hasNext(); i++) {
-            if (i == array.length) {
-                fail("Iterator did not stop correctly");
-            }
-            assertEquals(ii.next(), array[i], "element " + i + " not equal!");
+            assertThat(i).isNotEqualTo(array.length);
+            assertThat(ii.next()).isEqualTo(array[i]);
         }
 
-        if (i != array.length) {
-            fail("Iterator stopped at " + i + " not " + array.length);
-        }
+        assertThat(i).isEqualTo(array.length);
     }
 }

--- a/src/test/template/tfw/immutable/ila/__IlaCheck..NonNumeric.template
+++ b/src/test/template/tfw/immutable/ila/__IlaCheck..NonNumeric.template
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
-%%RANDOM_INCLUDE_2%%public final class %%NAME%%IlaCheck {
+%%RANDOM_INCLUDE%%import tfw.check.Argument;
+
+public final class %%NAME%%IlaCheck {
     private %%NAME%%IlaCheck() {
         // non-instantiable class
     }
@@ -82,36 +84,32 @@ import java.io.IOException;
 
     public static void checkFourFiveEquivalence(final %%NAME%%Ila%%TEMPLATE%% ila, final int offsetLength, %%TYPE%% epsilon)
             throws Exception {
-        if (epsilon != %%DEFAULT_VALUE%%) {
-            throw new IllegalArgumentException("epsilon != " + %%DEFAULT_VALUE%% + " not allowed");
-        } else {
-            if (offsetLength < 0) throw new Exception("offsetLength < 0 not allowed");
+        Argument.assertNotLessThan(offsetLength, 0, "offsetLength");
 
-            final Strided%%NAME%%Ila%%TEMPLATE%% strided%%NAME%%Ila = Strided%%NAME%%IlaFrom%%NAME%%Ila.create(ila, new %%TYPE%%[10]);
-            %%RANDOM_INIT_12%%final int ilaLength = ila.length() + offsetLength <= Integer.MAX_VALUE
-                    ? (int) ila.length()
-                    : Integer.MAX_VALUE - offsetLength;
-            for (int offset = 0; offset < offsetLength; ++offset) {
-                final %%TYPE%%[] four = new %%TYPE%%[ilaLength + offsetLength];
-                final %%TYPE%%[] five = new %%TYPE%%[ilaLength + offsetLength];
-                for (int length = 1; length <= ilaLength; ++length) {
-                    for (long start = 0; start < ilaLength - length + 1; ++start) {
-                        for (int ii = 0; ii < four.length; ++ii) {
-                            five[ii] = four[ii] = %%RANDOM_VALUE%%;
-                        }
-                        ila.get(four, offset, start, length);
-                        strided%%NAME%%Ila.get(five, offset, 1, start, length);
-                        for (int ii = 0; ii < length; ++ii) {
-                            if (!(four[ii]%%IS_EQUALS_START%%five[ii]%%IS_EQUALS_END%%))
-                                throw new Exception("four[" + ii + "] ("
-                                        + four[ii] + ") !~ five["
-                                        + ii + "] ("
-                                        + five[ii]
-                                        + ") {length=" + length
-                                        + ",start=" + start
-                                        + ",offset=" + offset
-                                        + "}");
-                        }
+        final Strided%%NAME%%Ila%%TEMPLATE%% strided%%NAME%%Ila = Strided%%NAME%%IlaFrom%%NAME%%Ila.create(ila, new %%TYPE%%[10]);
+        %%RANDOM_INIT_12%%final int ilaLength = ila.length() + offsetLength <= Integer.MAX_VALUE
+                ? (int) ila.length()
+                : Integer.MAX_VALUE - offsetLength;
+        for (int offset = 0; offset < offsetLength; ++offset) {
+            final %%TYPE%%[] four = new %%TYPE%%[ilaLength + offsetLength];
+            final %%TYPE%%[] five = new %%TYPE%%[ilaLength + offsetLength];
+            for (int length = 1; length <= ilaLength; ++length) {
+                for (long start = 0; start < ilaLength - length + 1; ++start) {
+                    for (int ii = 0; ii < four.length; ++ii) {
+                        five[ii] = four[ii] = %%RANDOM_VALUE%%;
+                    }
+                    ila.get(four, offset, start, length);
+                    strided%%NAME%%Ila.get(five, offset, 1, start, length);
+                    for (int ii = 0; ii < length; ++ii) {
+                        if (!(four[ii]%%IS_EQUALS_START%%five[ii]%%IS_EQUALS_END%%))
+                            throw new Exception("four[" + ii + "] ("
+                                    + four[ii] + ") !~ five["
+                                    + ii + "] ("
+                                    + five[ii]
+                                    + ") {length=" + length
+                                    + ",start=" + start
+                                    + ",offset=" + offset
+                                    + "}");
                     }
                 }
             }
@@ -121,51 +119,47 @@ import java.io.IOException;
     public static void checkCorrectness(
             %%NAME%%Ila%%TEMPLATE%% target, %%NAME%%Ila%%TEMPLATE%% actual, int addlOffsetLength, int maxAbsStride, %%TYPE%% epsilon)
             throws Exception {
-        if (epsilon != %%DEFAULT_VALUE%%) {
-            throw new IllegalArgumentException("epsilon != " + %%DEFAULT_VALUE%% + " not allowed");
-        } else {
-            if (addlOffsetLength < 0) throw new Exception("addlOffsetLength < 0 not allowed");
-            if (maxAbsStride < 1) throw new Exception("maxAbsStride < 1 not allowed");
-            if (target.length() != actual.length()) throw new Exception("target.length() != actual.length()");
+        Argument.assertNotLessThan(addlOffsetLength, 0, "addlOffsetLength");
+        Argument.assertNotLessThan(maxAbsStride, 1, "maxAbsStride");
+        Argument.assertEquals(target.length(), actual.length(), "target.length()", "actual.length()");
 
-            final Strided%%NAME%%Ila%%TEMPLATE%% stridedTarget = Strided%%NAME%%IlaFrom%%NAME%%Ila.create(target, new %%TYPE%%[10]);
-            final Strided%%NAME%%Ila%%TEMPLATE%% stridedActual = Strided%%NAME%%IlaFrom%%NAME%%Ila.create(target, new %%TYPE%%[10]);
-            %%RANDOM_INIT_12%%final int ilaLength = target.length() + addlOffsetLength <= Integer.MAX_VALUE
-                    ? (int) target.length()
-                    : Integer.MAX_VALUE - addlOffsetLength;
-            for (int stride = -maxAbsStride; stride <= maxAbsStride; ++stride) {
-                if (stride != 0) {
-                    int absStride = stride < 0 ? -stride : stride;
-                    int offsetStart = stride < 0 ? (ilaLength - 1) * absStride : 0;
-                    int offsetEnd = offsetStart + addlOffsetLength;
-                    for (int offset = offsetStart; offset < offsetEnd; ++offset) {
-                        final int arraySize = (ilaLength - 1) * absStride + 1 + addlOffsetLength;
-                        final %%TYPE%%[] targetBase = new %%TYPE%%[arraySize];
-                        final %%TYPE%%[] actualBase = new %%TYPE%%[arraySize];
-                        for (int length = 1; length <= ilaLength; ++length) {
-                            for (long start = 0; start < ilaLength - length + 1; ++start) {
-                                for (int ii = 0; ii < targetBase.length; ++ii) {
-                                    targetBase[ii] = actualBase[ii] = %%RANDOM_VALUE%%;
-                                }
-                                stridedTarget.get(targetBase, offset, stride, start, length);
-                                stridedActual.get(actualBase, offset, stride, start, length);
-                                for (int ii = 0; ii < arraySize; ++ii) {
-                                    if (!(actualBase[ii]%%IS_EQUALS_START%%targetBase[ii]%%IS_EQUALS_END%%))
-                                        throw new Exception("actual[" + ii
-                                                + "] ("
-                                                + actualBase[ii]
-                                                + ") !~ target["
-                                                + ii + "] ("
-                                                + targetBase[ii]
-                                                + ") {length="
-                                                + length
-                                                + ",start=" + start
-                                                + ",offset="
-                                                + offset
-                                                + ",stride="
-                                                + stride
-                                                + "}");
-                                }
+        final Strided%%NAME%%Ila%%TEMPLATE%% stridedTarget = Strided%%NAME%%IlaFrom%%NAME%%Ila.create(target, new %%TYPE%%[10]);
+        final Strided%%NAME%%Ila%%TEMPLATE%% stridedActual = Strided%%NAME%%IlaFrom%%NAME%%Ila.create(target, new %%TYPE%%[10]);
+        %%RANDOM_INIT_12%%final int ilaLength = target.length() + addlOffsetLength <= Integer.MAX_VALUE
+                ? (int) target.length()
+                : Integer.MAX_VALUE - addlOffsetLength;
+        for (int stride = -maxAbsStride; stride <= maxAbsStride; ++stride) {
+            if (stride != 0) {
+                int absStride = stride < 0 ? -stride : stride;
+                int offsetStart = stride < 0 ? (ilaLength - 1) * absStride : 0;
+                int offsetEnd = offsetStart + addlOffsetLength;
+                for (int offset = offsetStart; offset < offsetEnd; ++offset) {
+                    final int arraySize = (ilaLength - 1) * absStride + 1 + addlOffsetLength;
+                    final %%TYPE%%[] targetBase = new %%TYPE%%[arraySize];
+                    final %%TYPE%%[] actualBase = new %%TYPE%%[arraySize];
+                    for (int length = 1; length <= ilaLength; ++length) {
+                        for (long start = 0; start < ilaLength - length + 1; ++start) {
+                            for (int ii = 0; ii < targetBase.length; ++ii) {
+                                targetBase[ii] = actualBase[ii] = %%RANDOM_VALUE%%;
+                            }
+                            stridedTarget.get(targetBase, offset, stride, start, length);
+                            stridedActual.get(actualBase, offset, stride, start, length);
+                            for (int ii = 0; ii < arraySize; ++ii) {
+                                if (!(actualBase[ii]%%IS_EQUALS_START%%targetBase[ii]%%IS_EQUALS_END%%))
+                                    throw new Exception("actual[" + ii
+                                            + "] ("
+                                            + actualBase[ii]
+                                            + ") !~ target["
+                                            + ii + "] ("
+                                            + targetBase[ii]
+                                            + ") {length="
+                                            + length
+                                            + ",start=" + start
+                                            + ",offset="
+                                            + offset
+                                            + ",stride="
+                                            + stride
+                                            + "}");
                             }
                         }
                     }

--- a/src/test/template/tfw/immutable/ila/__IlaInterleaveTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaInterleaveTest.template
@@ -8,7 +8,7 @@ import java.lang.reflect.Array;
 import tfw.immutable.ila.IlaTestDimensions;
 
 final class %%NAME%%IlaInterleaveTest {
-    @Test%%SUPPRESS%%
+    %%SUPPRESS%%@Test
     void argumentsTest() {
         final %%NAME%%Ila%%TEMPLATE%% ila1 = %%NAME%%IlaFromArray.create(new %%TYPE%%[10]);
         final %%NAME%%Ila%%TEMPLATE%% ila2 = %%NAME%%IlaFromArray.create(new %%TYPE%%[20]);
@@ -52,7 +52,7 @@ final class %%NAME%%IlaInterleaveTest {
                 .hasMessage("ilas[0].length() (=20) != ilas[1].length() (=10) not allowed!");
     }
 
-    @Test%%SUPPRESS%%
+    %%SUPPRESS%%@Test
     void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         for (int jj = 2; jj < 6; ++jj) {

--- a/src/test/template/tfw/immutable/ila/__IlaInvertTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaInvertTest.template
@@ -1,19 +1,21 @@
 // doubleila,floatila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaInvertTest {
+final class %%NAME%%IlaInvertTest {
     @Test
-    void testArguments() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaInvert.create(null));
+    void argumentsTest() throws Exception {
+        assertThatThrownBy(() -> %%NAME%%IlaInvert.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%%[] array = new %%TYPE%%[length];
         final %%TYPE%%[] target = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/__IlaRoundTest.template
+++ b/src/test/template/tfw/immutable/ila/__IlaRoundTest.template
@@ -1,19 +1,21 @@
 // doubleila,floatila
 package %%PACKAGE%%;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 %%RANDOM_INCLUDE%%import org.junit.jupiter.api.Test;
 import tfw.immutable.ila.IlaTestDimensions;
 
-class %%NAME%%IlaRoundTest {
+final class %%NAME%%IlaRoundTest {
     @Test
-    void testArguments() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> %%NAME%%IlaRound.create(null));
+    void argumentsTest() throws Exception {
+        assertThatThrownBy(() -> %%NAME%%IlaRound.create(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ila == null not allowed!");
     }
 
     @Test
-    void testAll() throws Exception {
+    void allTest() throws Exception {
         %%RANDOM_INIT%%final int length = IlaTestDimensions.defaultIlaLength();
         final %%TYPE%%[] array = new %%TYPE%%[length];
         final %%TYPE%%[] target = new %%TYPE%%[length];

--- a/src/test/template/tfw/immutable/ila/booleanila.mapping
+++ b/src/test/template/tfw/immutable/ila/booleanila.mapping
@@ -7,7 +7,7 @@
 %%RANDOM_INCLUDE_2%%=import java.util.Random;\n\n
 %%RANDOM_INIT_0%%=final Random random = new Random(0);\n
 %%RANDOM_INIT%%=final Random random = new Random(0);\n\ \ \ \ \ \ \ \ 
-%%RANDOM_INIT_12%%=final Random random = new Random(0);\n\ \ \ \ \ \ \ \ \ \ \ \ 
+%%RANDOM_INIT_12%%=final Random random = new Random(0);\n\ \ \ \ \ \ \ \ 
 %%DEFAULT_VALUE%%=false
 %%ASSERT_EQUALS_DELTA%% =
 %%CREATE_IMMUTABLE_START%% = new Boolean(

--- a/src/test/template/tfw/immutable/ila/objectila.mapping
+++ b/src/test/template/tfw/immutable/ila/objectila.mapping
@@ -15,7 +15,7 @@
 %%IS_EQUALS_START%% = .equals(
 %%IS_EQUALS_END%% = )
 %%TEMPLATE%% = <Object>
-%%SUPPRESS%% = \n\ \ \ \ @SuppressWarnings("unchecked")
+%%SUPPRESS%% = @SuppressWarnings("unchecked")\n\ \ \ \ 
 %%FULL_CAST%% = (ObjectIla<Object>[])\ 
 %%DIAMOND%% = <>
 %%CHAR_CAST_TO_INT%% =


### PR DESCRIPTION
This PR updates the ila tests to use AssertJ.

## Summary by Sourcery

Replace manual argument checking with Argument class methods in tests.

Tests:
- Use AssertJ assertions instead of manual checks and JUnit assertions in iterator tests.
- Use Argument class methods for argument checking in tests.