### PR TITLE
Fixed Sonar warnings for tfw.immutable.streams package.

### DIFF
--- a/src/main/java/tfw/immutable/stream/StreamFromObjectIla.java
+++ b/src/main/java/tfw/immutable/stream/StreamFromObjectIla.java
@@ -33,8 +33,8 @@ public final class StreamFromObjectIla {
         public boolean tryAdvance(Consumer<? super T> action) {
             try {
                 if (position < ila.length()) {
-                    ila.get((T[]) array, 0, position++, 1);
-                    action.accept((T) array[0]);
+                    ila.get(array, 0, position++, 1);
+                    action.accept(array[0]);
 
                     return true;
                 }

--- a/src/test/java/tfw/immutable/stream/DoubleStreamFactoryFromDoubleIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/stream/DoubleStreamFactoryFromDoubleIlaFactoryTest.java
@@ -23,7 +23,7 @@ final class DoubleStreamFactoryFromDoubleIlaFactoryTest {
     }
 
     @Test
-    void badIlaLengthTest() throws IOException {
+    void badIlaLengthTest() {
         DoubleIlaFactory d = new DoubleIlaFactory() {
             @Override
             public DoubleIla create() {
@@ -42,7 +42,7 @@ final class DoubleStreamFactoryFromDoubleIlaFactoryTest {
         };
         final DoubleStreamFactory dsf = DoubleStreamFactoryFromDoubleIlaFactory.create(d);
 
-        assertThatThrownBy(() -> dsf.create())
+        assertThatThrownBy(dsf::create)
                 .isInstanceOf(IOException.class)
                 .hasMessage("Test DoubleIla that only throws IOExceptions!");
     }
@@ -68,7 +68,7 @@ final class DoubleStreamFactoryFromDoubleIlaFactoryTest {
         final DoubleStreamFactory dsf = DoubleStreamFactoryFromDoubleIlaFactory.create(l);
         final DoubleStream s = dsf.create();
 
-        assertThatThrownBy(() -> s.toArray())
+        assertThatThrownBy(s::toArray)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("End size 0 is less than fixed size 5");
     }

--- a/src/test/java/tfw/immutable/stream/IntStreamFactoryFromIntIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/stream/IntStreamFactoryFromIntIlaFactoryTest.java
@@ -23,7 +23,7 @@ final class IntStreamFactoryFromIntIlaFactoryTest {
     }
 
     @Test
-    void badIlaLengthTest() throws IOException {
+    void badIlaLengthTest() {
         IntIlaFactory i = new IntIlaFactory() {
             @Override
             public IntIla create() {
@@ -42,7 +42,7 @@ final class IntStreamFactoryFromIntIlaFactoryTest {
         };
         final IntStreamFactory isf = IntStreamFactoryFromIntIlaFactory.create(i);
 
-        assertThatThrownBy(() -> isf.create())
+        assertThatThrownBy(isf::create)
                 .isInstanceOf(IOException.class)
                 .hasMessage("Test IntIla that only throws IOExceptions!");
     }
@@ -68,7 +68,7 @@ final class IntStreamFactoryFromIntIlaFactoryTest {
         final IntStreamFactory isf = IntStreamFactoryFromIntIlaFactory.create(i);
         final IntStream s = isf.create();
 
-        assertThatThrownBy(() -> s.toArray())
+        assertThatThrownBy(s::toArray)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("End size 0 is less than fixed size 5");
     }

--- a/src/test/java/tfw/immutable/stream/LongStreamFactoryFromLongIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/stream/LongStreamFactoryFromLongIlaFactoryTest.java
@@ -23,7 +23,7 @@ final class LongStreamFactoryFromLongIlaFactoryTest {
     }
 
     @Test
-    void badIlaLengthTest() throws IOException {
+    void badIlaLengthTest() {
         LongIlaFactory l = new LongIlaFactory() {
             @Override
             public LongIla create() {
@@ -42,7 +42,7 @@ final class LongStreamFactoryFromLongIlaFactoryTest {
         };
         final LongStreamFactory lsf = LongStreamFactoryFromLongIlaFactory.create(l);
 
-        assertThatThrownBy(() -> lsf.create())
+        assertThatThrownBy(lsf::create)
                 .isInstanceOf(IOException.class)
                 .hasMessage("Test LongIla that only throws IOExceptions!");
     }
@@ -68,7 +68,7 @@ final class LongStreamFactoryFromLongIlaFactoryTest {
         final LongStreamFactory lsf = LongStreamFactoryFromLongIlaFactory.create(l);
         final LongStream s = lsf.create();
 
-        assertThatThrownBy(() -> s.toArray())
+        assertThatThrownBy(s::toArray)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("End size 0 is less than fixed size 5");
     }

--- a/src/test/java/tfw/immutable/stream/StreamFactoryFromObjectIlaFactoryTest.java
+++ b/src/test/java/tfw/immutable/stream/StreamFactoryFromObjectIlaFactoryTest.java
@@ -25,7 +25,7 @@ final class StreamFactoryFromObjectIlaFactoryTest {
     }
 
     @Test
-    void badIlaLengthTest() throws IOException {
+    void badIlaLengthTest() {
         ObjectIlaFactory<Object> o = new ObjectIlaFactory<Object>() {
             @Override
             public ObjectIla<Object> create() {
@@ -44,7 +44,7 @@ final class StreamFactoryFromObjectIlaFactoryTest {
         };
         final StreamFactory<Object> osf = StreamFactoryFromObjectIlaFactory.create(o, Object.class);
 
-        assertThatThrownBy(() -> osf.create())
+        assertThatThrownBy(osf::create)
                 .isInstanceOf(IOException.class)
                 .hasMessage("Test ObjectIla that only throws IOExceptions!");
     }
@@ -70,7 +70,7 @@ final class StreamFactoryFromObjectIlaFactoryTest {
         final StreamFactory<String> osf = StreamFactoryFromObjectIlaFactory.create(o, String.class);
         final Stream<String> s = osf.create();
 
-        assertThatThrownBy(() -> s.toArray())
+        assertThatThrownBy(s::toArray)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("End size 0 is less than fixed size 5");
     }


### PR DESCRIPTION
This PR fixes warnings introduced by the tfw.immutable.streams package.

## Summary by Sourcery

Fix Sonar warnings in the tfw.immutable.streams package by removing unnecessary IOException declarations in test methods and simplifying lambda expressions in test assertions.

Bug Fixes:
- Remove unnecessary IOException declaration from test methods in various stream factory test classes.

Enhancements:
- Simplify lambda expressions in test assertions by using method references instead of lambda expressions.