### PR TITLE
Fixes for Sonar warnings in the immutable and swing test packages.

### DIFF
--- a/src/test/java/tfw/component/TriggerRelayTest.java
+++ b/src/test/java/tfw/component/TriggerRelayTest.java
@@ -1,6 +1,6 @@
 package tfw.component;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import tfw.tsm.BasicTransactionQueue;
@@ -10,13 +10,13 @@ import tfw.tsm.RootFactory;
 import tfw.tsm.TriggeredCommit;
 import tfw.tsm.ecd.StatelessTriggerECD;
 
-class TriggerRelayTest {
+final class TriggerRelayTest {
     private final StatelessTriggerECD triggerToRelayECD = new StatelessTriggerECD("triggerToRelay");
 
     private final StatelessTriggerECD relayedTriggerECD = new StatelessTriggerECD("relayedTrigger");
 
     @Test
-    void testTriggerRelay() {
+    void triggerRelayTest() {
         RootFactory rf = new RootFactory();
         rf.addEventChannel(triggerToRelayECD);
         rf.addEventChannel(relayedTriggerECD);
@@ -29,7 +29,7 @@ class TriggerRelayTest {
         root.add(new TriggerRelay("relay", triggerToRelayECD, relayedTriggerECD));
         initiator.trigger(triggerToRelayECD);
         queue.waitTilEmpty();
-        assertTrue(commit.executed, "Trigger not relayed!");
+        assertThat(commit.executed).isTrue();
     }
 
     private class CommitImpl extends TriggeredCommit {

--- a/src/test/java/tfw/immutable/iis/booleaniis/AbstractBooleanIisTest.java
+++ b/src/test/java/tfw/immutable/iis/booleaniis/AbstractBooleanIisTest.java
@@ -15,9 +15,9 @@ final class AbstractBooleanIisTest {
             assertThatThrownBy(() -> ti.read(null, 0, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, -1, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-            assertThat(ti.read(array, 0, 0)).isEqualTo(0);
+            assertThat(ti.read(array, 0, 0)).isZero();
             assertThat(ti.read(array, 0, 1)).isEqualTo(1);
-            assertThat(ti.skip(0)).isEqualTo(0);
+            assertThat(ti.skip(0)).isZero();
             assertThat(ti.skip(1)).isEqualTo(1);
         }
     }

--- a/src/test/java/tfw/immutable/iis/byteiis/AbstractByteIisTest.java
+++ b/src/test/java/tfw/immutable/iis/byteiis/AbstractByteIisTest.java
@@ -15,9 +15,9 @@ final class AbstractByteIisTest {
             assertThatThrownBy(() -> ti.read(null, 0, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, -1, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-            assertThat(ti.read(array, 0, 0)).isEqualTo(0);
+            assertThat(ti.read(array, 0, 0)).isZero();
             assertThat(ti.read(array, 0, 1)).isEqualTo(1);
-            assertThat(ti.skip(0)).isEqualTo(0);
+            assertThat(ti.skip(0)).isZero();
             assertThat(ti.skip(1)).isEqualTo(1);
         }
     }

--- a/src/test/java/tfw/immutable/iis/byteiis/ByteIisFromInputStreamTest.java
+++ b/src/test/java/tfw/immutable/iis/byteiis/ByteIisFromInputStreamTest.java
@@ -20,7 +20,7 @@ final class ByteIisFromInputStreamTest {
 
         assertThatThrownBy(() -> byteIis.skip(10)).isInstanceOf(IOException.class);
         assertThatThrownBy(() -> byteIis.read(new byte[10], 0, 10)).isInstanceOf(IOException.class);
-        assertThatThrownBy(() -> byteIis.close()).isInstanceOf(IOException.class);
+        assertThatThrownBy(byteIis::close).isInstanceOf(IOException.class);
     }
 
     @Test

--- a/src/test/java/tfw/immutable/iis/chariis/AbstractCharIisTest.java
+++ b/src/test/java/tfw/immutable/iis/chariis/AbstractCharIisTest.java
@@ -15,9 +15,9 @@ final class AbstractCharIisTest {
             assertThatThrownBy(() -> ti.read(null, 0, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, -1, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-            assertThat(ti.read(array, 0, 0)).isEqualTo(0);
+            assertThat(ti.read(array, 0, 0)).isZero();
             assertThat(ti.read(array, 0, 1)).isEqualTo(1);
-            assertThat(ti.skip(0)).isEqualTo(0);
+            assertThat(ti.skip(0)).isZero();
             assertThat(ti.skip(1)).isEqualTo(1);
         }
     }

--- a/src/test/java/tfw/immutable/iis/doubleiis/AbstractDoubleIisTest.java
+++ b/src/test/java/tfw/immutable/iis/doubleiis/AbstractDoubleIisTest.java
@@ -15,9 +15,9 @@ final class AbstractDoubleIisTest {
             assertThatThrownBy(() -> ti.read(null, 0, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, -1, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-            assertThat(ti.read(array, 0, 0)).isEqualTo(0);
+            assertThat(ti.read(array, 0, 0)).isZero();
             assertThat(ti.read(array, 0, 1)).isEqualTo(1);
-            assertThat(ti.skip(0)).isEqualTo(0);
+            assertThat(ti.skip(0)).isZero();
             assertThat(ti.skip(1)).isEqualTo(1);
         }
     }

--- a/src/test/java/tfw/immutable/iis/floatiis/AbstractFloatIisTest.java
+++ b/src/test/java/tfw/immutable/iis/floatiis/AbstractFloatIisTest.java
@@ -15,9 +15,9 @@ final class AbstractFloatIisTest {
             assertThatThrownBy(() -> ti.read(null, 0, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, -1, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-            assertThat(ti.read(array, 0, 0)).isEqualTo(0);
+            assertThat(ti.read(array, 0, 0)).isZero();
             assertThat(ti.read(array, 0, 1)).isEqualTo(1);
-            assertThat(ti.skip(0)).isEqualTo(0);
+            assertThat(ti.skip(0)).isZero();
             assertThat(ti.skip(1)).isEqualTo(1);
         }
     }

--- a/src/test/java/tfw/immutable/iis/intiis/AbstractIntIisTest.java
+++ b/src/test/java/tfw/immutable/iis/intiis/AbstractIntIisTest.java
@@ -15,9 +15,9 @@ final class AbstractIntIisTest {
             assertThatThrownBy(() -> ti.read(null, 0, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, -1, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-            assertThat(ti.read(array, 0, 0)).isEqualTo(0);
+            assertThat(ti.read(array, 0, 0)).isZero();
             assertThat(ti.read(array, 0, 1)).isEqualTo(1);
-            assertThat(ti.skip(0)).isEqualTo(0);
+            assertThat(ti.skip(0)).isZero();
             assertThat(ti.skip(1)).isEqualTo(1);
         }
     }

--- a/src/test/java/tfw/immutable/iis/longiis/AbstractLongIisTest.java
+++ b/src/test/java/tfw/immutable/iis/longiis/AbstractLongIisTest.java
@@ -15,9 +15,9 @@ final class AbstractLongIisTest {
             assertThatThrownBy(() -> ti.read(null, 0, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, -1, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-            assertThat(ti.read(array, 0, 0)).isEqualTo(0);
+            assertThat(ti.read(array, 0, 0)).isZero();
             assertThat(ti.read(array, 0, 1)).isEqualTo(1);
-            assertThat(ti.skip(0)).isEqualTo(0);
+            assertThat(ti.skip(0)).isZero();
             assertThat(ti.skip(1)).isEqualTo(1);
         }
     }

--- a/src/test/java/tfw/immutable/iis/objectiis/AbstractObjectIisTest.java
+++ b/src/test/java/tfw/immutable/iis/objectiis/AbstractObjectIisTest.java
@@ -15,9 +15,9 @@ final class AbstractObjectIisTest {
             assertThatThrownBy(() -> ti.read(null, 0, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, -1, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-            assertThat(ti.read(array, 0, 0)).isEqualTo(0);
+            assertThat(ti.read(array, 0, 0)).isZero();
             assertThat(ti.read(array, 0, 1)).isEqualTo(1);
-            assertThat(ti.skip(0)).isEqualTo(0);
+            assertThat(ti.skip(0)).isZero();
             assertThat(ti.skip(1)).isEqualTo(1);
         }
     }

--- a/src/test/java/tfw/immutable/iis/shortiis/AbstractShortIisTest.java
+++ b/src/test/java/tfw/immutable/iis/shortiis/AbstractShortIisTest.java
@@ -15,9 +15,9 @@ final class AbstractShortIisTest {
             assertThatThrownBy(() -> ti.read(null, 0, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, -1, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-            assertThat(ti.read(array, 0, 0)).isEqualTo(0);
+            assertThat(ti.read(array, 0, 0)).isZero();
             assertThat(ti.read(array, 0, 1)).isEqualTo(1);
-            assertThat(ti.skip(0)).isEqualTo(0);
+            assertThat(ti.skip(0)).isZero();
             assertThat(ti.skip(1)).isEqualTo(1);
         }
     }

--- a/src/test/java/tfw/swing/JButtonBBTest.java
+++ b/src/test/java/tfw/swing/JButtonBBTest.java
@@ -7,6 +7,7 @@ import java.awt.Color;
 import java.awt.Font;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.UIManager;
@@ -71,7 +72,7 @@ final class JButtonBBTest {
     static void beforeAll() {
         FailOnThreadViolationRepaintManager.install();
 
-        final JButton jb = GuiActionRunner.execute(() -> new JButton());
+        final JButton jb = GuiActionRunner.execute((Callable<JButton>) JButton::new);
         final JButtonFixture jbf = new JButtonFixture(BasicRobot.robotWithCurrentAwtHierarchyWithoutScreenLock(), jb);
 
         buttonBackgroundDefault = jbf.background().target();
@@ -133,42 +134,42 @@ final class JButtonBBTest {
 
         compareWidgetAndTfwState(jButton, testCommit, 1, basicTransactionQueue);
 
-        assertThat(0).isEqualTo(testTriggeredCommit.getCount());
+        assertThat(testTriggeredCommit.getCount()).isZero();
 
         window.button(BUTTON_NAME).click();
 
         compareWidgetAndTfwState(jButton, testCommit, 1, basicTransactionQueue);
-        assertThat(1).isEqualTo(testTriggeredCommit.getCount());
+        assertThat(testTriggeredCommit.getCount()).isEqualTo(1);
 
         initiator.set(BUTTON_BACKGROUND_ECD, BUTTON_BACKGROUND_TEST);
 
         compareWidgetAndTfwState(jButton, testCommit, 2, basicTransactionQueue);
-        assertThat(1).isEqualTo(testTriggeredCommit.getCount());
+        assertThat(testTriggeredCommit.getCount()).isEqualTo(1);
 
         initiator.set(BUTTON_FOREGROUND_ECD, BUTTON_FOREGROUND_TEST);
 
         compareWidgetAndTfwState(jButton, testCommit, 3, basicTransactionQueue);
-        assertThat(1).isEqualTo(testTriggeredCommit.getCount());
+        assertThat(testTriggeredCommit.getCount()).isEqualTo(1);
 
         initiator.set(BUTTON_ENABLED_ECD, Boolean.FALSE);
 
         compareWidgetAndTfwState(jButton, testCommit, 4, basicTransactionQueue);
-        assertThat(1).isEqualTo(testTriggeredCommit.getCount());
+        assertThat(testTriggeredCommit.getCount()).isEqualTo(1);
 
         initiator.set(BUTTON_FONT_ECD, BUTTON_FONT_TEST);
 
         compareWidgetAndTfwState(jButton, testCommit, 5, basicTransactionQueue);
-        assertThat(1).isEqualTo(testTriggeredCommit.getCount());
+        assertThat(testTriggeredCommit.getCount()).isEqualTo(1);
 
         initiator.set(BUTTON_TEXT_ECD, BUTTON_TEXT_TEST);
 
         compareWidgetAndTfwState(jButton, testCommit, 6, basicTransactionQueue);
-        assertThat(1).isEqualTo(testTriggeredCommit.getCount());
+        assertThat(testTriggeredCommit.getCount()).isEqualTo(1);
 
         initiator.set(BUTTON_ICON_ECD, BUTTON_ICON_TEST);
 
         compareWidgetAndTfwState(jButton, testCommit, 7, basicTransactionQueue);
-        assertThat(1).isEqualTo(testTriggeredCommit.getCount());
+        assertThat(testTriggeredCommit.getCount()).isEqualTo(1);
     }
 
     @Test
@@ -176,7 +177,7 @@ final class JButtonBBTest {
         final JButtonBB jButtonBB = GuiActionRunner.execute(
                 () -> JButtonBB.builder().setName(BUTTON_NAME).build());
 
-        assertThat(0).isEqualTo(new BranchProxy(jButtonBB.getBranch()).getChildProxies().length);
+        assertThat(new BranchProxy(jButtonBB.getBranch()).getChildProxies()).isEmpty();
 
         final TestActionListenerBranchBox testActionListenerBranchBox = new TestActionListenerBranchBox();
 

--- a/src/test/java/tfw/swing/JTextFieldBBTest.java
+++ b/src/test/java/tfw/swing/JTextFieldBBTest.java
@@ -98,7 +98,7 @@ final class JTextFieldBBTest {
         final JTextFieldBB jTextFieldBB = GuiActionRunner.execute(
                 () -> JTextFieldBB.builder().setName(TEXTFIELD_NAME).build());
 
-        assertThat(0).isEqualTo(new BranchProxy(jTextFieldBB.getBranch()).getChildProxies().length);
+        assertThat(new BranchProxy(jTextFieldBB.getBranch()).getChildProxies()).isEmpty();
 
         final TestActionListenerBranchBox testActionListenerBranchBox = new TestActionListenerBranchBox();
 
@@ -129,7 +129,7 @@ final class JTextFieldBBTest {
         final JTextFieldBB jTextFieldBB = GuiActionRunner.execute(
                 () -> JTextFieldBB.builder().setName(TEXTFIELD_NAME).build());
 
-        assertThat(0).isEqualTo(new BranchProxy(jTextFieldBB.getBranch()).getChildProxies().length);
+        assertThat(new BranchProxy(jTextFieldBB.getBranch()).getChildProxies()).isEmpty();
 
         final TestDocumentListenerBranchBox testDocumentListenerBranchBox = new TestDocumentListenerBranchBox();
 

--- a/src/test/java/tfw/swing/event/ActionListenerFactoryTest.java
+++ b/src/test/java/tfw/swing/event/ActionListenerFactoryTest.java
@@ -58,7 +58,7 @@ final class ActionListenerFactoryTest {
 
         SwingTestUtil.waitForTfwAndSwing(basicTransactionQueue);
 
-        assertThat(1).isEqualTo(testTriggeredCommit.getCount());
+        assertThat(testTriggeredCommit.getCount()).isEqualTo(1);
     }
 
     @Test
@@ -84,6 +84,6 @@ final class ActionListenerFactoryTest {
 
         SwingTestUtil.waitForTfwAndSwing(basicTransactionQueue);
 
-        assertThat(1).isEqualTo(testTriggeredCommit.getCount());
+        assertThat(testTriggeredCommit.getCount()).isEqualTo(1);
     }
 }

--- a/src/test/java/tfw/swing/event/DocumentListenerFactoryTest.java
+++ b/src/test/java/tfw/swing/event/DocumentListenerFactoryTest.java
@@ -65,19 +65,19 @@ final class DocumentListenerFactoryTest {
 
         SwingTestUtil.waitForTfwAndSwing(basicTransactionQueue);
 
-        assertThat(STRING_ONE).isEqualTo(testCommit.getState().get(TEXT_ECD));
+        assertThat(testCommit.getState()).containsEntry(TEXT_ECD, STRING_ONE);
 
         testDocument.remove(STRING_ONE.length() / 4 * 3, STRING_ONE.length() / 4);
 
         SwingTestUtil.waitForTfwAndSwing(basicTransactionQueue);
 
-        assertThat(STRING_ONE_AND_TWO).isEqualTo(testCommit.getState().get(TEXT_ECD));
+        assertThat(testCommit.getState()).containsEntry(TEXT_ECD, STRING_ONE_AND_TWO);
 
         testDocument.fireChangedUpdate(STRING_ONE.length() / 3, STRING_ONE.length() / 3);
 
         SwingTestUtil.waitForTfwAndSwing(basicTransactionQueue);
 
-        assertThat(STRING_ONE_AND_TWO).isEqualTo(testCommit.getState().get(TEXT_ECD));
+        assertThat(testCommit.getState()).containsEntry(TEXT_ECD, STRING_ONE_AND_TWO);
 
         final ExceptionDocument exceptionDocument = new ExceptionDocument();
 

--- a/src/test/java/tfw/swing/event/SetBackgroundFactoryTest.java
+++ b/src/test/java/tfw/swing/event/SetBackgroundFactoryTest.java
@@ -2,6 +2,7 @@ package tfw.swing.event;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.Callable;
 import javax.swing.JButton;
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager;
 import org.assertj.swing.edt.GuiActionRunner;
@@ -22,7 +23,7 @@ final class SetBackgroundFactoryTest {
 
     @Test
     void argumentsTest() {
-        final JButton jButton = GuiActionRunner.execute(() -> new JButton());
+        final JButton jButton = GuiActionRunner.execute((Callable<JButton>) JButton::new);
 
         assertThatThrownBy(() -> SetBackgroundFactory.create(null, COLOR_ECD, jButton, null))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/tfw/swing/event/SetEnabledFactoryTest.java
+++ b/src/test/java/tfw/swing/event/SetEnabledFactoryTest.java
@@ -2,6 +2,7 @@ package tfw.swing.event;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.Callable;
 import javax.swing.JButton;
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager;
 import org.assertj.swing.edt.GuiActionRunner;
@@ -22,7 +23,7 @@ final class SetEnabledFactoryTest {
 
     @Test
     void argumentsTest() {
-        final JButton jButton = GuiActionRunner.execute(() -> new JButton());
+        final JButton jButton = GuiActionRunner.execute((Callable<JButton>) JButton::new);
 
         assertThatThrownBy(() -> SetEnabledFactory.create(null, ENABLED_ECD, jButton, null))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/tfw/swing/event/SetFontFactoryTest.java
+++ b/src/test/java/tfw/swing/event/SetFontFactoryTest.java
@@ -2,6 +2,7 @@ package tfw.swing.event;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.Callable;
 import javax.swing.JButton;
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager;
 import org.assertj.swing.edt.GuiActionRunner;
@@ -22,7 +23,7 @@ final class SetFontFactoryTest {
 
     @Test
     void argumentsTest() {
-        final JButton jButton = GuiActionRunner.execute(() -> new JButton());
+        final JButton jButton = GuiActionRunner.execute((Callable<JButton>) JButton::new);
 
         assertThatThrownBy(() -> SetFontFactory.create(null, FONT_ECD, jButton, null))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/tfw/swing/event/SetForegroundFactoryTest.java
+++ b/src/test/java/tfw/swing/event/SetForegroundFactoryTest.java
@@ -2,6 +2,7 @@ package tfw.swing.event;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.Callable;
 import javax.swing.JButton;
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager;
 import org.assertj.swing.edt.GuiActionRunner;
@@ -22,7 +23,7 @@ final class SetForegroundFactoryTest {
 
     @Test
     void argumentsTest() {
-        final JButton jButton = GuiActionRunner.execute(() -> new JButton());
+        final JButton jButton = GuiActionRunner.execute((Callable<JButton>) JButton::new);
 
         assertThatThrownBy(() -> SetForegroundFactory.create(null, COLOR_ECD, jButton, null))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/tfw/swing/event/SetIconFactoryTest.java
+++ b/src/test/java/tfw/swing/event/SetIconFactoryTest.java
@@ -2,6 +2,7 @@ package tfw.swing.event;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.Callable;
 import javax.swing.JButton;
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager;
 import org.assertj.swing.edt.GuiActionRunner;
@@ -22,7 +23,7 @@ final class SetIconFactoryTest {
 
     @Test
     void argumentsTest() {
-        final JButton jButton = GuiActionRunner.execute(() -> new JButton());
+        final JButton jButton = GuiActionRunner.execute((Callable<JButton>) JButton::new);
 
         assertThatThrownBy(() -> SetIconFactory.create(null, ICON_ECD, jButton, null))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/tfw/swing/event/SetTextFactoryTest.java
+++ b/src/test/java/tfw/swing/event/SetTextFactoryTest.java
@@ -2,6 +2,7 @@ package tfw.swing.event;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.Callable;
 import javax.swing.AbstractButton;
 import javax.swing.JButton;
 import javax.swing.JTextField;
@@ -25,8 +26,8 @@ final class SetTextFactoryTest {
 
     @Test
     void argumentsTest() {
-        final JButton jButton = GuiActionRunner.execute(() -> new JButton());
-        final JTextField jTextField = GuiActionRunner.execute(() -> new JTextField());
+        final JButton jButton = GuiActionRunner.execute((Callable<JButton>) JButton::new);
+        final JTextField jTextField = GuiActionRunner.execute((Callable<JTextField>) JTextField::new);
 
         assertThatThrownBy(() -> SetTextFactory.create(null, TEXT_ECD, jButton, null))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/template/tfw/immutable/iis/Abstract__IisTest.template
+++ b/src/test/template/tfw/immutable/iis/Abstract__IisTest.template
@@ -16,9 +16,9 @@ final class Abstract%%NAME%%IisTest {
             assertThatThrownBy(() -> ti.read(null, 0, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, -1, 1)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> ti.read(array, 0, -1)).isInstanceOf(IllegalArgumentException.class);
-            assertThat(ti.read(array, 0, 0)).isEqualTo(0);
+            assertThat(ti.read(array, 0, 0)).isZero();
             assertThat(ti.read(array, 0, 1)).isEqualTo(1);
-            assertThat(ti.skip(0)).isEqualTo(0);
+            assertThat(ti.skip(0)).isZero();
             assertThat(ti.skip(1)).isEqualTo(1);
         }
     }


### PR DESCRIPTION
This PR addresses Sonar warnings in the immutable and swing test packages.

## Summary by Sourcery

Fix Sonar warnings by replacing deprecated methods with their updated AssertJ equivalents and using method references for conciseness.

Tests:
- Update tests to use AssertJ's `isTrue` and `isZero` for boolean and numeric assertions respectively.
- Replace explicit lambda expressions with method references when creating Swing components in test setup methods.
- Use more descriptive test method names, improving readability and maintainability.