### PR TITLE
Add IlaFactory implementations - Part 3.

### DIFF
--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaDivide.java
@@ -8,12 +8,7 @@ public final class ByteIlaDivide {
         // non-instantiable class
     }
 
-    public static ByteIla create(ByteIla leftIla, ByteIla rightIla, int bufferSize) throws IOException {
-        Argument.assertNotNull(leftIla, "leftIla");
-        Argument.assertNotNull(rightIla, "rightIla");
-        Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
+    public static ByteIla create(ByteIla leftIla, ByteIla rightIla, int bufferSize) {
         return new ByteIlaImpl(leftIla, rightIla, bufferSize);
     }
 
@@ -23,6 +18,15 @@ public final class ByteIlaDivide {
         private final int bufferSize;
 
         private ByteIlaImpl(ByteIla leftIla, ByteIla rightIla, int bufferSize) {
+            Argument.assertNotNull(leftIla, "leftIla");
+            Argument.assertNotNull(rightIla, "rightIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+            try {
+                Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Could not get ila length!", e);
+            }
+
             this.leftIla = leftIla;
             this.rightIla = rightIla;
             this.bufferSize = bufferSize;

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastCharIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastCharIla.java
@@ -12,9 +12,6 @@ public final class ByteIlaFromCastCharIla {
     }
 
     public static ByteIla create(CharIla charIla, int bufferSize) {
-        Argument.assertNotNull(charIla, "charIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new ByteIlaImpl(charIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class ByteIlaFromCastCharIla {
         private final int bufferSize;
 
         private ByteIlaImpl(CharIla charIla, int bufferSize) {
+            Argument.assertNotNull(charIla, "charIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.charIla = charIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastDoubleIla.java
@@ -12,9 +12,6 @@ public final class ByteIlaFromCastDoubleIla {
     }
 
     public static ByteIla create(DoubleIla doubleIla, int bufferSize) {
-        Argument.assertNotNull(doubleIla, "doubleIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new ByteIlaImpl(doubleIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class ByteIlaFromCastDoubleIla {
         private final int bufferSize;
 
         private ByteIlaImpl(DoubleIla doubleIla, int bufferSize) {
+            Argument.assertNotNull(doubleIla, "doubleIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.doubleIla = doubleIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastFloatIla.java
@@ -12,9 +12,6 @@ public final class ByteIlaFromCastFloatIla {
     }
 
     public static ByteIla create(FloatIla floatIla, int bufferSize) {
-        Argument.assertNotNull(floatIla, "floatIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new ByteIlaImpl(floatIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class ByteIlaFromCastFloatIla {
         private final int bufferSize;
 
         private ByteIlaImpl(FloatIla floatIla, int bufferSize) {
+            Argument.assertNotNull(floatIla, "floatIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.floatIla = floatIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastIntIla.java
@@ -12,9 +12,6 @@ public final class ByteIlaFromCastIntIla {
     }
 
     public static ByteIla create(IntIla intIla, int bufferSize) {
-        Argument.assertNotNull(intIla, "intIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new ByteIlaImpl(intIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class ByteIlaFromCastIntIla {
         private final int bufferSize;
 
         private ByteIlaImpl(IntIla intIla, int bufferSize) {
+            Argument.assertNotNull(intIla, "intIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.intIla = intIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastLongIla.java
@@ -12,9 +12,6 @@ public final class ByteIlaFromCastLongIla {
     }
 
     public static ByteIla create(LongIla longIla, int bufferSize) {
-        Argument.assertNotNull(longIla, "longIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new ByteIlaImpl(longIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class ByteIlaFromCastLongIla {
         private final int bufferSize;
 
         private ByteIlaImpl(LongIla longIla, int bufferSize) {
+            Argument.assertNotNull(longIla, "longIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.longIla = longIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIla.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromCastShortIla.java
@@ -12,9 +12,6 @@ public final class ByteIlaFromCastShortIla {
     }
 
     public static ByteIla create(ShortIla shortIla, int bufferSize) {
-        Argument.assertNotNull(shortIla, "shortIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new ByteIlaImpl(shortIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class ByteIlaFromCastShortIla {
         private final int bufferSize;
 
         private ByteIlaImpl(ShortIla shortIla, int bufferSize) {
+            Argument.assertNotNull(shortIla, "shortIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.shortIla = shortIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaDivide.java
@@ -8,12 +8,7 @@ public final class CharIlaDivide {
         // non-instantiable class
     }
 
-    public static CharIla create(CharIla leftIla, CharIla rightIla, int bufferSize) throws IOException {
-        Argument.assertNotNull(leftIla, "leftIla");
-        Argument.assertNotNull(rightIla, "rightIla");
-        Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
+    public static CharIla create(CharIla leftIla, CharIla rightIla, int bufferSize) {
         return new CharIlaImpl(leftIla, rightIla, bufferSize);
     }
 
@@ -23,6 +18,15 @@ public final class CharIlaDivide {
         private final int bufferSize;
 
         private CharIlaImpl(CharIla leftIla, CharIla rightIla, int bufferSize) {
+            Argument.assertNotNull(leftIla, "leftIla");
+            Argument.assertNotNull(rightIla, "rightIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+            try {
+                Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Could not get ila length!", e);
+            }
+
             this.leftIla = leftIla;
             this.rightIla = rightIla;
             this.bufferSize = bufferSize;

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastByteIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastByteIla.java
@@ -12,9 +12,6 @@ public final class CharIlaFromCastByteIla {
     }
 
     public static CharIla create(ByteIla byteIla, int bufferSize) {
-        Argument.assertNotNull(byteIla, "byteIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new CharIlaImpl(byteIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class CharIlaFromCastByteIla {
         private final int bufferSize;
 
         private CharIlaImpl(ByteIla byteIla, int bufferSize) {
+            Argument.assertNotNull(byteIla, "byteIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.byteIla = byteIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastDoubleIla.java
@@ -12,9 +12,6 @@ public final class CharIlaFromCastDoubleIla {
     }
 
     public static CharIla create(DoubleIla doubleIla, int bufferSize) {
-        Argument.assertNotNull(doubleIla, "doubleIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new CharIlaImpl(doubleIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class CharIlaFromCastDoubleIla {
         private final int bufferSize;
 
         private CharIlaImpl(DoubleIla doubleIla, int bufferSize) {
+            Argument.assertNotNull(doubleIla, "doubleIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.doubleIla = doubleIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastFloatIla.java
@@ -12,9 +12,6 @@ public final class CharIlaFromCastFloatIla {
     }
 
     public static CharIla create(FloatIla floatIla, int bufferSize) {
-        Argument.assertNotNull(floatIla, "floatIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new CharIlaImpl(floatIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class CharIlaFromCastFloatIla {
         private final int bufferSize;
 
         private CharIlaImpl(FloatIla floatIla, int bufferSize) {
+            Argument.assertNotNull(floatIla, "floatIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.floatIla = floatIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastIntIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastIntIla.java
@@ -12,9 +12,6 @@ public final class CharIlaFromCastIntIla {
     }
 
     public static CharIla create(IntIla intIla, int bufferSize) {
-        Argument.assertNotNull(intIla, "intIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new CharIlaImpl(intIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class CharIlaFromCastIntIla {
         private final int bufferSize;
 
         private CharIlaImpl(IntIla intIla, int bufferSize) {
+            Argument.assertNotNull(intIla, "intIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.intIla = intIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastLongIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastLongIla.java
@@ -12,9 +12,6 @@ public final class CharIlaFromCastLongIla {
     }
 
     public static CharIla create(LongIla longIla, int bufferSize) {
-        Argument.assertNotNull(longIla, "longIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new CharIlaImpl(longIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class CharIlaFromCastLongIla {
         private final int bufferSize;
 
         private CharIlaImpl(LongIla longIla, int bufferSize) {
+            Argument.assertNotNull(longIla, "longIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.longIla = longIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastShortIla.java
+++ b/src/main/java/tfw/immutable/ila/charila/CharIlaFromCastShortIla.java
@@ -12,9 +12,6 @@ public final class CharIlaFromCastShortIla {
     }
 
     public static CharIla create(ShortIla shortIla, int bufferSize) {
-        Argument.assertNotNull(shortIla, "shortIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new CharIlaImpl(shortIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class CharIlaFromCastShortIla {
         private final int bufferSize;
 
         private CharIlaImpl(ShortIla shortIla, int bufferSize) {
+            Argument.assertNotNull(shortIla, "shortIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.shortIla = shortIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaDivide.java
@@ -8,12 +8,7 @@ public final class DoubleIlaDivide {
         // non-instantiable class
     }
 
-    public static DoubleIla create(DoubleIla leftIla, DoubleIla rightIla, int bufferSize) throws IOException {
-        Argument.assertNotNull(leftIla, "leftIla");
-        Argument.assertNotNull(rightIla, "rightIla");
-        Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
+    public static DoubleIla create(DoubleIla leftIla, DoubleIla rightIla, int bufferSize) {
         return new DoubleIlaImpl(leftIla, rightIla, bufferSize);
     }
 
@@ -23,6 +18,15 @@ public final class DoubleIlaDivide {
         private final int bufferSize;
 
         private DoubleIlaImpl(DoubleIla leftIla, DoubleIla rightIla, int bufferSize) {
+            Argument.assertNotNull(leftIla, "leftIla");
+            Argument.assertNotNull(rightIla, "rightIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+            try {
+                Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Could not get ila length!", e);
+            }
+
             this.leftIla = leftIla;
             this.rightIla = rightIla;
             this.bufferSize = bufferSize;

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastByteIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastByteIla.java
@@ -12,9 +12,6 @@ public final class DoubleIlaFromCastByteIla {
     }
 
     public static DoubleIla create(ByteIla byteIla, int bufferSize) {
-        Argument.assertNotNull(byteIla, "byteIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new DoubleIlaImpl(byteIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class DoubleIlaFromCastByteIla {
         private final int bufferSize;
 
         private DoubleIlaImpl(ByteIla byteIla, int bufferSize) {
+            Argument.assertNotNull(byteIla, "byteIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.byteIla = byteIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastCharIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastCharIla.java
@@ -12,9 +12,6 @@ public final class DoubleIlaFromCastCharIla {
     }
 
     public static DoubleIla create(CharIla charIla, int bufferSize) {
-        Argument.assertNotNull(charIla, "charIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new DoubleIlaImpl(charIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class DoubleIlaFromCastCharIla {
         private final int bufferSize;
 
         private DoubleIlaImpl(CharIla charIla, int bufferSize) {
+            Argument.assertNotNull(charIla, "charIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.charIla = charIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastFloatIla.java
@@ -12,9 +12,6 @@ public final class DoubleIlaFromCastFloatIla {
     }
 
     public static DoubleIla create(FloatIla floatIla, int bufferSize) {
-        Argument.assertNotNull(floatIla, "floatIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new DoubleIlaImpl(floatIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class DoubleIlaFromCastFloatIla {
         private final int bufferSize;
 
         private DoubleIlaImpl(FloatIla floatIla, int bufferSize) {
+            Argument.assertNotNull(floatIla, "floatIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.floatIla = floatIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastIntIla.java
@@ -12,9 +12,6 @@ public final class DoubleIlaFromCastIntIla {
     }
 
     public static DoubleIla create(IntIla intIla, int bufferSize) {
-        Argument.assertNotNull(intIla, "intIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new DoubleIlaImpl(intIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class DoubleIlaFromCastIntIla {
         private final int bufferSize;
 
         private DoubleIlaImpl(IntIla intIla, int bufferSize) {
+            Argument.assertNotNull(intIla, "intIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.intIla = intIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastLongIla.java
@@ -12,9 +12,6 @@ public final class DoubleIlaFromCastLongIla {
     }
 
     public static DoubleIla create(LongIla longIla, int bufferSize) {
-        Argument.assertNotNull(longIla, "longIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new DoubleIlaImpl(longIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class DoubleIlaFromCastLongIla {
         private final int bufferSize;
 
         private DoubleIlaImpl(LongIla longIla, int bufferSize) {
+            Argument.assertNotNull(longIla, "longIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.longIla = longIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIla.java
+++ b/src/main/java/tfw/immutable/ila/doubleila/DoubleIlaFromCastShortIla.java
@@ -12,9 +12,6 @@ public final class DoubleIlaFromCastShortIla {
     }
 
     public static DoubleIla create(ShortIla shortIla, int bufferSize) {
-        Argument.assertNotNull(shortIla, "shortIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new DoubleIlaImpl(shortIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class DoubleIlaFromCastShortIla {
         private final int bufferSize;
 
         private DoubleIlaImpl(ShortIla shortIla, int bufferSize) {
+            Argument.assertNotNull(shortIla, "shortIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.shortIla = shortIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaDivide.java
@@ -8,12 +8,7 @@ public final class FloatIlaDivide {
         // non-instantiable class
     }
 
-    public static FloatIla create(FloatIla leftIla, FloatIla rightIla, int bufferSize) throws IOException {
-        Argument.assertNotNull(leftIla, "leftIla");
-        Argument.assertNotNull(rightIla, "rightIla");
-        Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
+    public static FloatIla create(FloatIla leftIla, FloatIla rightIla, int bufferSize) {
         return new FloatIlaImpl(leftIla, rightIla, bufferSize);
     }
 
@@ -23,6 +18,15 @@ public final class FloatIlaDivide {
         private final int bufferSize;
 
         private FloatIlaImpl(FloatIla leftIla, FloatIla rightIla, int bufferSize) {
+            Argument.assertNotNull(leftIla, "leftIla");
+            Argument.assertNotNull(rightIla, "rightIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+            try {
+                Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Could not get ila length!", e);
+            }
+
             this.leftIla = leftIla;
             this.rightIla = rightIla;
             this.bufferSize = bufferSize;

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastByteIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastByteIla.java
@@ -12,9 +12,6 @@ public final class FloatIlaFromCastByteIla {
     }
 
     public static FloatIla create(ByteIla byteIla, int bufferSize) {
-        Argument.assertNotNull(byteIla, "byteIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new FloatIlaImpl(byteIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class FloatIlaFromCastByteIla {
         private final int bufferSize;
 
         private FloatIlaImpl(ByteIla byteIla, int bufferSize) {
+            Argument.assertNotNull(byteIla, "byteIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.byteIla = byteIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastCharIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastCharIla.java
@@ -12,9 +12,6 @@ public final class FloatIlaFromCastCharIla {
     }
 
     public static FloatIla create(CharIla charIla, int bufferSize) {
-        Argument.assertNotNull(charIla, "charIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new FloatIlaImpl(charIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class FloatIlaFromCastCharIla {
         private final int bufferSize;
 
         private FloatIlaImpl(CharIla charIla, int bufferSize) {
+            Argument.assertNotNull(charIla, "charIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.charIla = charIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastDoubleIla.java
@@ -12,9 +12,6 @@ public final class FloatIlaFromCastDoubleIla {
     }
 
     public static FloatIla create(DoubleIla doubleIla, int bufferSize) {
-        Argument.assertNotNull(doubleIla, "doubleIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new FloatIlaImpl(doubleIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class FloatIlaFromCastDoubleIla {
         private final int bufferSize;
 
         private FloatIlaImpl(DoubleIla doubleIla, int bufferSize) {
+            Argument.assertNotNull(doubleIla, "doubleIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.doubleIla = doubleIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastIntIla.java
@@ -12,9 +12,6 @@ public final class FloatIlaFromCastIntIla {
     }
 
     public static FloatIla create(IntIla intIla, int bufferSize) {
-        Argument.assertNotNull(intIla, "intIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new FloatIlaImpl(intIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class FloatIlaFromCastIntIla {
         private final int bufferSize;
 
         private FloatIlaImpl(IntIla intIla, int bufferSize) {
+            Argument.assertNotNull(intIla, "intIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.intIla = intIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastLongIla.java
@@ -12,9 +12,6 @@ public final class FloatIlaFromCastLongIla {
     }
 
     public static FloatIla create(LongIla longIla, int bufferSize) {
-        Argument.assertNotNull(longIla, "longIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new FloatIlaImpl(longIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class FloatIlaFromCastLongIla {
         private final int bufferSize;
 
         private FloatIlaImpl(LongIla longIla, int bufferSize) {
+            Argument.assertNotNull(longIla, "longIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.longIla = longIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIla.java
+++ b/src/main/java/tfw/immutable/ila/floatila/FloatIlaFromCastShortIla.java
@@ -12,9 +12,6 @@ public final class FloatIlaFromCastShortIla {
     }
 
     public static FloatIla create(ShortIla shortIla, int bufferSize) {
-        Argument.assertNotNull(shortIla, "shortIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new FloatIlaImpl(shortIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class FloatIlaFromCastShortIla {
         private final int bufferSize;
 
         private FloatIlaImpl(ShortIla shortIla, int bufferSize) {
+            Argument.assertNotNull(shortIla, "shortIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.shortIla = shortIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaDivide.java
@@ -8,12 +8,7 @@ public final class IntIlaDivide {
         // non-instantiable class
     }
 
-    public static IntIla create(IntIla leftIla, IntIla rightIla, int bufferSize) throws IOException {
-        Argument.assertNotNull(leftIla, "leftIla");
-        Argument.assertNotNull(rightIla, "rightIla");
-        Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
+    public static IntIla create(IntIla leftIla, IntIla rightIla, int bufferSize) {
         return new IntIlaImpl(leftIla, rightIla, bufferSize);
     }
 
@@ -23,6 +18,15 @@ public final class IntIlaDivide {
         private final int bufferSize;
 
         private IntIlaImpl(IntIla leftIla, IntIla rightIla, int bufferSize) {
+            Argument.assertNotNull(leftIla, "leftIla");
+            Argument.assertNotNull(rightIla, "rightIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+            try {
+                Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Could not get ila length!", e);
+            }
+
             this.leftIla = leftIla;
             this.rightIla = rightIla;
             this.bufferSize = bufferSize;

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastByteIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastByteIla.java
@@ -12,9 +12,6 @@ public final class IntIlaFromCastByteIla {
     }
 
     public static IntIla create(ByteIla byteIla, int bufferSize) {
-        Argument.assertNotNull(byteIla, "byteIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new IntIlaImpl(byteIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class IntIlaFromCastByteIla {
         private final int bufferSize;
 
         private IntIlaImpl(ByteIla byteIla, int bufferSize) {
+            Argument.assertNotNull(byteIla, "byteIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.byteIla = byteIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastCharIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastCharIla.java
@@ -12,9 +12,6 @@ public final class IntIlaFromCastCharIla {
     }
 
     public static IntIla create(CharIla charIla, int bufferSize) {
-        Argument.assertNotNull(charIla, "charIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new IntIlaImpl(charIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class IntIlaFromCastCharIla {
         private final int bufferSize;
 
         private IntIlaImpl(CharIla charIla, int bufferSize) {
+            Argument.assertNotNull(charIla, "charIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.charIla = charIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastDoubleIla.java
@@ -12,9 +12,6 @@ public final class IntIlaFromCastDoubleIla {
     }
 
     public static IntIla create(DoubleIla doubleIla, int bufferSize) {
-        Argument.assertNotNull(doubleIla, "doubleIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new IntIlaImpl(doubleIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class IntIlaFromCastDoubleIla {
         private final int bufferSize;
 
         private IntIlaImpl(DoubleIla doubleIla, int bufferSize) {
+            Argument.assertNotNull(doubleIla, "doubleIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.doubleIla = doubleIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastFloatIla.java
@@ -12,9 +12,6 @@ public final class IntIlaFromCastFloatIla {
     }
 
     public static IntIla create(FloatIla floatIla, int bufferSize) {
-        Argument.assertNotNull(floatIla, "floatIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new IntIlaImpl(floatIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class IntIlaFromCastFloatIla {
         private final int bufferSize;
 
         private IntIlaImpl(FloatIla floatIla, int bufferSize) {
+            Argument.assertNotNull(floatIla, "floatIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.floatIla = floatIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastLongIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastLongIla.java
@@ -12,9 +12,6 @@ public final class IntIlaFromCastLongIla {
     }
 
     public static IntIla create(LongIla longIla, int bufferSize) {
-        Argument.assertNotNull(longIla, "longIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new IntIlaImpl(longIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class IntIlaFromCastLongIla {
         private final int bufferSize;
 
         private IntIlaImpl(LongIla longIla, int bufferSize) {
+            Argument.assertNotNull(longIla, "longIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.longIla = longIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastShortIla.java
+++ b/src/main/java/tfw/immutable/ila/intila/IntIlaFromCastShortIla.java
@@ -12,9 +12,6 @@ public final class IntIlaFromCastShortIla {
     }
 
     public static IntIla create(ShortIla shortIla, int bufferSize) {
-        Argument.assertNotNull(shortIla, "shortIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new IntIlaImpl(shortIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class IntIlaFromCastShortIla {
         private final int bufferSize;
 
         private IntIlaImpl(ShortIla shortIla, int bufferSize) {
+            Argument.assertNotNull(shortIla, "shortIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.shortIla = shortIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaDivide.java
@@ -8,12 +8,7 @@ public final class LongIlaDivide {
         // non-instantiable class
     }
 
-    public static LongIla create(LongIla leftIla, LongIla rightIla, int bufferSize) throws IOException {
-        Argument.assertNotNull(leftIla, "leftIla");
-        Argument.assertNotNull(rightIla, "rightIla");
-        Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
+    public static LongIla create(LongIla leftIla, LongIla rightIla, int bufferSize) {
         return new LongIlaImpl(leftIla, rightIla, bufferSize);
     }
 
@@ -23,6 +18,15 @@ public final class LongIlaDivide {
         private final int bufferSize;
 
         private LongIlaImpl(LongIla leftIla, LongIla rightIla, int bufferSize) {
+            Argument.assertNotNull(leftIla, "leftIla");
+            Argument.assertNotNull(rightIla, "rightIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+            try {
+                Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Could not get ila length!", e);
+            }
+
             this.leftIla = leftIla;
             this.rightIla = rightIla;
             this.bufferSize = bufferSize;

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastByteIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastByteIla.java
@@ -12,9 +12,6 @@ public final class LongIlaFromCastByteIla {
     }
 
     public static LongIla create(ByteIla byteIla, int bufferSize) {
-        Argument.assertNotNull(byteIla, "byteIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new LongIlaImpl(byteIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class LongIlaFromCastByteIla {
         private final int bufferSize;
 
         private LongIlaImpl(ByteIla byteIla, int bufferSize) {
+            Argument.assertNotNull(byteIla, "byteIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.byteIla = byteIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastCharIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastCharIla.java
@@ -12,9 +12,6 @@ public final class LongIlaFromCastCharIla {
     }
 
     public static LongIla create(CharIla charIla, int bufferSize) {
-        Argument.assertNotNull(charIla, "charIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new LongIlaImpl(charIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class LongIlaFromCastCharIla {
         private final int bufferSize;
 
         private LongIlaImpl(CharIla charIla, int bufferSize) {
+            Argument.assertNotNull(charIla, "charIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.charIla = charIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastDoubleIla.java
@@ -12,9 +12,6 @@ public final class LongIlaFromCastDoubleIla {
     }
 
     public static LongIla create(DoubleIla doubleIla, int bufferSize) {
-        Argument.assertNotNull(doubleIla, "doubleIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new LongIlaImpl(doubleIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class LongIlaFromCastDoubleIla {
         private final int bufferSize;
 
         private LongIlaImpl(DoubleIla doubleIla, int bufferSize) {
+            Argument.assertNotNull(doubleIla, "doubleIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.doubleIla = doubleIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastFloatIla.java
@@ -12,9 +12,6 @@ public final class LongIlaFromCastFloatIla {
     }
 
     public static LongIla create(FloatIla floatIla, int bufferSize) {
-        Argument.assertNotNull(floatIla, "floatIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new LongIlaImpl(floatIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class LongIlaFromCastFloatIla {
         private final int bufferSize;
 
         private LongIlaImpl(FloatIla floatIla, int bufferSize) {
+            Argument.assertNotNull(floatIla, "floatIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.floatIla = floatIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastIntIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastIntIla.java
@@ -12,9 +12,6 @@ public final class LongIlaFromCastIntIla {
     }
 
     public static LongIla create(IntIla intIla, int bufferSize) {
-        Argument.assertNotNull(intIla, "intIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new LongIlaImpl(intIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class LongIlaFromCastIntIla {
         private final int bufferSize;
 
         private LongIlaImpl(IntIla intIla, int bufferSize) {
+            Argument.assertNotNull(intIla, "intIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.intIla = intIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastShortIla.java
+++ b/src/main/java/tfw/immutable/ila/longila/LongIlaFromCastShortIla.java
@@ -12,9 +12,6 @@ public final class LongIlaFromCastShortIla {
     }
 
     public static LongIla create(ShortIla shortIla, int bufferSize) {
-        Argument.assertNotNull(shortIla, "shortIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new LongIlaImpl(shortIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class LongIlaFromCastShortIla {
         private final int bufferSize;
 
         private LongIlaImpl(ShortIla shortIla, int bufferSize) {
+            Argument.assertNotNull(shortIla, "shortIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.shortIla = shortIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaDivide.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaDivide.java
@@ -8,12 +8,7 @@ public final class ShortIlaDivide {
         // non-instantiable class
     }
 
-    public static ShortIla create(ShortIla leftIla, ShortIla rightIla, int bufferSize) throws IOException {
-        Argument.assertNotNull(leftIla, "leftIla");
-        Argument.assertNotNull(rightIla, "rightIla");
-        Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
+    public static ShortIla create(ShortIla leftIla, ShortIla rightIla, int bufferSize) {
         return new ShortIlaImpl(leftIla, rightIla, bufferSize);
     }
 
@@ -23,6 +18,15 @@ public final class ShortIlaDivide {
         private final int bufferSize;
 
         private ShortIlaImpl(ShortIla leftIla, ShortIla rightIla, int bufferSize) {
+            Argument.assertNotNull(leftIla, "leftIla");
+            Argument.assertNotNull(rightIla, "rightIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+            try {
+                Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Could not get ila length!", e);
+            }
+
             this.leftIla = leftIla;
             this.rightIla = rightIla;
             this.bufferSize = bufferSize;

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastByteIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastByteIla.java
@@ -12,9 +12,6 @@ public final class ShortIlaFromCastByteIla {
     }
 
     public static ShortIla create(ByteIla byteIla, int bufferSize) {
-        Argument.assertNotNull(byteIla, "byteIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new ShortIlaImpl(byteIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class ShortIlaFromCastByteIla {
         private final int bufferSize;
 
         private ShortIlaImpl(ByteIla byteIla, int bufferSize) {
+            Argument.assertNotNull(byteIla, "byteIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.byteIla = byteIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastCharIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastCharIla.java
@@ -12,9 +12,6 @@ public final class ShortIlaFromCastCharIla {
     }
 
     public static ShortIla create(CharIla charIla, int bufferSize) {
-        Argument.assertNotNull(charIla, "charIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new ShortIlaImpl(charIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class ShortIlaFromCastCharIla {
         private final int bufferSize;
 
         private ShortIlaImpl(CharIla charIla, int bufferSize) {
+            Argument.assertNotNull(charIla, "charIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.charIla = charIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastDoubleIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastDoubleIla.java
@@ -12,9 +12,6 @@ public final class ShortIlaFromCastDoubleIla {
     }
 
     public static ShortIla create(DoubleIla doubleIla, int bufferSize) {
-        Argument.assertNotNull(doubleIla, "doubleIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new ShortIlaImpl(doubleIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class ShortIlaFromCastDoubleIla {
         private final int bufferSize;
 
         private ShortIlaImpl(DoubleIla doubleIla, int bufferSize) {
+            Argument.assertNotNull(doubleIla, "doubleIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.doubleIla = doubleIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastFloatIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastFloatIla.java
@@ -12,9 +12,6 @@ public final class ShortIlaFromCastFloatIla {
     }
 
     public static ShortIla create(FloatIla floatIla, int bufferSize) {
-        Argument.assertNotNull(floatIla, "floatIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new ShortIlaImpl(floatIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class ShortIlaFromCastFloatIla {
         private final int bufferSize;
 
         private ShortIlaImpl(FloatIla floatIla, int bufferSize) {
+            Argument.assertNotNull(floatIla, "floatIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.floatIla = floatIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastIntIla.java
@@ -12,9 +12,6 @@ public final class ShortIlaFromCastIntIla {
     }
 
     public static ShortIla create(IntIla intIla, int bufferSize) {
-        Argument.assertNotNull(intIla, "intIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new ShortIlaImpl(intIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class ShortIlaFromCastIntIla {
         private final int bufferSize;
 
         private ShortIlaImpl(IntIla intIla, int bufferSize) {
+            Argument.assertNotNull(intIla, "intIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.intIla = intIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIla.java
+++ b/src/main/java/tfw/immutable/ila/shortila/ShortIlaFromCastLongIla.java
@@ -12,9 +12,6 @@ public final class ShortIlaFromCastLongIla {
     }
 
     public static ShortIla create(LongIla longIla, int bufferSize) {
-        Argument.assertNotNull(longIla, "longIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new ShortIlaImpl(longIla, bufferSize);
     }
 
@@ -23,6 +20,9 @@ public final class ShortIlaFromCastLongIla {
         private final int bufferSize;
 
         private ShortIlaImpl(LongIla longIla, int bufferSize) {
+            Argument.assertNotNull(longIla, "longIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.longIla = longIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryDivide.java
+++ b/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryDivide.java
@@ -1,0 +1,36 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.byteila.ByteIla;
+import tfw.immutable.ila.byteila.ByteIlaDivide;
+
+public class ByteIlaFactoryDivide {
+    private ByteIlaFactoryDivide() {}
+
+    public static ByteIlaFactory create(
+            final ByteIlaFactory leftFactory, final ByteIlaFactory rightFactory, final int bufferSize) {
+        return new ByteIlaFactoryImpl(leftFactory, rightFactory, bufferSize);
+    }
+
+    private static class ByteIlaFactoryImpl implements ByteIlaFactory {
+        private final ByteIlaFactory leftFactory;
+        private final ByteIlaFactory rightFactory;
+        private final int bufferSize;
+
+        public ByteIlaFactoryImpl(
+                final ByteIlaFactory leftFactory, final ByteIlaFactory rightFactory, final int bufferSize) {
+            Argument.assertNotNull(leftFactory, "leftFactory");
+            Argument.assertNotNull(rightFactory, "rightFactory");
+
+            this.leftFactory = leftFactory;
+            this.rightFactory = rightFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ByteIla create() {
+            return ByteIlaDivide.create(leftFactory.create(), rightFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastCharIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastCharIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.byteila.ByteIla;
+import tfw.immutable.ila.byteila.ByteIlaFromCastCharIla;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+
+public class ByteIlaFactoryFromCastCharIlaFactory {
+    private ByteIlaFactoryFromCastCharIlaFactory() {}
+
+    public static ByteIlaFactory create(CharIlaFactory charIlaFactory, final int bufferSize) {
+        return new ByteIlaFactoryImpl(charIlaFactory, bufferSize);
+    }
+
+    private static class ByteIlaFactoryImpl implements ByteIlaFactory {
+        private final CharIlaFactory charIlaFactory;
+        private final int bufferSize;
+
+        public ByteIlaFactoryImpl(final CharIlaFactory charIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(charIlaFactory, "charIlaFactory");
+
+            this.charIlaFactory = charIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ByteIla create() {
+            return ByteIlaFromCastCharIla.create(charIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastDoubleIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastDoubleIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.byteila.ByteIla;
+import tfw.immutable.ila.byteila.ByteIlaFromCastDoubleIla;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+
+public class ByteIlaFactoryFromCastDoubleIlaFactory {
+    private ByteIlaFactoryFromCastDoubleIlaFactory() {}
+
+    public static ByteIlaFactory create(DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+        return new ByteIlaFactoryImpl(doubleIlaFactory, bufferSize);
+    }
+
+    private static class ByteIlaFactoryImpl implements ByteIlaFactory {
+        private final DoubleIlaFactory doubleIlaFactory;
+        private final int bufferSize;
+
+        public ByteIlaFactoryImpl(final DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(doubleIlaFactory, "doubleIlaFactory");
+
+            this.doubleIlaFactory = doubleIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ByteIla create() {
+            return ByteIlaFromCastDoubleIla.create(doubleIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastFloatIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastFloatIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.byteila.ByteIla;
+import tfw.immutable.ila.byteila.ByteIlaFromCastFloatIla;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+
+public class ByteIlaFactoryFromCastFloatIlaFactory {
+    private ByteIlaFactoryFromCastFloatIlaFactory() {}
+
+    public static ByteIlaFactory create(FloatIlaFactory floatIlaFactory, final int bufferSize) {
+        return new ByteIlaFactoryImpl(floatIlaFactory, bufferSize);
+    }
+
+    private static class ByteIlaFactoryImpl implements ByteIlaFactory {
+        private final FloatIlaFactory floatIlaFactory;
+        private final int bufferSize;
+
+        public ByteIlaFactoryImpl(final FloatIlaFactory floatIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(floatIlaFactory, "floatIlaFactory");
+
+            this.floatIlaFactory = floatIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ByteIla create() {
+            return ByteIlaFromCastFloatIla.create(floatIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastIntIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastIntIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.byteila.ByteIla;
+import tfw.immutable.ila.byteila.ByteIlaFromCastIntIla;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+
+public class ByteIlaFactoryFromCastIntIlaFactory {
+    private ByteIlaFactoryFromCastIntIlaFactory() {}
+
+    public static ByteIlaFactory create(IntIlaFactory intIlaFactory, final int bufferSize) {
+        return new ByteIlaFactoryImpl(intIlaFactory, bufferSize);
+    }
+
+    private static class ByteIlaFactoryImpl implements ByteIlaFactory {
+        private final IntIlaFactory intIlaFactory;
+        private final int bufferSize;
+
+        public ByteIlaFactoryImpl(final IntIlaFactory intIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(intIlaFactory, "intIlaFactory");
+
+            this.intIlaFactory = intIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ByteIla create() {
+            return ByteIlaFromCastIntIla.create(intIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastLongIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastLongIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.byteila.ByteIla;
+import tfw.immutable.ila.byteila.ByteIlaFromCastLongIla;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+
+public class ByteIlaFactoryFromCastLongIlaFactory {
+    private ByteIlaFactoryFromCastLongIlaFactory() {}
+
+    public static ByteIlaFactory create(LongIlaFactory longIlaFactory, final int bufferSize) {
+        return new ByteIlaFactoryImpl(longIlaFactory, bufferSize);
+    }
+
+    private static class ByteIlaFactoryImpl implements ByteIlaFactory {
+        private final LongIlaFactory longIlaFactory;
+        private final int bufferSize;
+
+        public ByteIlaFactoryImpl(final LongIlaFactory longIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(longIlaFactory, "longIlaFactory");
+
+            this.longIlaFactory = longIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ByteIla create() {
+            return ByteIlaFromCastLongIla.create(longIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastShortIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastShortIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.byteila.ByteIla;
+import tfw.immutable.ila.byteila.ByteIlaFromCastShortIla;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+
+public class ByteIlaFactoryFromCastShortIlaFactory {
+    private ByteIlaFactoryFromCastShortIlaFactory() {}
+
+    public static ByteIlaFactory create(ShortIlaFactory shortIlaFactory, final int bufferSize) {
+        return new ByteIlaFactoryImpl(shortIlaFactory, bufferSize);
+    }
+
+    private static class ByteIlaFactoryImpl implements ByteIlaFactory {
+        private final ShortIlaFactory shortIlaFactory;
+        private final int bufferSize;
+
+        public ByteIlaFactoryImpl(final ShortIlaFactory shortIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(shortIlaFactory, "shortIlaFactory");
+
+            this.shortIlaFactory = shortIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ByteIla create() {
+            return ByteIlaFromCastShortIla.create(shortIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryDivide.java
+++ b/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryDivide.java
@@ -1,0 +1,36 @@
+package tfw.immutable.ilaf.charilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.charila.CharIla;
+import tfw.immutable.ila.charila.CharIlaDivide;
+
+public class CharIlaFactoryDivide {
+    private CharIlaFactoryDivide() {}
+
+    public static CharIlaFactory create(
+            final CharIlaFactory leftFactory, final CharIlaFactory rightFactory, final int bufferSize) {
+        return new CharIlaFactoryImpl(leftFactory, rightFactory, bufferSize);
+    }
+
+    private static class CharIlaFactoryImpl implements CharIlaFactory {
+        private final CharIlaFactory leftFactory;
+        private final CharIlaFactory rightFactory;
+        private final int bufferSize;
+
+        public CharIlaFactoryImpl(
+                final CharIlaFactory leftFactory, final CharIlaFactory rightFactory, final int bufferSize) {
+            Argument.assertNotNull(leftFactory, "leftFactory");
+            Argument.assertNotNull(rightFactory, "rightFactory");
+
+            this.leftFactory = leftFactory;
+            this.rightFactory = rightFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public CharIla create() {
+            return CharIlaDivide.create(leftFactory.create(), rightFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastByteIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastByteIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.charilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.charila.CharIla;
+import tfw.immutable.ila.charila.CharIlaFromCastByteIla;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+
+public class CharIlaFactoryFromCastByteIlaFactory {
+    private CharIlaFactoryFromCastByteIlaFactory() {}
+
+    public static CharIlaFactory create(ByteIlaFactory byteIlaFactory, final int bufferSize) {
+        return new CharIlaFactoryImpl(byteIlaFactory, bufferSize);
+    }
+
+    private static class CharIlaFactoryImpl implements CharIlaFactory {
+        private final ByteIlaFactory byteIlaFactory;
+        private final int bufferSize;
+
+        public CharIlaFactoryImpl(final ByteIlaFactory byteIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(byteIlaFactory, "byteIlaFactory");
+
+            this.byteIlaFactory = byteIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public CharIla create() {
+            return CharIlaFromCastByteIla.create(byteIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastDoubleIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastDoubleIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.charilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.charila.CharIla;
+import tfw.immutable.ila.charila.CharIlaFromCastDoubleIla;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+
+public class CharIlaFactoryFromCastDoubleIlaFactory {
+    private CharIlaFactoryFromCastDoubleIlaFactory() {}
+
+    public static CharIlaFactory create(DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+        return new CharIlaFactoryImpl(doubleIlaFactory, bufferSize);
+    }
+
+    private static class CharIlaFactoryImpl implements CharIlaFactory {
+        private final DoubleIlaFactory doubleIlaFactory;
+        private final int bufferSize;
+
+        public CharIlaFactoryImpl(final DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(doubleIlaFactory, "doubleIlaFactory");
+
+            this.doubleIlaFactory = doubleIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public CharIla create() {
+            return CharIlaFromCastDoubleIla.create(doubleIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastFloatIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastFloatIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.charilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.charila.CharIla;
+import tfw.immutable.ila.charila.CharIlaFromCastFloatIla;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+
+public class CharIlaFactoryFromCastFloatIlaFactory {
+    private CharIlaFactoryFromCastFloatIlaFactory() {}
+
+    public static CharIlaFactory create(FloatIlaFactory floatIlaFactory, final int bufferSize) {
+        return new CharIlaFactoryImpl(floatIlaFactory, bufferSize);
+    }
+
+    private static class CharIlaFactoryImpl implements CharIlaFactory {
+        private final FloatIlaFactory floatIlaFactory;
+        private final int bufferSize;
+
+        public CharIlaFactoryImpl(final FloatIlaFactory floatIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(floatIlaFactory, "floatIlaFactory");
+
+            this.floatIlaFactory = floatIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public CharIla create() {
+            return CharIlaFromCastFloatIla.create(floatIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastIntIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastIntIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.charilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.charila.CharIla;
+import tfw.immutable.ila.charila.CharIlaFromCastIntIla;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+
+public class CharIlaFactoryFromCastIntIlaFactory {
+    private CharIlaFactoryFromCastIntIlaFactory() {}
+
+    public static CharIlaFactory create(IntIlaFactory intIlaFactory, final int bufferSize) {
+        return new CharIlaFactoryImpl(intIlaFactory, bufferSize);
+    }
+
+    private static class CharIlaFactoryImpl implements CharIlaFactory {
+        private final IntIlaFactory intIlaFactory;
+        private final int bufferSize;
+
+        public CharIlaFactoryImpl(final IntIlaFactory intIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(intIlaFactory, "intIlaFactory");
+
+            this.intIlaFactory = intIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public CharIla create() {
+            return CharIlaFromCastIntIla.create(intIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastLongIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastLongIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.charilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.charila.CharIla;
+import tfw.immutable.ila.charila.CharIlaFromCastLongIla;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+
+public class CharIlaFactoryFromCastLongIlaFactory {
+    private CharIlaFactoryFromCastLongIlaFactory() {}
+
+    public static CharIlaFactory create(LongIlaFactory longIlaFactory, final int bufferSize) {
+        return new CharIlaFactoryImpl(longIlaFactory, bufferSize);
+    }
+
+    private static class CharIlaFactoryImpl implements CharIlaFactory {
+        private final LongIlaFactory longIlaFactory;
+        private final int bufferSize;
+
+        public CharIlaFactoryImpl(final LongIlaFactory longIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(longIlaFactory, "longIlaFactory");
+
+            this.longIlaFactory = longIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public CharIla create() {
+            return CharIlaFromCastLongIla.create(longIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastShortIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastShortIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.charilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.charila.CharIla;
+import tfw.immutable.ila.charila.CharIlaFromCastShortIla;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+
+public class CharIlaFactoryFromCastShortIlaFactory {
+    private CharIlaFactoryFromCastShortIlaFactory() {}
+
+    public static CharIlaFactory create(ShortIlaFactory shortIlaFactory, final int bufferSize) {
+        return new CharIlaFactoryImpl(shortIlaFactory, bufferSize);
+    }
+
+    private static class CharIlaFactoryImpl implements CharIlaFactory {
+        private final ShortIlaFactory shortIlaFactory;
+        private final int bufferSize;
+
+        public CharIlaFactoryImpl(final ShortIlaFactory shortIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(shortIlaFactory, "shortIlaFactory");
+
+            this.shortIlaFactory = shortIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public CharIla create() {
+            return CharIlaFromCastShortIla.create(shortIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryDivide.java
+++ b/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryDivide.java
@@ -1,0 +1,36 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.doubleila.DoubleIla;
+import tfw.immutable.ila.doubleila.DoubleIlaDivide;
+
+public class DoubleIlaFactoryDivide {
+    private DoubleIlaFactoryDivide() {}
+
+    public static DoubleIlaFactory create(
+            final DoubleIlaFactory leftFactory, final DoubleIlaFactory rightFactory, final int bufferSize) {
+        return new DoubleIlaFactoryImpl(leftFactory, rightFactory, bufferSize);
+    }
+
+    private static class DoubleIlaFactoryImpl implements DoubleIlaFactory {
+        private final DoubleIlaFactory leftFactory;
+        private final DoubleIlaFactory rightFactory;
+        private final int bufferSize;
+
+        public DoubleIlaFactoryImpl(
+                final DoubleIlaFactory leftFactory, final DoubleIlaFactory rightFactory, final int bufferSize) {
+            Argument.assertNotNull(leftFactory, "leftFactory");
+            Argument.assertNotNull(rightFactory, "rightFactory");
+
+            this.leftFactory = leftFactory;
+            this.rightFactory = rightFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public DoubleIla create() {
+            return DoubleIlaDivide.create(leftFactory.create(), rightFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastByteIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastByteIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.doubleila.DoubleIla;
+import tfw.immutable.ila.doubleila.DoubleIlaFromCastByteIla;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+
+public class DoubleIlaFactoryFromCastByteIlaFactory {
+    private DoubleIlaFactoryFromCastByteIlaFactory() {}
+
+    public static DoubleIlaFactory create(ByteIlaFactory byteIlaFactory, final int bufferSize) {
+        return new DoubleIlaFactoryImpl(byteIlaFactory, bufferSize);
+    }
+
+    private static class DoubleIlaFactoryImpl implements DoubleIlaFactory {
+        private final ByteIlaFactory byteIlaFactory;
+        private final int bufferSize;
+
+        public DoubleIlaFactoryImpl(final ByteIlaFactory byteIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(byteIlaFactory, "byteIlaFactory");
+
+            this.byteIlaFactory = byteIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public DoubleIla create() {
+            return DoubleIlaFromCastByteIla.create(byteIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastCharIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastCharIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.doubleila.DoubleIla;
+import tfw.immutable.ila.doubleila.DoubleIlaFromCastCharIla;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+
+public class DoubleIlaFactoryFromCastCharIlaFactory {
+    private DoubleIlaFactoryFromCastCharIlaFactory() {}
+
+    public static DoubleIlaFactory create(CharIlaFactory charIlaFactory, final int bufferSize) {
+        return new DoubleIlaFactoryImpl(charIlaFactory, bufferSize);
+    }
+
+    private static class DoubleIlaFactoryImpl implements DoubleIlaFactory {
+        private final CharIlaFactory charIlaFactory;
+        private final int bufferSize;
+
+        public DoubleIlaFactoryImpl(final CharIlaFactory charIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(charIlaFactory, "charIlaFactory");
+
+            this.charIlaFactory = charIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public DoubleIla create() {
+            return DoubleIlaFromCastCharIla.create(charIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastFloatIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastFloatIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.doubleila.DoubleIla;
+import tfw.immutable.ila.doubleila.DoubleIlaFromCastFloatIla;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+
+public class DoubleIlaFactoryFromCastFloatIlaFactory {
+    private DoubleIlaFactoryFromCastFloatIlaFactory() {}
+
+    public static DoubleIlaFactory create(FloatIlaFactory floatIlaFactory, final int bufferSize) {
+        return new DoubleIlaFactoryImpl(floatIlaFactory, bufferSize);
+    }
+
+    private static class DoubleIlaFactoryImpl implements DoubleIlaFactory {
+        private final FloatIlaFactory floatIlaFactory;
+        private final int bufferSize;
+
+        public DoubleIlaFactoryImpl(final FloatIlaFactory floatIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(floatIlaFactory, "floatIlaFactory");
+
+            this.floatIlaFactory = floatIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public DoubleIla create() {
+            return DoubleIlaFromCastFloatIla.create(floatIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastIntIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastIntIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.doubleila.DoubleIla;
+import tfw.immutable.ila.doubleila.DoubleIlaFromCastIntIla;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+
+public class DoubleIlaFactoryFromCastIntIlaFactory {
+    private DoubleIlaFactoryFromCastIntIlaFactory() {}
+
+    public static DoubleIlaFactory create(IntIlaFactory intIlaFactory, final int bufferSize) {
+        return new DoubleIlaFactoryImpl(intIlaFactory, bufferSize);
+    }
+
+    private static class DoubleIlaFactoryImpl implements DoubleIlaFactory {
+        private final IntIlaFactory intIlaFactory;
+        private final int bufferSize;
+
+        public DoubleIlaFactoryImpl(final IntIlaFactory intIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(intIlaFactory, "intIlaFactory");
+
+            this.intIlaFactory = intIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public DoubleIla create() {
+            return DoubleIlaFromCastIntIla.create(intIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastLongIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastLongIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.doubleila.DoubleIla;
+import tfw.immutable.ila.doubleila.DoubleIlaFromCastLongIla;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+
+public class DoubleIlaFactoryFromCastLongIlaFactory {
+    private DoubleIlaFactoryFromCastLongIlaFactory() {}
+
+    public static DoubleIlaFactory create(LongIlaFactory longIlaFactory, final int bufferSize) {
+        return new DoubleIlaFactoryImpl(longIlaFactory, bufferSize);
+    }
+
+    private static class DoubleIlaFactoryImpl implements DoubleIlaFactory {
+        private final LongIlaFactory longIlaFactory;
+        private final int bufferSize;
+
+        public DoubleIlaFactoryImpl(final LongIlaFactory longIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(longIlaFactory, "longIlaFactory");
+
+            this.longIlaFactory = longIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public DoubleIla create() {
+            return DoubleIlaFromCastLongIla.create(longIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastShortIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastShortIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.doubleila.DoubleIla;
+import tfw.immutable.ila.doubleila.DoubleIlaFromCastShortIla;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+
+public class DoubleIlaFactoryFromCastShortIlaFactory {
+    private DoubleIlaFactoryFromCastShortIlaFactory() {}
+
+    public static DoubleIlaFactory create(ShortIlaFactory shortIlaFactory, final int bufferSize) {
+        return new DoubleIlaFactoryImpl(shortIlaFactory, bufferSize);
+    }
+
+    private static class DoubleIlaFactoryImpl implements DoubleIlaFactory {
+        private final ShortIlaFactory shortIlaFactory;
+        private final int bufferSize;
+
+        public DoubleIlaFactoryImpl(final ShortIlaFactory shortIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(shortIlaFactory, "shortIlaFactory");
+
+            this.shortIlaFactory = shortIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public DoubleIla create() {
+            return DoubleIlaFromCastShortIla.create(shortIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryDivide.java
+++ b/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryDivide.java
@@ -1,0 +1,36 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.floatila.FloatIla;
+import tfw.immutable.ila.floatila.FloatIlaDivide;
+
+public class FloatIlaFactoryDivide {
+    private FloatIlaFactoryDivide() {}
+
+    public static FloatIlaFactory create(
+            final FloatIlaFactory leftFactory, final FloatIlaFactory rightFactory, final int bufferSize) {
+        return new FloatIlaFactoryImpl(leftFactory, rightFactory, bufferSize);
+    }
+
+    private static class FloatIlaFactoryImpl implements FloatIlaFactory {
+        private final FloatIlaFactory leftFactory;
+        private final FloatIlaFactory rightFactory;
+        private final int bufferSize;
+
+        public FloatIlaFactoryImpl(
+                final FloatIlaFactory leftFactory, final FloatIlaFactory rightFactory, final int bufferSize) {
+            Argument.assertNotNull(leftFactory, "leftFactory");
+            Argument.assertNotNull(rightFactory, "rightFactory");
+
+            this.leftFactory = leftFactory;
+            this.rightFactory = rightFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public FloatIla create() {
+            return FloatIlaDivide.create(leftFactory.create(), rightFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastByteIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastByteIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.floatila.FloatIla;
+import tfw.immutable.ila.floatila.FloatIlaFromCastByteIla;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+
+public class FloatIlaFactoryFromCastByteIlaFactory {
+    private FloatIlaFactoryFromCastByteIlaFactory() {}
+
+    public static FloatIlaFactory create(ByteIlaFactory byteIlaFactory, final int bufferSize) {
+        return new FloatIlaFactoryImpl(byteIlaFactory, bufferSize);
+    }
+
+    private static class FloatIlaFactoryImpl implements FloatIlaFactory {
+        private final ByteIlaFactory byteIlaFactory;
+        private final int bufferSize;
+
+        public FloatIlaFactoryImpl(final ByteIlaFactory byteIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(byteIlaFactory, "byteIlaFactory");
+
+            this.byteIlaFactory = byteIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public FloatIla create() {
+            return FloatIlaFromCastByteIla.create(byteIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastCharIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastCharIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.floatila.FloatIla;
+import tfw.immutable.ila.floatila.FloatIlaFromCastCharIla;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+
+public class FloatIlaFactoryFromCastCharIlaFactory {
+    private FloatIlaFactoryFromCastCharIlaFactory() {}
+
+    public static FloatIlaFactory create(CharIlaFactory charIlaFactory, final int bufferSize) {
+        return new FloatIlaFactoryImpl(charIlaFactory, bufferSize);
+    }
+
+    private static class FloatIlaFactoryImpl implements FloatIlaFactory {
+        private final CharIlaFactory charIlaFactory;
+        private final int bufferSize;
+
+        public FloatIlaFactoryImpl(final CharIlaFactory charIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(charIlaFactory, "charIlaFactory");
+
+            this.charIlaFactory = charIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public FloatIla create() {
+            return FloatIlaFromCastCharIla.create(charIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastDoubleIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastDoubleIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.floatila.FloatIla;
+import tfw.immutable.ila.floatila.FloatIlaFromCastDoubleIla;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+
+public class FloatIlaFactoryFromCastDoubleIlaFactory {
+    private FloatIlaFactoryFromCastDoubleIlaFactory() {}
+
+    public static FloatIlaFactory create(DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+        return new FloatIlaFactoryImpl(doubleIlaFactory, bufferSize);
+    }
+
+    private static class FloatIlaFactoryImpl implements FloatIlaFactory {
+        private final DoubleIlaFactory doubleIlaFactory;
+        private final int bufferSize;
+
+        public FloatIlaFactoryImpl(final DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(doubleIlaFactory, "doubleIlaFactory");
+
+            this.doubleIlaFactory = doubleIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public FloatIla create() {
+            return FloatIlaFromCastDoubleIla.create(doubleIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastIntIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastIntIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.floatila.FloatIla;
+import tfw.immutable.ila.floatila.FloatIlaFromCastIntIla;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+
+public class FloatIlaFactoryFromCastIntIlaFactory {
+    private FloatIlaFactoryFromCastIntIlaFactory() {}
+
+    public static FloatIlaFactory create(IntIlaFactory intIlaFactory, final int bufferSize) {
+        return new FloatIlaFactoryImpl(intIlaFactory, bufferSize);
+    }
+
+    private static class FloatIlaFactoryImpl implements FloatIlaFactory {
+        private final IntIlaFactory intIlaFactory;
+        private final int bufferSize;
+
+        public FloatIlaFactoryImpl(final IntIlaFactory intIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(intIlaFactory, "intIlaFactory");
+
+            this.intIlaFactory = intIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public FloatIla create() {
+            return FloatIlaFromCastIntIla.create(intIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastLongIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastLongIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.floatila.FloatIla;
+import tfw.immutable.ila.floatila.FloatIlaFromCastLongIla;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+
+public class FloatIlaFactoryFromCastLongIlaFactory {
+    private FloatIlaFactoryFromCastLongIlaFactory() {}
+
+    public static FloatIlaFactory create(LongIlaFactory longIlaFactory, final int bufferSize) {
+        return new FloatIlaFactoryImpl(longIlaFactory, bufferSize);
+    }
+
+    private static class FloatIlaFactoryImpl implements FloatIlaFactory {
+        private final LongIlaFactory longIlaFactory;
+        private final int bufferSize;
+
+        public FloatIlaFactoryImpl(final LongIlaFactory longIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(longIlaFactory, "longIlaFactory");
+
+            this.longIlaFactory = longIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public FloatIla create() {
+            return FloatIlaFromCastLongIla.create(longIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastShortIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastShortIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.floatila.FloatIla;
+import tfw.immutable.ila.floatila.FloatIlaFromCastShortIla;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+
+public class FloatIlaFactoryFromCastShortIlaFactory {
+    private FloatIlaFactoryFromCastShortIlaFactory() {}
+
+    public static FloatIlaFactory create(ShortIlaFactory shortIlaFactory, final int bufferSize) {
+        return new FloatIlaFactoryImpl(shortIlaFactory, bufferSize);
+    }
+
+    private static class FloatIlaFactoryImpl implements FloatIlaFactory {
+        private final ShortIlaFactory shortIlaFactory;
+        private final int bufferSize;
+
+        public FloatIlaFactoryImpl(final ShortIlaFactory shortIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(shortIlaFactory, "shortIlaFactory");
+
+            this.shortIlaFactory = shortIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public FloatIla create() {
+            return FloatIlaFromCastShortIla.create(shortIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryDivide.java
+++ b/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryDivide.java
@@ -1,0 +1,36 @@
+package tfw.immutable.ilaf.intilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.intila.IntIla;
+import tfw.immutable.ila.intila.IntIlaDivide;
+
+public class IntIlaFactoryDivide {
+    private IntIlaFactoryDivide() {}
+
+    public static IntIlaFactory create(
+            final IntIlaFactory leftFactory, final IntIlaFactory rightFactory, final int bufferSize) {
+        return new IntIlaFactoryImpl(leftFactory, rightFactory, bufferSize);
+    }
+
+    private static class IntIlaFactoryImpl implements IntIlaFactory {
+        private final IntIlaFactory leftFactory;
+        private final IntIlaFactory rightFactory;
+        private final int bufferSize;
+
+        public IntIlaFactoryImpl(
+                final IntIlaFactory leftFactory, final IntIlaFactory rightFactory, final int bufferSize) {
+            Argument.assertNotNull(leftFactory, "leftFactory");
+            Argument.assertNotNull(rightFactory, "rightFactory");
+
+            this.leftFactory = leftFactory;
+            this.rightFactory = rightFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public IntIla create() {
+            return IntIlaDivide.create(leftFactory.create(), rightFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastByteIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastByteIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.intilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.intila.IntIla;
+import tfw.immutable.ila.intila.IntIlaFromCastByteIla;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+
+public class IntIlaFactoryFromCastByteIlaFactory {
+    private IntIlaFactoryFromCastByteIlaFactory() {}
+
+    public static IntIlaFactory create(ByteIlaFactory byteIlaFactory, final int bufferSize) {
+        return new IntIlaFactoryImpl(byteIlaFactory, bufferSize);
+    }
+
+    private static class IntIlaFactoryImpl implements IntIlaFactory {
+        private final ByteIlaFactory byteIlaFactory;
+        private final int bufferSize;
+
+        public IntIlaFactoryImpl(final ByteIlaFactory byteIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(byteIlaFactory, "byteIlaFactory");
+
+            this.byteIlaFactory = byteIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public IntIla create() {
+            return IntIlaFromCastByteIla.create(byteIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastCharIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastCharIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.intilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.intila.IntIla;
+import tfw.immutable.ila.intila.IntIlaFromCastCharIla;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+
+public class IntIlaFactoryFromCastCharIlaFactory {
+    private IntIlaFactoryFromCastCharIlaFactory() {}
+
+    public static IntIlaFactory create(CharIlaFactory charIlaFactory, final int bufferSize) {
+        return new IntIlaFactoryImpl(charIlaFactory, bufferSize);
+    }
+
+    private static class IntIlaFactoryImpl implements IntIlaFactory {
+        private final CharIlaFactory charIlaFactory;
+        private final int bufferSize;
+
+        public IntIlaFactoryImpl(final CharIlaFactory charIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(charIlaFactory, "charIlaFactory");
+
+            this.charIlaFactory = charIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public IntIla create() {
+            return IntIlaFromCastCharIla.create(charIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastDoubleIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastDoubleIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.intilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.intila.IntIla;
+import tfw.immutable.ila.intila.IntIlaFromCastDoubleIla;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+
+public class IntIlaFactoryFromCastDoubleIlaFactory {
+    private IntIlaFactoryFromCastDoubleIlaFactory() {}
+
+    public static IntIlaFactory create(DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+        return new IntIlaFactoryImpl(doubleIlaFactory, bufferSize);
+    }
+
+    private static class IntIlaFactoryImpl implements IntIlaFactory {
+        private final DoubleIlaFactory doubleIlaFactory;
+        private final int bufferSize;
+
+        public IntIlaFactoryImpl(final DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(doubleIlaFactory, "doubleIlaFactory");
+
+            this.doubleIlaFactory = doubleIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public IntIla create() {
+            return IntIlaFromCastDoubleIla.create(doubleIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastFloatIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastFloatIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.intilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.intila.IntIla;
+import tfw.immutable.ila.intila.IntIlaFromCastFloatIla;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+
+public class IntIlaFactoryFromCastFloatIlaFactory {
+    private IntIlaFactoryFromCastFloatIlaFactory() {}
+
+    public static IntIlaFactory create(FloatIlaFactory floatIlaFactory, final int bufferSize) {
+        return new IntIlaFactoryImpl(floatIlaFactory, bufferSize);
+    }
+
+    private static class IntIlaFactoryImpl implements IntIlaFactory {
+        private final FloatIlaFactory floatIlaFactory;
+        private final int bufferSize;
+
+        public IntIlaFactoryImpl(final FloatIlaFactory floatIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(floatIlaFactory, "floatIlaFactory");
+
+            this.floatIlaFactory = floatIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public IntIla create() {
+            return IntIlaFromCastFloatIla.create(floatIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastLongIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastLongIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.intilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.intila.IntIla;
+import tfw.immutable.ila.intila.IntIlaFromCastLongIla;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+
+public class IntIlaFactoryFromCastLongIlaFactory {
+    private IntIlaFactoryFromCastLongIlaFactory() {}
+
+    public static IntIlaFactory create(LongIlaFactory longIlaFactory, final int bufferSize) {
+        return new IntIlaFactoryImpl(longIlaFactory, bufferSize);
+    }
+
+    private static class IntIlaFactoryImpl implements IntIlaFactory {
+        private final LongIlaFactory longIlaFactory;
+        private final int bufferSize;
+
+        public IntIlaFactoryImpl(final LongIlaFactory longIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(longIlaFactory, "longIlaFactory");
+
+            this.longIlaFactory = longIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public IntIla create() {
+            return IntIlaFromCastLongIla.create(longIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastShortIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastShortIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.intilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.intila.IntIla;
+import tfw.immutable.ila.intila.IntIlaFromCastShortIla;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+
+public class IntIlaFactoryFromCastShortIlaFactory {
+    private IntIlaFactoryFromCastShortIlaFactory() {}
+
+    public static IntIlaFactory create(ShortIlaFactory shortIlaFactory, final int bufferSize) {
+        return new IntIlaFactoryImpl(shortIlaFactory, bufferSize);
+    }
+
+    private static class IntIlaFactoryImpl implements IntIlaFactory {
+        private final ShortIlaFactory shortIlaFactory;
+        private final int bufferSize;
+
+        public IntIlaFactoryImpl(final ShortIlaFactory shortIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(shortIlaFactory, "shortIlaFactory");
+
+            this.shortIlaFactory = shortIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public IntIla create() {
+            return IntIlaFromCastShortIla.create(shortIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryDivide.java
+++ b/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryDivide.java
@@ -1,0 +1,36 @@
+package tfw.immutable.ilaf.longilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.longila.LongIla;
+import tfw.immutable.ila.longila.LongIlaDivide;
+
+public class LongIlaFactoryDivide {
+    private LongIlaFactoryDivide() {}
+
+    public static LongIlaFactory create(
+            final LongIlaFactory leftFactory, final LongIlaFactory rightFactory, final int bufferSize) {
+        return new LongIlaFactoryImpl(leftFactory, rightFactory, bufferSize);
+    }
+
+    private static class LongIlaFactoryImpl implements LongIlaFactory {
+        private final LongIlaFactory leftFactory;
+        private final LongIlaFactory rightFactory;
+        private final int bufferSize;
+
+        public LongIlaFactoryImpl(
+                final LongIlaFactory leftFactory, final LongIlaFactory rightFactory, final int bufferSize) {
+            Argument.assertNotNull(leftFactory, "leftFactory");
+            Argument.assertNotNull(rightFactory, "rightFactory");
+
+            this.leftFactory = leftFactory;
+            this.rightFactory = rightFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public LongIla create() {
+            return LongIlaDivide.create(leftFactory.create(), rightFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastByteIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastByteIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.longilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.longila.LongIla;
+import tfw.immutable.ila.longila.LongIlaFromCastByteIla;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+
+public class LongIlaFactoryFromCastByteIlaFactory {
+    private LongIlaFactoryFromCastByteIlaFactory() {}
+
+    public static LongIlaFactory create(ByteIlaFactory byteIlaFactory, final int bufferSize) {
+        return new LongIlaFactoryImpl(byteIlaFactory, bufferSize);
+    }
+
+    private static class LongIlaFactoryImpl implements LongIlaFactory {
+        private final ByteIlaFactory byteIlaFactory;
+        private final int bufferSize;
+
+        public LongIlaFactoryImpl(final ByteIlaFactory byteIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(byteIlaFactory, "byteIlaFactory");
+
+            this.byteIlaFactory = byteIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public LongIla create() {
+            return LongIlaFromCastByteIla.create(byteIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastCharIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastCharIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.longilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.longila.LongIla;
+import tfw.immutable.ila.longila.LongIlaFromCastCharIla;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+
+public class LongIlaFactoryFromCastCharIlaFactory {
+    private LongIlaFactoryFromCastCharIlaFactory() {}
+
+    public static LongIlaFactory create(CharIlaFactory charIlaFactory, final int bufferSize) {
+        return new LongIlaFactoryImpl(charIlaFactory, bufferSize);
+    }
+
+    private static class LongIlaFactoryImpl implements LongIlaFactory {
+        private final CharIlaFactory charIlaFactory;
+        private final int bufferSize;
+
+        public LongIlaFactoryImpl(final CharIlaFactory charIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(charIlaFactory, "charIlaFactory");
+
+            this.charIlaFactory = charIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public LongIla create() {
+            return LongIlaFromCastCharIla.create(charIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastDoubleIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastDoubleIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.longilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.longila.LongIla;
+import tfw.immutable.ila.longila.LongIlaFromCastDoubleIla;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+
+public class LongIlaFactoryFromCastDoubleIlaFactory {
+    private LongIlaFactoryFromCastDoubleIlaFactory() {}
+
+    public static LongIlaFactory create(DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+        return new LongIlaFactoryImpl(doubleIlaFactory, bufferSize);
+    }
+
+    private static class LongIlaFactoryImpl implements LongIlaFactory {
+        private final DoubleIlaFactory doubleIlaFactory;
+        private final int bufferSize;
+
+        public LongIlaFactoryImpl(final DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(doubleIlaFactory, "doubleIlaFactory");
+
+            this.doubleIlaFactory = doubleIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public LongIla create() {
+            return LongIlaFromCastDoubleIla.create(doubleIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastFloatIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastFloatIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.longilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.longila.LongIla;
+import tfw.immutable.ila.longila.LongIlaFromCastFloatIla;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+
+public class LongIlaFactoryFromCastFloatIlaFactory {
+    private LongIlaFactoryFromCastFloatIlaFactory() {}
+
+    public static LongIlaFactory create(FloatIlaFactory floatIlaFactory, final int bufferSize) {
+        return new LongIlaFactoryImpl(floatIlaFactory, bufferSize);
+    }
+
+    private static class LongIlaFactoryImpl implements LongIlaFactory {
+        private final FloatIlaFactory floatIlaFactory;
+        private final int bufferSize;
+
+        public LongIlaFactoryImpl(final FloatIlaFactory floatIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(floatIlaFactory, "floatIlaFactory");
+
+            this.floatIlaFactory = floatIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public LongIla create() {
+            return LongIlaFromCastFloatIla.create(floatIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastIntIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastIntIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.longilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.longila.LongIla;
+import tfw.immutable.ila.longila.LongIlaFromCastIntIla;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+
+public class LongIlaFactoryFromCastIntIlaFactory {
+    private LongIlaFactoryFromCastIntIlaFactory() {}
+
+    public static LongIlaFactory create(IntIlaFactory intIlaFactory, final int bufferSize) {
+        return new LongIlaFactoryImpl(intIlaFactory, bufferSize);
+    }
+
+    private static class LongIlaFactoryImpl implements LongIlaFactory {
+        private final IntIlaFactory intIlaFactory;
+        private final int bufferSize;
+
+        public LongIlaFactoryImpl(final IntIlaFactory intIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(intIlaFactory, "intIlaFactory");
+
+            this.intIlaFactory = intIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public LongIla create() {
+            return LongIlaFromCastIntIla.create(intIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastShortIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastShortIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.longilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.longila.LongIla;
+import tfw.immutable.ila.longila.LongIlaFromCastShortIla;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+
+public class LongIlaFactoryFromCastShortIlaFactory {
+    private LongIlaFactoryFromCastShortIlaFactory() {}
+
+    public static LongIlaFactory create(ShortIlaFactory shortIlaFactory, final int bufferSize) {
+        return new LongIlaFactoryImpl(shortIlaFactory, bufferSize);
+    }
+
+    private static class LongIlaFactoryImpl implements LongIlaFactory {
+        private final ShortIlaFactory shortIlaFactory;
+        private final int bufferSize;
+
+        public LongIlaFactoryImpl(final ShortIlaFactory shortIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(shortIlaFactory, "shortIlaFactory");
+
+            this.shortIlaFactory = shortIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public LongIla create() {
+            return LongIlaFromCastShortIla.create(shortIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryDivide.java
+++ b/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryDivide.java
@@ -1,0 +1,36 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.shortila.ShortIla;
+import tfw.immutable.ila.shortila.ShortIlaDivide;
+
+public class ShortIlaFactoryDivide {
+    private ShortIlaFactoryDivide() {}
+
+    public static ShortIlaFactory create(
+            final ShortIlaFactory leftFactory, final ShortIlaFactory rightFactory, final int bufferSize) {
+        return new ShortIlaFactoryImpl(leftFactory, rightFactory, bufferSize);
+    }
+
+    private static class ShortIlaFactoryImpl implements ShortIlaFactory {
+        private final ShortIlaFactory leftFactory;
+        private final ShortIlaFactory rightFactory;
+        private final int bufferSize;
+
+        public ShortIlaFactoryImpl(
+                final ShortIlaFactory leftFactory, final ShortIlaFactory rightFactory, final int bufferSize) {
+            Argument.assertNotNull(leftFactory, "leftFactory");
+            Argument.assertNotNull(rightFactory, "rightFactory");
+
+            this.leftFactory = leftFactory;
+            this.rightFactory = rightFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ShortIla create() {
+            return ShortIlaDivide.create(leftFactory.create(), rightFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastByteIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastByteIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.shortila.ShortIla;
+import tfw.immutable.ila.shortila.ShortIlaFromCastByteIla;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+
+public class ShortIlaFactoryFromCastByteIlaFactory {
+    private ShortIlaFactoryFromCastByteIlaFactory() {}
+
+    public static ShortIlaFactory create(ByteIlaFactory byteIlaFactory, final int bufferSize) {
+        return new ShortIlaFactoryImpl(byteIlaFactory, bufferSize);
+    }
+
+    private static class ShortIlaFactoryImpl implements ShortIlaFactory {
+        private final ByteIlaFactory byteIlaFactory;
+        private final int bufferSize;
+
+        public ShortIlaFactoryImpl(final ByteIlaFactory byteIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(byteIlaFactory, "byteIlaFactory");
+
+            this.byteIlaFactory = byteIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ShortIla create() {
+            return ShortIlaFromCastByteIla.create(byteIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastCharIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastCharIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.shortila.ShortIla;
+import tfw.immutable.ila.shortila.ShortIlaFromCastCharIla;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+
+public class ShortIlaFactoryFromCastCharIlaFactory {
+    private ShortIlaFactoryFromCastCharIlaFactory() {}
+
+    public static ShortIlaFactory create(CharIlaFactory charIlaFactory, final int bufferSize) {
+        return new ShortIlaFactoryImpl(charIlaFactory, bufferSize);
+    }
+
+    private static class ShortIlaFactoryImpl implements ShortIlaFactory {
+        private final CharIlaFactory charIlaFactory;
+        private final int bufferSize;
+
+        public ShortIlaFactoryImpl(final CharIlaFactory charIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(charIlaFactory, "charIlaFactory");
+
+            this.charIlaFactory = charIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ShortIla create() {
+            return ShortIlaFromCastCharIla.create(charIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastDoubleIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastDoubleIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.shortila.ShortIla;
+import tfw.immutable.ila.shortila.ShortIlaFromCastDoubleIla;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+
+public class ShortIlaFactoryFromCastDoubleIlaFactory {
+    private ShortIlaFactoryFromCastDoubleIlaFactory() {}
+
+    public static ShortIlaFactory create(DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+        return new ShortIlaFactoryImpl(doubleIlaFactory, bufferSize);
+    }
+
+    private static class ShortIlaFactoryImpl implements ShortIlaFactory {
+        private final DoubleIlaFactory doubleIlaFactory;
+        private final int bufferSize;
+
+        public ShortIlaFactoryImpl(final DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(doubleIlaFactory, "doubleIlaFactory");
+
+            this.doubleIlaFactory = doubleIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ShortIla create() {
+            return ShortIlaFromCastDoubleIla.create(doubleIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastFloatIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastFloatIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.shortila.ShortIla;
+import tfw.immutable.ila.shortila.ShortIlaFromCastFloatIla;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+
+public class ShortIlaFactoryFromCastFloatIlaFactory {
+    private ShortIlaFactoryFromCastFloatIlaFactory() {}
+
+    public static ShortIlaFactory create(FloatIlaFactory floatIlaFactory, final int bufferSize) {
+        return new ShortIlaFactoryImpl(floatIlaFactory, bufferSize);
+    }
+
+    private static class ShortIlaFactoryImpl implements ShortIlaFactory {
+        private final FloatIlaFactory floatIlaFactory;
+        private final int bufferSize;
+
+        public ShortIlaFactoryImpl(final FloatIlaFactory floatIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(floatIlaFactory, "floatIlaFactory");
+
+            this.floatIlaFactory = floatIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ShortIla create() {
+            return ShortIlaFromCastFloatIla.create(floatIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastIntIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastIntIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.shortila.ShortIla;
+import tfw.immutable.ila.shortila.ShortIlaFromCastIntIla;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+
+public class ShortIlaFactoryFromCastIntIlaFactory {
+    private ShortIlaFactoryFromCastIntIlaFactory() {}
+
+    public static ShortIlaFactory create(IntIlaFactory intIlaFactory, final int bufferSize) {
+        return new ShortIlaFactoryImpl(intIlaFactory, bufferSize);
+    }
+
+    private static class ShortIlaFactoryImpl implements ShortIlaFactory {
+        private final IntIlaFactory intIlaFactory;
+        private final int bufferSize;
+
+        public ShortIlaFactoryImpl(final IntIlaFactory intIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(intIlaFactory, "intIlaFactory");
+
+            this.intIlaFactory = intIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ShortIla create() {
+            return ShortIlaFromCastIntIla.create(intIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastLongIlaFactory.java
+++ b/src/main/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastLongIlaFactory.java
@@ -1,0 +1,32 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.shortila.ShortIla;
+import tfw.immutable.ila.shortila.ShortIlaFromCastLongIla;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+
+public class ShortIlaFactoryFromCastLongIlaFactory {
+    private ShortIlaFactoryFromCastLongIlaFactory() {}
+
+    public static ShortIlaFactory create(LongIlaFactory longIlaFactory, final int bufferSize) {
+        return new ShortIlaFactoryImpl(longIlaFactory, bufferSize);
+    }
+
+    private static class ShortIlaFactoryImpl implements ShortIlaFactory {
+        private final LongIlaFactory longIlaFactory;
+        private final int bufferSize;
+
+        public ShortIlaFactoryImpl(final LongIlaFactory longIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(longIlaFactory, "longIlaFactory");
+
+            this.longIlaFactory = longIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ShortIla create() {
+            return ShortIlaFromCastLongIla.create(longIlaFactory.create(), bufferSize);
+        }
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/template/tfw/immutable/ila/__IlaDivide.template
+++ b/src/main/template/tfw/immutable/ila/__IlaDivide.template
@@ -9,12 +9,7 @@ public final class %%NAME%%IlaDivide {
         // non-instantiable class
     }
 
-    public static %%NAME%%Ila create(%%NAME%%Ila leftIla, %%NAME%%Ila rightIla, int bufferSize) throws IOException {
-        Argument.assertNotNull(leftIla, "leftIla");
-        Argument.assertNotNull(rightIla, "rightIla");
-        Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
+    public static %%NAME%%Ila create(%%NAME%%Ila leftIla, %%NAME%%Ila rightIla, int bufferSize) {
         return new %%NAME%%IlaImpl(leftIla, rightIla, bufferSize);
     }
 
@@ -24,6 +19,15 @@ public final class %%NAME%%IlaDivide {
         private final int bufferSize;
 
         private %%NAME%%IlaImpl(%%NAME%%Ila leftIla, %%NAME%%Ila rightIla, int bufferSize) {
+            Argument.assertNotNull(leftIla, "leftIla");
+            Argument.assertNotNull(rightIla, "rightIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+            try {
+                Argument.assertEquals(leftIla.length(), rightIla.length(), "leftIla.length()", "rightIla.length()");
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Could not get ila length!", e);
+            }
+
             this.leftIla = leftIla;
             this.rightIla = rightIla;
             this.bufferSize = bufferSize;

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastByteIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastByteIla.template
@@ -13,9 +13,6 @@ public final class %%NAME%%IlaFromCastByteIla {
     }
 
     public static %%NAME%%Ila create(ByteIla byteIla, int bufferSize) {
-        Argument.assertNotNull(byteIla, "byteIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new %%NAME%%IlaImpl(byteIla, bufferSize);
     }
 
@@ -24,6 +21,9 @@ public final class %%NAME%%IlaFromCastByteIla {
         private final int bufferSize;
 
         private %%NAME%%IlaImpl(ByteIla byteIla, int bufferSize) {
+            Argument.assertNotNull(byteIla, "byteIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.byteIla = byteIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastCharIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastCharIla.template
@@ -13,9 +13,6 @@ public final class %%NAME%%IlaFromCastCharIla {
     }
 
     public static %%NAME%%Ila create(CharIla charIla, int bufferSize) {
-        Argument.assertNotNull(charIla, "charIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new %%NAME%%IlaImpl(charIla, bufferSize);
     }
 
@@ -24,6 +21,9 @@ public final class %%NAME%%IlaFromCastCharIla {
         private final int bufferSize;
 
         private %%NAME%%IlaImpl(CharIla charIla, int bufferSize) {
+            Argument.assertNotNull(charIla, "charIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.charIla = charIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastDoubleIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastDoubleIla.template
@@ -13,9 +13,6 @@ public final class %%NAME%%IlaFromCastDoubleIla {
     }
 
     public static %%NAME%%Ila create(DoubleIla doubleIla, int bufferSize) {
-        Argument.assertNotNull(doubleIla, "doubleIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new %%NAME%%IlaImpl(doubleIla, bufferSize);
     }
 
@@ -24,6 +21,9 @@ public final class %%NAME%%IlaFromCastDoubleIla {
         private final int bufferSize;
 
         private %%NAME%%IlaImpl(DoubleIla doubleIla, int bufferSize) {
+            Argument.assertNotNull(doubleIla, "doubleIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.doubleIla = doubleIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastFloatIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastFloatIla.template
@@ -13,9 +13,6 @@ public final class %%NAME%%IlaFromCastFloatIla {
     }
 
     public static %%NAME%%Ila create(FloatIla floatIla, int bufferSize) {
-        Argument.assertNotNull(floatIla, "floatIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new %%NAME%%IlaImpl(floatIla, bufferSize);
     }
 
@@ -24,6 +21,9 @@ public final class %%NAME%%IlaFromCastFloatIla {
         private final int bufferSize;
 
         private %%NAME%%IlaImpl(FloatIla floatIla, int bufferSize) {
+            Argument.assertNotNull(floatIla, "floatIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.floatIla = floatIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastIntIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastIntIla.template
@@ -13,9 +13,6 @@ public final class %%NAME%%IlaFromCastIntIla {
     }
 
     public static %%NAME%%Ila create(IntIla intIla, int bufferSize) {
-        Argument.assertNotNull(intIla, "intIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new %%NAME%%IlaImpl(intIla, bufferSize);
     }
 
@@ -24,6 +21,9 @@ public final class %%NAME%%IlaFromCastIntIla {
         private final int bufferSize;
 
         private %%NAME%%IlaImpl(IntIla intIla, int bufferSize) {
+            Argument.assertNotNull(intIla, "intIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.intIla = intIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastLongIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastLongIla.template
@@ -13,9 +13,6 @@ public final class %%NAME%%IlaFromCastLongIla {
     }
 
     public static %%NAME%%Ila create(LongIla longIla, int bufferSize) {
-        Argument.assertNotNull(longIla, "longIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new %%NAME%%IlaImpl(longIla, bufferSize);
     }
 
@@ -24,6 +21,9 @@ public final class %%NAME%%IlaFromCastLongIla {
         private final int bufferSize;
 
         private %%NAME%%IlaImpl(LongIla longIla, int bufferSize) {
+            Argument.assertNotNull(longIla, "longIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.longIla = longIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/template/tfw/immutable/ila/__IlaFromCastShortIla.template
+++ b/src/main/template/tfw/immutable/ila/__IlaFromCastShortIla.template
@@ -13,9 +13,6 @@ public final class %%NAME%%IlaFromCastShortIla {
     }
 
     public static %%NAME%%Ila create(ShortIla shortIla, int bufferSize) {
-        Argument.assertNotNull(shortIla, "shortIla");
-        Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
-
         return new %%NAME%%IlaImpl(shortIla, bufferSize);
     }
 
@@ -24,6 +21,9 @@ public final class %%NAME%%IlaFromCastShortIla {
         private final int bufferSize;
 
         private %%NAME%%IlaImpl(ShortIla shortIla, int bufferSize) {
+            Argument.assertNotNull(shortIla, "shortIla");
+            Argument.assertNotLessThan(bufferSize, 1, "bufferSize");
+
             this.shortIla = shortIla;
             this.bufferSize = bufferSize;
         }

--- a/src/main/template/tfw/immutable/ilaf/__IlaFactoryDivide.template
+++ b/src/main/template/tfw/immutable/ilaf/__IlaFactoryDivide.template
@@ -1,0 +1,36 @@
+// byteilaf,charilaf,doubleilaf,floatilaf,intilaf,longilaf,shortilaf
+package %%PACKAGE%%;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%Ila;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%IlaDivide;
+
+public class %%NAME%%IlaFactoryDivide {
+    private %%NAME%%IlaFactoryDivide() {}
+
+    public static %%TEMPLATE_SPACE%%%%NAME%%IlaFactory%%TEMPLATE%% create(
+            final %%NAME%%IlaFactory%%TEMPLATE%% leftFactory, final %%NAME%%IlaFactory%%TEMPLATE%% rightFactory, final int bufferSize) {
+        return new %%NAME%%IlaFactoryImpl%%DIAMOND%%(leftFactory, rightFactory, bufferSize);
+    }
+
+    private static class %%NAME%%IlaFactoryImpl%%TEMPLATE%% implements %%NAME%%IlaFactory%%TEMPLATE%% {
+        private final %%NAME%%IlaFactory%%TEMPLATE%% leftFactory;
+        private final %%NAME%%IlaFactory%%TEMPLATE%% rightFactory;
+        private final int bufferSize;
+
+        public %%NAME%%IlaFactoryImpl(
+                final %%NAME%%IlaFactory%%TEMPLATE%% leftFactory, final %%NAME%%IlaFactory%%TEMPLATE%% rightFactory, final int bufferSize) {
+            Argument.assertNotNull(leftFactory, "leftFactory");
+            Argument.assertNotNull(rightFactory, "rightFactory");
+
+            this.leftFactory = leftFactory;
+            this.rightFactory = rightFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public %%NAME%%Ila%%TEMPLATE%% create() {
+            return %%NAME%%IlaDivide.create(leftFactory.create(), rightFactory.create(), bufferSize);
+        }
+    }
+}

--- a/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastByteIlaFactory.template
+++ b/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastByteIlaFactory.template
@@ -1,0 +1,32 @@
+// charilaf,doubleilaf,floatilaf,intilaf,longilaf,shortilaf
+package %%PACKAGE%%;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%Ila;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%IlaFromCastByteIla;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+
+public class %%NAME%%IlaFactoryFromCastByteIlaFactory {
+    private %%NAME%%IlaFactoryFromCastByteIlaFactory() {}
+
+    public static %%NAME%%IlaFactory create(ByteIlaFactory byteIlaFactory, final int bufferSize) {
+        return new %%NAME%%IlaFactoryImpl(byteIlaFactory, bufferSize);
+    }
+
+    private static class %%NAME%%IlaFactoryImpl implements %%NAME%%IlaFactory {
+        private final ByteIlaFactory byteIlaFactory;
+        private final int bufferSize;
+
+        public %%NAME%%IlaFactoryImpl(final ByteIlaFactory byteIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(byteIlaFactory, "byteIlaFactory");
+
+            this.byteIlaFactory = byteIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public %%NAME%%Ila create() {
+            return %%NAME%%IlaFromCastByteIla.create(byteIlaFactory.create(), bufferSize);
+        }
+    }
+}

--- a/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastCharIlaFactory.template
+++ b/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastCharIlaFactory.template
@@ -1,0 +1,32 @@
+// byteilaf,doubleilaf,floatilaf,intilaf,longilaf,shortilaf
+package %%PACKAGE%%;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%Ila;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%IlaFromCastCharIla;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+
+public class %%NAME%%IlaFactoryFromCastCharIlaFactory {
+    private %%NAME%%IlaFactoryFromCastCharIlaFactory() {}
+
+    public static %%NAME%%IlaFactory create(CharIlaFactory charIlaFactory, final int bufferSize) {
+        return new %%NAME%%IlaFactoryImpl(charIlaFactory, bufferSize);
+    }
+
+    private static class %%NAME%%IlaFactoryImpl implements %%NAME%%IlaFactory {
+        private final CharIlaFactory charIlaFactory;
+        private final int bufferSize;
+
+        public %%NAME%%IlaFactoryImpl(final CharIlaFactory charIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(charIlaFactory, "charIlaFactory");
+
+            this.charIlaFactory = charIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public %%NAME%%Ila create() {
+            return %%NAME%%IlaFromCastCharIla.create(charIlaFactory.create(), bufferSize);
+        }
+    }
+}

--- a/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastDoubleIlaFactory.template
+++ b/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastDoubleIlaFactory.template
@@ -1,0 +1,32 @@
+// byteilaf,charilaf,floatilaf,intilaf,longilaf,shortilaf
+package %%PACKAGE%%;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%Ila;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%IlaFromCastDoubleIla;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+
+public class %%NAME%%IlaFactoryFromCastDoubleIlaFactory {
+    private %%NAME%%IlaFactoryFromCastDoubleIlaFactory() {}
+
+    public static %%NAME%%IlaFactory create(DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+        return new %%NAME%%IlaFactoryImpl(doubleIlaFactory, bufferSize);
+    }
+
+    private static class %%NAME%%IlaFactoryImpl implements %%NAME%%IlaFactory {
+        private final DoubleIlaFactory doubleIlaFactory;
+        private final int bufferSize;
+
+        public %%NAME%%IlaFactoryImpl(final DoubleIlaFactory doubleIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(doubleIlaFactory, "doubleIlaFactory");
+
+            this.doubleIlaFactory = doubleIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public %%NAME%%Ila create() {
+            return %%NAME%%IlaFromCastDoubleIla.create(doubleIlaFactory.create(), bufferSize);
+        }
+    }
+}

--- a/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastFloatIlaFactory.template
+++ b/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastFloatIlaFactory.template
@@ -1,0 +1,32 @@
+// byteilaf,charilaf,doubleilaf,intilaf,longilaf,shortilaf
+package %%PACKAGE%%;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%Ila;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%IlaFromCastFloatIla;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+
+public class %%NAME%%IlaFactoryFromCastFloatIlaFactory {
+    private %%NAME%%IlaFactoryFromCastFloatIlaFactory() {}
+
+    public static %%NAME%%IlaFactory create(FloatIlaFactory floatIlaFactory, final int bufferSize) {
+        return new %%NAME%%IlaFactoryImpl(floatIlaFactory, bufferSize);
+    }
+
+    private static class %%NAME%%IlaFactoryImpl implements %%NAME%%IlaFactory {
+        private final FloatIlaFactory floatIlaFactory;
+        private final int bufferSize;
+
+        public %%NAME%%IlaFactoryImpl(final FloatIlaFactory floatIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(floatIlaFactory, "floatIlaFactory");
+
+            this.floatIlaFactory = floatIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public %%NAME%%Ila create() {
+            return %%NAME%%IlaFromCastFloatIla.create(floatIlaFactory.create(), bufferSize);
+        }
+    }
+}

--- a/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastIntIlaFactory.template
+++ b/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastIntIlaFactory.template
@@ -1,0 +1,32 @@
+// byteilaf,charilaf,doubleilaf,floatilaf,longilaf,shortilaf
+package %%PACKAGE%%;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%Ila;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%IlaFromCastIntIla;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+
+public class %%NAME%%IlaFactoryFromCastIntIlaFactory {
+    private %%NAME%%IlaFactoryFromCastIntIlaFactory() {}
+
+    public static %%NAME%%IlaFactory create(IntIlaFactory intIlaFactory, final int bufferSize) {
+        return new %%NAME%%IlaFactoryImpl(intIlaFactory, bufferSize);
+    }
+
+    private static class %%NAME%%IlaFactoryImpl implements %%NAME%%IlaFactory {
+        private final IntIlaFactory intIlaFactory;
+        private final int bufferSize;
+
+        public %%NAME%%IlaFactoryImpl(final IntIlaFactory intIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(intIlaFactory, "intIlaFactory");
+
+            this.intIlaFactory = intIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public %%NAME%%Ila create() {
+            return %%NAME%%IlaFromCastIntIla.create(intIlaFactory.create(), bufferSize);
+        }
+    }
+}

--- a/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastLongIlaFactory.template
+++ b/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastLongIlaFactory.template
@@ -1,0 +1,32 @@
+// byteilaf,charilaf,doubleilaf,floatilaf,intilaf,shortilaf
+package %%PACKAGE%%;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%Ila;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%IlaFromCastLongIla;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+
+public class %%NAME%%IlaFactoryFromCastLongIlaFactory {
+    private %%NAME%%IlaFactoryFromCastLongIlaFactory() {}
+
+    public static %%NAME%%IlaFactory create(LongIlaFactory longIlaFactory, final int bufferSize) {
+        return new %%NAME%%IlaFactoryImpl(longIlaFactory, bufferSize);
+    }
+
+    private static class %%NAME%%IlaFactoryImpl implements %%NAME%%IlaFactory {
+        private final LongIlaFactory longIlaFactory;
+        private final int bufferSize;
+
+        public %%NAME%%IlaFactoryImpl(final LongIlaFactory longIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(longIlaFactory, "longIlaFactory");
+
+            this.longIlaFactory = longIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public %%NAME%%Ila create() {
+            return %%NAME%%IlaFromCastLongIla.create(longIlaFactory.create(), bufferSize);
+        }
+    }
+}

--- a/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastShortIlaFactory.template
+++ b/src/main/template/tfw/immutable/ilaf/__IlaFactoryFromCastShortIlaFactory.template
@@ -1,0 +1,32 @@
+// byteilaf,charilaf,doubleilaf,floatilaf,intilaf,longilaf
+package %%PACKAGE%%;
+
+import tfw.check.Argument;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%Ila;
+import tfw.immutable.ila.%%LOWER_NAME%%ila.%%NAME%%IlaFromCastShortIla;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+
+public class %%NAME%%IlaFactoryFromCastShortIlaFactory {
+    private %%NAME%%IlaFactoryFromCastShortIlaFactory() {}
+
+    public static %%NAME%%IlaFactory create(ShortIlaFactory shortIlaFactory, final int bufferSize) {
+        return new %%NAME%%IlaFactoryImpl(shortIlaFactory, bufferSize);
+    }
+
+    private static class %%NAME%%IlaFactoryImpl implements %%NAME%%IlaFactory {
+        private final ShortIlaFactory shortIlaFactory;
+        private final int bufferSize;
+
+        public %%NAME%%IlaFactoryImpl(final ShortIlaFactory shortIlaFactory, final int bufferSize) {
+            Argument.assertNotNull(shortIlaFactory, "shortIlaFactory");
+
+            this.shortIlaFactory = shortIlaFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public %%NAME%%Ila create() {
+            return %%NAME%%IlaFromCastShortIla.create(shortIlaFactory.create(), bufferSize);
+        }
+    }
+}

--- a/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryDivideTest.java
+++ b/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryDivideTest.java
@@ -1,0 +1,28 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class ByteIlaFactoryDivideTest {
+    @Test
+    void argumentTest() {
+        final ByteIlaFactory byteIlaFactory = ByteIlaFactoryFill.create((byte) 0, 10);
+
+        assertThatThrownBy(() -> ByteIlaFactoryDivide.create(null, byteIlaFactory, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftFactory == null not allowed!");
+        assertThatThrownBy(() -> ByteIlaFactoryDivide.create(byteIlaFactory, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ByteIlaFactory f = ByteIlaFactoryFill.create((byte) 0, 10);
+
+        assertThat(ByteIlaFactoryDivide.create(f, f, 10).create()).isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastCharIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastCharIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+import tfw.immutable.ilaf.charilaf.CharIlaFactoryFill;
+
+final class ByteIlaFactoryFromCastCharIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> ByteIlaFactoryFromCastCharIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final CharIlaFactory charIlaFactory = CharIlaFactoryFill.create((char) 0, 10);
+
+        assertThat(ByteIlaFactoryFromCastCharIlaFactory.create(charIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastDoubleIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastDoubleIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactoryFill;
+
+final class ByteIlaFactoryFromCastDoubleIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> ByteIlaFactoryFromCastDoubleIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final DoubleIlaFactory doubleIlaFactory = DoubleIlaFactoryFill.create(0.0, 10);
+
+        assertThat(ByteIlaFactoryFromCastDoubleIlaFactory.create(doubleIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastFloatIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastFloatIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactoryFill;
+
+final class ByteIlaFactoryFromCastFloatIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> ByteIlaFactoryFromCastFloatIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final FloatIlaFactory floatIlaFactory = FloatIlaFactoryFill.create(0.0F, 10);
+
+        assertThat(ByteIlaFactoryFromCastFloatIlaFactory.create(floatIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastIntIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastIntIlaFactoryTest.java
@@ -1,0 +1,26 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+import tfw.immutable.ilaf.intilaf.IntIlaFactoryFill;
+
+final class ByteIlaFactoryFromCastIntIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> ByteIlaFactoryFromCastIntIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final IntIlaFactory ilaFactory = IntIlaFactoryFill.create(0, 10);
+
+        assertThat(ByteIlaFactoryFromCastIntIlaFactory.create(ilaFactory, 10).create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastLongIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastLongIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+import tfw.immutable.ilaf.longilaf.LongIlaFactoryFill;
+
+final class ByteIlaFactoryFromCastLongIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> ByteIlaFactoryFromCastLongIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final LongIlaFactory longIlaFactory = LongIlaFactoryFill.create(0L, 10);
+
+        assertThat(ByteIlaFactoryFromCastLongIlaFactory.create(longIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastShortIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/byteilaf/ByteIlaFactoryFromCastShortIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.byteilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactoryFill;
+
+final class ByteIlaFactoryFromCastShortIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> ByteIlaFactoryFromCastShortIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ShortIlaFactory shortIlaFactory = ShortIlaFactoryFill.create((short) 0, 10);
+
+        assertThat(ByteIlaFactoryFromCastShortIlaFactory.create(shortIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryDivideTest.java
+++ b/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryDivideTest.java
@@ -1,0 +1,28 @@
+package tfw.immutable.ilaf.charilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class CharIlaFactoryDivideTest {
+    @Test
+    void argumentTest() {
+        final CharIlaFactory charIlaFactory = CharIlaFactoryFill.create((char) 0, 10);
+
+        assertThatThrownBy(() -> CharIlaFactoryDivide.create(null, charIlaFactory, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftFactory == null not allowed!");
+        assertThatThrownBy(() -> CharIlaFactoryDivide.create(charIlaFactory, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final CharIlaFactory f = CharIlaFactoryFill.create((char) 0, 10);
+
+        assertThat(CharIlaFactoryDivide.create(f, f, 10).create()).isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastByteIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastByteIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.charilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactoryFill;
+
+final class CharIlaFactoryFromCastByteIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> CharIlaFactoryFromCastByteIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ByteIlaFactory byteIlaFactory = ByteIlaFactoryFill.create((byte) 0, 10);
+
+        assertThat(CharIlaFactoryFromCastByteIlaFactory.create(byteIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastDoubleIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastDoubleIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.charilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactoryFill;
+
+final class CharIlaFactoryFromCastDoubleIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> CharIlaFactoryFromCastDoubleIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final DoubleIlaFactory doubleIlaFactory = DoubleIlaFactoryFill.create(0.0, 10);
+
+        assertThat(CharIlaFactoryFromCastDoubleIlaFactory.create(doubleIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastFloatIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastFloatIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.charilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactoryFill;
+
+final class CharIlaFactoryFromCastFloatIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> CharIlaFactoryFromCastFloatIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final FloatIlaFactory floatIlaFactory = FloatIlaFactoryFill.create(0.0F, 10);
+
+        assertThat(CharIlaFactoryFromCastFloatIlaFactory.create(floatIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastIntIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastIntIlaFactoryTest.java
@@ -1,0 +1,26 @@
+package tfw.immutable.ilaf.charilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+import tfw.immutable.ilaf.intilaf.IntIlaFactoryFill;
+
+final class CharIlaFactoryFromCastIntIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> CharIlaFactoryFromCastIntIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final IntIlaFactory ilaFactory = IntIlaFactoryFill.create(0, 10);
+
+        assertThat(CharIlaFactoryFromCastIntIlaFactory.create(ilaFactory, 10).create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastLongIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastLongIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.charilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+import tfw.immutable.ilaf.longilaf.LongIlaFactoryFill;
+
+final class CharIlaFactoryFromCastLongIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> CharIlaFactoryFromCastLongIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final LongIlaFactory longIlaFactory = LongIlaFactoryFill.create(0L, 10);
+
+        assertThat(CharIlaFactoryFromCastLongIlaFactory.create(longIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastShortIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/charilaf/CharIlaFactoryFromCastShortIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.charilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactoryFill;
+
+final class CharIlaFactoryFromCastShortIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> CharIlaFactoryFromCastShortIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ShortIlaFactory shortIlaFactory = ShortIlaFactoryFill.create((short) 0, 10);
+
+        assertThat(CharIlaFactoryFromCastShortIlaFactory.create(shortIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryDivideTest.java
+++ b/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryDivideTest.java
@@ -1,0 +1,28 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class DoubleIlaFactoryDivideTest {
+    @Test
+    void argumentTest() {
+        final DoubleIlaFactory doubleIlaFactory = DoubleIlaFactoryFill.create(0.0, 10);
+
+        assertThatThrownBy(() -> DoubleIlaFactoryDivide.create(null, doubleIlaFactory, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftFactory == null not allowed!");
+        assertThatThrownBy(() -> DoubleIlaFactoryDivide.create(doubleIlaFactory, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final DoubleIlaFactory f = DoubleIlaFactoryFill.create(0.0, 10);
+
+        assertThat(DoubleIlaFactoryDivide.create(f, f, 10).create()).isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastByteIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastByteIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactoryFill;
+
+final class DoubleIlaFactoryFromCastByteIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> DoubleIlaFactoryFromCastByteIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ByteIlaFactory byteIlaFactory = ByteIlaFactoryFill.create((byte) 0, 10);
+
+        assertThat(DoubleIlaFactoryFromCastByteIlaFactory.create(byteIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastCharIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastCharIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+import tfw.immutable.ilaf.charilaf.CharIlaFactoryFill;
+
+final class DoubleIlaFactoryFromCastCharIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> DoubleIlaFactoryFromCastCharIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final CharIlaFactory charIlaFactory = CharIlaFactoryFill.create((char) 0, 10);
+
+        assertThat(DoubleIlaFactoryFromCastCharIlaFactory.create(charIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastFloatIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastFloatIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactoryFill;
+
+final class DoubleIlaFactoryFromCastFloatIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> DoubleIlaFactoryFromCastFloatIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final FloatIlaFactory floatIlaFactory = FloatIlaFactoryFill.create(0.0F, 10);
+
+        assertThat(DoubleIlaFactoryFromCastFloatIlaFactory.create(floatIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastIntIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastIntIlaFactoryTest.java
@@ -1,0 +1,26 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+import tfw.immutable.ilaf.intilaf.IntIlaFactoryFill;
+
+final class DoubleIlaFactoryFromCastIntIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> DoubleIlaFactoryFromCastIntIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final IntIlaFactory ilaFactory = IntIlaFactoryFill.create(0, 10);
+
+        assertThat(DoubleIlaFactoryFromCastIntIlaFactory.create(ilaFactory, 10).create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastLongIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastLongIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+import tfw.immutable.ilaf.longilaf.LongIlaFactoryFill;
+
+final class DoubleIlaFactoryFromCastLongIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> DoubleIlaFactoryFromCastLongIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final LongIlaFactory longIlaFactory = LongIlaFactoryFill.create(0L, 10);
+
+        assertThat(DoubleIlaFactoryFromCastLongIlaFactory.create(longIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastShortIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/doubleilaf/DoubleIlaFactoryFromCastShortIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.doubleilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactoryFill;
+
+final class DoubleIlaFactoryFromCastShortIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> DoubleIlaFactoryFromCastShortIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ShortIlaFactory shortIlaFactory = ShortIlaFactoryFill.create((short) 0, 10);
+
+        assertThat(DoubleIlaFactoryFromCastShortIlaFactory.create(shortIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryDivideTest.java
+++ b/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryDivideTest.java
@@ -1,0 +1,28 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class FloatIlaFactoryDivideTest {
+    @Test
+    void argumentTest() {
+        final FloatIlaFactory floatIlaFactory = FloatIlaFactoryFill.create(0.0f, 10);
+
+        assertThatThrownBy(() -> FloatIlaFactoryDivide.create(null, floatIlaFactory, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftFactory == null not allowed!");
+        assertThatThrownBy(() -> FloatIlaFactoryDivide.create(floatIlaFactory, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final FloatIlaFactory f = FloatIlaFactoryFill.create(0.0f, 10);
+
+        assertThat(FloatIlaFactoryDivide.create(f, f, 10).create()).isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastByteIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastByteIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactoryFill;
+
+final class FloatIlaFactoryFromCastByteIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> FloatIlaFactoryFromCastByteIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ByteIlaFactory byteIlaFactory = ByteIlaFactoryFill.create((byte) 0, 10);
+
+        assertThat(FloatIlaFactoryFromCastByteIlaFactory.create(byteIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastCharIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastCharIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+import tfw.immutable.ilaf.charilaf.CharIlaFactoryFill;
+
+final class FloatIlaFactoryFromCastCharIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> FloatIlaFactoryFromCastCharIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final CharIlaFactory charIlaFactory = CharIlaFactoryFill.create((char) 0, 10);
+
+        assertThat(FloatIlaFactoryFromCastCharIlaFactory.create(charIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastDoubleIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastDoubleIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactoryFill;
+
+final class FloatIlaFactoryFromCastDoubleIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> FloatIlaFactoryFromCastDoubleIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final DoubleIlaFactory doubleIlaFactory = DoubleIlaFactoryFill.create(0.0, 10);
+
+        assertThat(FloatIlaFactoryFromCastDoubleIlaFactory.create(doubleIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastIntIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastIntIlaFactoryTest.java
@@ -1,0 +1,26 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+import tfw.immutable.ilaf.intilaf.IntIlaFactoryFill;
+
+final class FloatIlaFactoryFromCastIntIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> FloatIlaFactoryFromCastIntIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final IntIlaFactory ilaFactory = IntIlaFactoryFill.create(0, 10);
+
+        assertThat(FloatIlaFactoryFromCastIntIlaFactory.create(ilaFactory, 10).create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastLongIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastLongIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+import tfw.immutable.ilaf.longilaf.LongIlaFactoryFill;
+
+final class FloatIlaFactoryFromCastLongIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> FloatIlaFactoryFromCastLongIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final LongIlaFactory longIlaFactory = LongIlaFactoryFill.create(0L, 10);
+
+        assertThat(FloatIlaFactoryFromCastLongIlaFactory.create(longIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastShortIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/floatilaf/FloatIlaFactoryFromCastShortIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.floatilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactoryFill;
+
+final class FloatIlaFactoryFromCastShortIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> FloatIlaFactoryFromCastShortIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ShortIlaFactory shortIlaFactory = ShortIlaFactoryFill.create((short) 0, 10);
+
+        assertThat(FloatIlaFactoryFromCastShortIlaFactory.create(shortIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryDivideTest.java
+++ b/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryDivideTest.java
@@ -1,0 +1,28 @@
+package tfw.immutable.ilaf.intilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class IntIlaFactoryDivideTest {
+    @Test
+    void argumentTest() {
+        final IntIlaFactory intIlaFactory = IntIlaFactoryFill.create(0, 10);
+
+        assertThatThrownBy(() -> IntIlaFactoryDivide.create(null, intIlaFactory, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftFactory == null not allowed!");
+        assertThatThrownBy(() -> IntIlaFactoryDivide.create(intIlaFactory, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final IntIlaFactory f = IntIlaFactoryFill.create(0, 10);
+
+        assertThat(IntIlaFactoryDivide.create(f, f, 10).create()).isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastByteIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastByteIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.intilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactoryFill;
+
+final class IntIlaFactoryFromCastByteIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> IntIlaFactoryFromCastByteIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ByteIlaFactory byteIlaFactory = ByteIlaFactoryFill.create((byte) 0, 10);
+
+        assertThat(IntIlaFactoryFromCastByteIlaFactory.create(byteIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastCharIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastCharIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.intilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+import tfw.immutable.ilaf.charilaf.CharIlaFactoryFill;
+
+final class IntIlaFactoryFromCastCharIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> IntIlaFactoryFromCastCharIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final CharIlaFactory charIlaFactory = CharIlaFactoryFill.create((char) 0, 10);
+
+        assertThat(IntIlaFactoryFromCastCharIlaFactory.create(charIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastDoubleIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastDoubleIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.intilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactoryFill;
+
+final class IntIlaFactoryFromCastDoubleIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> IntIlaFactoryFromCastDoubleIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final DoubleIlaFactory doubleIlaFactory = DoubleIlaFactoryFill.create(0.0, 10);
+
+        assertThat(IntIlaFactoryFromCastDoubleIlaFactory.create(doubleIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastFloatIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastFloatIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.intilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactoryFill;
+
+final class IntIlaFactoryFromCastFloatIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> IntIlaFactoryFromCastFloatIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final FloatIlaFactory floatIlaFactory = FloatIlaFactoryFill.create(0.0F, 10);
+
+        assertThat(IntIlaFactoryFromCastFloatIlaFactory.create(floatIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastLongIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastLongIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.intilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+import tfw.immutable.ilaf.longilaf.LongIlaFactoryFill;
+
+final class IntIlaFactoryFromCastLongIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> IntIlaFactoryFromCastLongIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final LongIlaFactory longIlaFactory = LongIlaFactoryFill.create(0L, 10);
+
+        assertThat(IntIlaFactoryFromCastLongIlaFactory.create(longIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastShortIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/intilaf/IntIlaFactoryFromCastShortIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.intilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactoryFill;
+
+final class IntIlaFactoryFromCastShortIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> IntIlaFactoryFromCastShortIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ShortIlaFactory shortIlaFactory = ShortIlaFactoryFill.create((short) 0, 10);
+
+        assertThat(IntIlaFactoryFromCastShortIlaFactory.create(shortIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryDivideTest.java
+++ b/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryDivideTest.java
@@ -1,0 +1,28 @@
+package tfw.immutable.ilaf.longilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class LongIlaFactoryDivideTest {
+    @Test
+    void argumentTest() {
+        final LongIlaFactory longIlaFactory = LongIlaFactoryFill.create(0L, 10);
+
+        assertThatThrownBy(() -> LongIlaFactoryDivide.create(null, longIlaFactory, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftFactory == null not allowed!");
+        assertThatThrownBy(() -> LongIlaFactoryDivide.create(longIlaFactory, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final LongIlaFactory f = LongIlaFactoryFill.create(0L, 10);
+
+        assertThat(LongIlaFactoryDivide.create(f, f, 10).create()).isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastByteIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastByteIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.longilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactoryFill;
+
+final class LongIlaFactoryFromCastByteIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> LongIlaFactoryFromCastByteIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ByteIlaFactory byteIlaFactory = ByteIlaFactoryFill.create((byte) 0, 10);
+
+        assertThat(LongIlaFactoryFromCastByteIlaFactory.create(byteIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastCharIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastCharIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.longilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+import tfw.immutable.ilaf.charilaf.CharIlaFactoryFill;
+
+final class LongIlaFactoryFromCastCharIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> LongIlaFactoryFromCastCharIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final CharIlaFactory charIlaFactory = CharIlaFactoryFill.create((char) 0, 10);
+
+        assertThat(LongIlaFactoryFromCastCharIlaFactory.create(charIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastDoubleIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastDoubleIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.longilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactoryFill;
+
+final class LongIlaFactoryFromCastDoubleIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> LongIlaFactoryFromCastDoubleIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final DoubleIlaFactory doubleIlaFactory = DoubleIlaFactoryFill.create(0.0, 10);
+
+        assertThat(LongIlaFactoryFromCastDoubleIlaFactory.create(doubleIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastFloatIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastFloatIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.longilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactoryFill;
+
+final class LongIlaFactoryFromCastFloatIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> LongIlaFactoryFromCastFloatIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final FloatIlaFactory floatIlaFactory = FloatIlaFactoryFill.create(0.0F, 10);
+
+        assertThat(LongIlaFactoryFromCastFloatIlaFactory.create(floatIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastIntIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastIntIlaFactoryTest.java
@@ -1,0 +1,26 @@
+package tfw.immutable.ilaf.longilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+import tfw.immutable.ilaf.intilaf.IntIlaFactoryFill;
+
+final class LongIlaFactoryFromCastIntIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> LongIlaFactoryFromCastIntIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final IntIlaFactory ilaFactory = IntIlaFactoryFill.create(0, 10);
+
+        assertThat(LongIlaFactoryFromCastIntIlaFactory.create(ilaFactory, 10).create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastShortIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/longilaf/LongIlaFactoryFromCastShortIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.longilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactoryFill;
+
+final class LongIlaFactoryFromCastShortIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> LongIlaFactoryFromCastShortIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ShortIlaFactory shortIlaFactory = ShortIlaFactoryFill.create((short) 0, 10);
+
+        assertThat(LongIlaFactoryFromCastShortIlaFactory.create(shortIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryDivideTest.java
+++ b/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryDivideTest.java
@@ -1,0 +1,28 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class ShortIlaFactoryDivideTest {
+    @Test
+    void argumentTest() {
+        final ShortIlaFactory shortIlaFactory = ShortIlaFactoryFill.create((short) 0, 10);
+
+        assertThatThrownBy(() -> ShortIlaFactoryDivide.create(null, shortIlaFactory, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftFactory == null not allowed!");
+        assertThatThrownBy(() -> ShortIlaFactoryDivide.create(shortIlaFactory, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ShortIlaFactory f = ShortIlaFactoryFill.create((short) 0, 10);
+
+        assertThat(ShortIlaFactoryDivide.create(f, f, 10).create()).isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastByteIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastByteIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactoryFill;
+
+final class ShortIlaFactoryFromCastByteIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> ShortIlaFactoryFromCastByteIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ByteIlaFactory byteIlaFactory = ByteIlaFactoryFill.create((byte) 0, 10);
+
+        assertThat(ShortIlaFactoryFromCastByteIlaFactory.create(byteIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastCharIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastCharIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+import tfw.immutable.ilaf.charilaf.CharIlaFactoryFill;
+
+final class ShortIlaFactoryFromCastCharIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> ShortIlaFactoryFromCastCharIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final CharIlaFactory charIlaFactory = CharIlaFactoryFill.create((char) 0, 10);
+
+        assertThat(ShortIlaFactoryFromCastCharIlaFactory.create(charIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastDoubleIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastDoubleIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactoryFill;
+
+final class ShortIlaFactoryFromCastDoubleIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> ShortIlaFactoryFromCastDoubleIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final DoubleIlaFactory doubleIlaFactory = DoubleIlaFactoryFill.create(0.0, 10);
+
+        assertThat(ShortIlaFactoryFromCastDoubleIlaFactory.create(doubleIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastFloatIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastFloatIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactoryFill;
+
+final class ShortIlaFactoryFromCastFloatIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> ShortIlaFactoryFromCastFloatIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final FloatIlaFactory floatIlaFactory = FloatIlaFactoryFill.create(0.0F, 10);
+
+        assertThat(ShortIlaFactoryFromCastFloatIlaFactory.create(floatIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastIntIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastIntIlaFactoryTest.java
@@ -1,0 +1,26 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+import tfw.immutable.ilaf.intilaf.IntIlaFactoryFill;
+
+final class ShortIlaFactoryFromCastIntIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> ShortIlaFactoryFromCastIntIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final IntIlaFactory ilaFactory = IntIlaFactoryFill.create(0, 10);
+
+        assertThat(ShortIlaFactoryFromCastIntIlaFactory.create(ilaFactory, 10).create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastLongIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/ilaf/shortilaf/ShortIlaFactoryFromCastLongIlaFactoryTest.java
@@ -1,0 +1,27 @@
+package tfw.immutable.ilaf.shortilaf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+import tfw.immutable.ilaf.longilaf.LongIlaFactoryFill;
+
+final class ShortIlaFactoryFromCastLongIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> ShortIlaFactoryFromCastLongIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final LongIlaFactory longIlaFactory = LongIlaFactoryFill.create(0L, 10);
+
+        assertThat(ShortIlaFactoryFromCastLongIlaFactory.create(longIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/test/template/tfw/immutable/ilaf/__IlaFactoryDivideTest.template
+++ b/src/test/template/tfw/immutable/ilaf/__IlaFactoryDivideTest.template
@@ -1,0 +1,28 @@
+// byteilaf,charilaf,doubleilaf,floatilaf,intilaf,longilaf,shortilaf
+package %%PACKAGE%%;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class %%NAME%%IlaFactoryDivideTest {
+    @Test
+    void argumentTest() {
+        final %%NAME%%IlaFactory%%TEMPLATE%% %%LOWER_NAME%%IlaFactory = %%NAME%%IlaFactoryFill.create(%%DEFAULT_VALUE%%, 10);
+
+        assertThatThrownBy(() -> %%NAME%%IlaFactoryDivide.create(null, %%LOWER_NAME%%IlaFactory, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("leftFactory == null not allowed!");
+        assertThatThrownBy(() -> %%NAME%%IlaFactoryDivide.create(%%LOWER_NAME%%IlaFactory, null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rightFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final %%NAME%%IlaFactory%%TEMPLATE%% f = %%NAME%%IlaFactoryFill.create(%%DEFAULT_VALUE%%, 10);
+
+        assertThat(%%NAME%%IlaFactoryDivide.create(f, f, 10).create()).isNotNull();
+    }
+}

--- a/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastByteIlaFactoryTest.template
+++ b/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastByteIlaFactoryTest.template
@@ -1,0 +1,27 @@
+// charilaf,doubleilaf,floatilaf,intilaf,longilaf,shortilaf
+package %%PACKAGE%%;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactory;
+import tfw.immutable.ilaf.byteilaf.ByteIlaFactoryFill;
+
+final class %%NAME%%IlaFactoryFromCastByteIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> %%NAME%%IlaFactoryFromCastByteIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("byteIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ByteIlaFactory byteIlaFactory = ByteIlaFactoryFill.create((byte) 0, 10);
+
+        assertThat(%%NAME%%IlaFactoryFromCastByteIlaFactory.create(byteIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}

--- a/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastCharIlaFactoryTest.template
+++ b/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastCharIlaFactoryTest.template
@@ -1,0 +1,27 @@
+// byteilaf,doubleilaf,floatilaf,intilaf,longilaf,shortilaf
+package %%PACKAGE%%;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.charilaf.CharIlaFactory;
+import tfw.immutable.ilaf.charilaf.CharIlaFactoryFill;
+
+final class %%NAME%%IlaFactoryFromCastCharIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> %%NAME%%IlaFactoryFromCastCharIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("charIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final CharIlaFactory charIlaFactory = CharIlaFactoryFill.create((char) 0, 10);
+
+        assertThat(%%NAME%%IlaFactoryFromCastCharIlaFactory.create(charIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}

--- a/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastDoubleIlaFactoryTest.template
+++ b/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastDoubleIlaFactoryTest.template
@@ -1,0 +1,27 @@
+// byteilaf,charilaf,floatilaf,intilaf,longilaf,shortilaf
+package %%PACKAGE%%;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactory;
+import tfw.immutable.ilaf.doubleilaf.DoubleIlaFactoryFill;
+
+final class %%NAME%%IlaFactoryFromCastDoubleIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> %%NAME%%IlaFactoryFromCastDoubleIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("doubleIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final DoubleIlaFactory doubleIlaFactory = DoubleIlaFactoryFill.create(0.0, 10);
+
+        assertThat(%%NAME%%IlaFactoryFromCastDoubleIlaFactory.create(doubleIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}

--- a/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastFloatIlaFactoryTest.template
+++ b/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastFloatIlaFactoryTest.template
@@ -1,0 +1,27 @@
+// byteilaf,charilaf,doubleilaf,intilaf,longilaf,shortilaf
+package %%PACKAGE%%;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactory;
+import tfw.immutable.ilaf.floatilaf.FloatIlaFactoryFill;
+
+final class %%NAME%%IlaFactoryFromCastFloatIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> %%NAME%%IlaFactoryFromCastFloatIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("floatIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final FloatIlaFactory floatIlaFactory = FloatIlaFactoryFill.create(0.0F, 10);
+
+        assertThat(%%NAME%%IlaFactoryFromCastFloatIlaFactory.create(floatIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}

--- a/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastIntIlaFactoryTest.template
+++ b/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastIntIlaFactoryTest.template
@@ -1,0 +1,26 @@
+// byteilaf,charilaf,doubleilaf,floatilaf,longilaf,shortilaf
+package %%PACKAGE%%;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.intilaf.IntIlaFactory;
+import tfw.immutable.ilaf.intilaf.IntIlaFactoryFill;
+
+final class %%NAME%%IlaFactoryFromCastIntIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> %%NAME%%IlaFactoryFromCastIntIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("intIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final IntIlaFactory ilaFactory = IntIlaFactoryFill.create(0, 10);
+
+        assertThat(%%NAME%%IlaFactoryFromCastIntIlaFactory.create(ilaFactory, 10).create())
+                .isNotNull();
+    }
+}

--- a/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastLongIlaFactoryTest.template
+++ b/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastLongIlaFactoryTest.template
@@ -1,0 +1,27 @@
+// byteilaf,charilaf,doubleilaf,floatilaf,intilaf,shortilaf
+package %%PACKAGE%%;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.longilaf.LongIlaFactory;
+import tfw.immutable.ilaf.longilaf.LongIlaFactoryFill;
+
+final class %%NAME%%IlaFactoryFromCastLongIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> %%NAME%%IlaFactoryFromCastLongIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("longIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final LongIlaFactory longIlaFactory = LongIlaFactoryFill.create(0L, 10);
+
+        assertThat(%%NAME%%IlaFactoryFromCastLongIlaFactory.create(longIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}

--- a/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastShortIlaFactoryTest.template
+++ b/src/test/template/tfw/immutable/ilaf/__IlaFactoryFromCastShortIlaFactoryTest.template
@@ -1,0 +1,27 @@
+// byteilaf,charilaf,doubleilaf,floatilaf,intilaf,longilaf
+package %%PACKAGE%%;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactory;
+import tfw.immutable.ilaf.shortilaf.ShortIlaFactoryFill;
+
+final class %%NAME%%IlaFactoryFromCastShortIlaFactoryTest {
+    @Test
+    void argumentTest() {
+        assertThatThrownBy(() -> %%NAME%%IlaFactoryFromCastShortIlaFactory.create(null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("shortIlaFactory == null not allowed!");
+    }
+
+    @Test
+    void createTest() {
+        final ShortIlaFactory shortIlaFactory = ShortIlaFactoryFill.create((short) 0, 10);
+
+        assertThat(%%NAME%%IlaFactoryFromCastShortIlaFactory.create(shortIlaFactory, 10)
+                        .create())
+                .isNotNull();
+    }
+}


### PR DESCRIPTION
This PR is the third set of IlaFactory implementations.

## Summary by Sourcery

Implement IlaFactory for division and casting.

New Features:
- Added `IlaFactory` implementations for dividing two ILAs.
- Added `IlaFactory` implementations for casting between different primitive types.