### PR TITLE
Completed more migrations to Flogger.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <plugin.error-prone-contrib.version>0.28.0</plugin.error-prone-contrib.version>
         <plugin.error_prone_core.version>2.47.0</plugin.error_prone_core.version>
         <plugin.errorprone-slf4j.version>0.1.29</plugin.errorprone-slf4j.version>
+        <plugin.exec-maven-plugin.version>3.5.0</plugin.exec-maven-plugin.version>
         <plugin.jacoco-maven-plugin.version>0.8.14</plugin.jacoco-maven-plugin.version>
         <plugin.maven-compiler-plugin.version>3.15.0</plugin.maven-compiler-plugin.version>
         <plugin.maven-dependency-plugin.version>3.10.0</plugin.maven-dependency-plugin.version>
@@ -317,6 +318,18 @@
                         <version>${plugin.maven-surefire-junit5-tree-reporter.version}</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${plugin.exec-maven-plugin.version}</version>
+                <configuration>
+                    <mainClass>tfw.build.SearchAndReplace</mainClass>
+                    <arguments>
+                        <argument>./src/main/template</argument>
+                        <argument>./src/test/template</argument>
+                    </arguments>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>

--- a/src/main/java/tfw/build/SearchAndReplace.java
+++ b/src/main/java/tfw/build/SearchAndReplace.java
@@ -1,5 +1,6 @@
 package tfw.build;
 
+import com.google.common.flogger.FluentLogger;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -10,22 +11,19 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class SearchAndReplace {
-    private static final Logger LOGGER;
+    private static final FluentLogger LOGGER = FluentLogger.forEnclosingClass();
 
     static {
         System.setProperty("java.util.logging.SimpleFormatter.format", "[%1$tF %1$tT] [%4$-7s] %5$s %n");
-        LOGGER = LoggerFactory.getLogger(SearchAndReplace.class);
     }
 
     private SearchAndReplace() {}
 
     public static void main(final String[] args) throws Exception {
         if (args.length < 1) {
-            LOGGER.error("Usage: SearchAndReplace <template/mapping root directory>");
+            LOGGER.atSevere().log("Usage: SearchAndReplace <template/mapping root directory>");
 
             System.exit(-1);
         }
@@ -40,38 +38,38 @@ public final class SearchAndReplace {
             }
 
             for (final Path p : templateList) {
-                LOGGER.info("Template Path ={}", p);
+                LOGGER.atInfo().log("Template Path =%s", p);
 
                 final String templateString = new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
                 final String[] mappingTemplate = templateString.split("\\R", 2);
 
-                LOGGER.info("  mapping = {}", mappingTemplate[0]);
-                LOGGER.debug("  template.l = \n{}", mappingTemplate[1].length());
+                LOGGER.atInfo().log("  mapping = %s", mappingTemplate[0]);
+                LOGGER.atFine().log("  template.l = %n%s", mappingTemplate[1].length());
 
                 final int commentIndex = mappingTemplate[0].indexOf("//");
 
                 if (commentIndex != 0) {
-                    LOGGER.error("Mapping comment not at beginning of first line!");
+                    LOGGER.atSevere().log("Mapping comment not at beginning of first line!");
 
                     System.exit(-1);
                 }
 
                 final String mapping = mappingTemplate[0].substring(2).trim();
 
-                LOGGER.debug("  mapping = {}", mapping);
+                LOGGER.atFine().log("  mapping = %s", mapping);
 
                 final String[] mappings = mapping.split(",");
 
-                LOGGER.info("  mappings = {}", mappings.length);
+                LOGGER.atInfo().log("  mappings = %s", mappings.length);
 
                 for (int i = 0; i < mappings.length; i++) {
                     final Path mappingPath = Paths.get(p.getParent().toString(), mappings[i] + ".mapping");
 
-                    LOGGER.debug("  mappingPath = {}", mappingPath);
+                    LOGGER.atFine().log("  mappingPath = %s", mappingPath);
 
                     final String mappingString = new String(Files.readAllBytes(mappingPath), StandardCharsets.UTF_8);
 
-                    LOGGER.debug("  mappingString = \n{}", mappingString);
+                    LOGGER.atFine().log("  mappingString = %n%s", mappingString);
 
                     final Properties properties = new Properties();
                     properties.load(new StringReader(mappingString));
@@ -87,7 +85,7 @@ public final class SearchAndReplace {
                     // DELETE THIS!!!
                     template = template.replace("\r\n", System.lineSeparator());
 
-                    LOGGER.debug("  template = \n{}", template);
+                    LOGGER.atFine().log("  template = %n%s", template);
 
                     final Path outputPath = Paths.get(
                             p.getParent().toString().replace("template", "java"),
@@ -98,23 +96,23 @@ public final class SearchAndReplace {
                                     .replace("__", properties.getProperty("%%NAME%%"))
                                     .replaceAll("\\.\\..+\\.", "."));
 
-                    LOGGER.debug("  outputPath = {}", outputPath);
+                    LOGGER.atFine().log("  outputPath = %s", outputPath);
 
                     if (outputPath.toFile().exists()) {
                         final String originalFileString =
                                 new String(Files.readAllBytes(outputPath), StandardCharsets.UTF_8);
 
                         if (originalFileString.equals(template)) {
-                            LOGGER.info("  same as {}", outputPath);
+                            LOGGER.atInfo().log("  same as %s", outputPath);
                         } else {
                             Files.write(outputPath, template.getBytes(StandardCharsets.UTF_8));
 
-                            LOGGER.info("  writing {}", outputPath);
+                            LOGGER.atInfo().log("  writing %s", outputPath);
                         }
                     } else {
                         Files.write(outputPath, template.getBytes(StandardCharsets.UTF_8));
 
-                        LOGGER.info("  writing {}", outputPath);
+                        LOGGER.atInfo().log("  writing %s", outputPath);
                     }
                 }
             }

--- a/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromFile.java
+++ b/src/main/java/tfw/immutable/ila/byteila/ByteIlaFromFile.java
@@ -1,15 +1,14 @@
 package tfw.immutable.ila.byteila;
 
+import com.google.common.flogger.FluentLogger;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import tfw.check.Argument;
 
 public final class ByteIlaFromFile {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ByteIlaFromFile.class);
+    private static final FluentLogger LOGGER = FluentLogger.forEnclosingClass();
 
     private ByteIlaFromFile() {}
 
@@ -70,7 +69,7 @@ public final class ByteIlaFromFile {
             try {
                 raf.close();
             } catch (IOException ioe) {
-                LOGGER.warn("Failed to close RandomAccessFile!", ioe);
+                LOGGER.atWarning().withCause(ioe).log("Failed to close RandomAccessFile!");
             }
 
             raf = null;

--- a/src/main/java/tfw/immutable/ila/demo/OctalDump.java
+++ b/src/main/java/tfw/immutable/ila/demo/OctalDump.java
@@ -1,5 +1,6 @@
 package tfw.immutable.ila.demo;
 
+import com.google.common.flogger.FluentLogger;
 import java.io.File;
 import java.io.IOException;
 import tfw.check.Argument;
@@ -33,12 +34,15 @@ import tfw.immutable.ila.shortila.ShortIlaIterator;
 import tfw.immutable.ila.shortila.ShortIlaSegment;
 
 public class OctalDump {
+    private static final FluentLogger LOGGER = FluentLogger.forEnclosingClass();
+
     public static final int BUFFER_SIZE = 1000;
 
     public static void main(String[] args) throws IOException {
         if (args.length != 3 || args[1].length() != 2) {
-            System.err.println("Usage: OctalDump <-t type> <file>");
-            System.err.println("       type = <d,f,o,x><1,2,4,8>");
+            LOGGER.atSevere().log("Usage: OctalDump <-t type> <file>");
+            LOGGER.atSevere().log("       type = <d,f,o,x><1,2,4,8>");
+
             System.exit(-1);
         }
 
@@ -104,10 +108,10 @@ public class OctalDump {
 
         for (ObjectIlaIterator<String> oii = new ObjectIlaIterator<>(strings, new String[BUFFER_SIZE]);
                 oii.hasNext(); ) {
-            System.out.println(oii.next());
+            LOGGER.atInfo().log("%s", oii.next());
         }
 
-        System.out.println("strings = \n" + strings);
+        LOGGER.atInfo().log("strings = %n%s", strings);
     }
 
     private static class StringObjectIlaFromByteIla {

--- a/src/main/java/tfw/state/StateMachine.java
+++ b/src/main/java/tfw/state/StateMachine.java
@@ -3,7 +3,6 @@ package tfw.state;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.slf4j.LoggerFactory;
 import tfw.check.Argument;
 
 public class StateMachine {
@@ -67,12 +66,7 @@ public class StateMachine {
 
                 if (e && g && s) {
                     for (int j = 0; j < t.actions.size(); j++) {
-                        try {
-                            t.actions.get(j).act(event);
-                        } catch (Exception exception) {
-                            LoggerFactory.getLogger(StateMachine.class)
-                                    .error("Exception thrown while executing action!", exception);
-                        }
+                        t.actions.get(j).act(event);
                     }
 
                     state = t.toState;

--- a/src/main/java/tfw/swing/demo/ByteInterleavedImagePanelDemo.java
+++ b/src/main/java/tfw/swing/demo/ByteInterleavedImagePanelDemo.java
@@ -1,5 +1,6 @@
 package tfw.swing.demo;
 
+import com.google.common.flogger.FluentLogger;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.GridLayout;
@@ -15,7 +16,6 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import org.slf4j.LoggerFactory;
 import tfw.awt.ecd.ColorModelECD;
 import tfw.swing.ByteInterleavedImagePanel;
 import tfw.tsm.AWTTransactionQueue;
@@ -28,6 +28,8 @@ import tfw.tsm.ecd.ObjectECD;
 import tfw.tsm.ecd.ilm.ByteIlmECD;
 
 public class ByteInterleavedImagePanelDemo {
+    private static final FluentLogger LOGGER = FluentLogger.forEnclosingClass();
+
     public ByteInterleavedImagePanelDemo() {}
 
     public static final void main(String[] args) {
@@ -118,7 +120,7 @@ public class ByteInterleavedImagePanelDemo {
 
                     initiator.set(ecsb.toArray());
                 } catch (NumberFormatException nfe) {
-                    LoggerFactory.getLogger(this.getClass()).error("Couldn't parse number!", nfe);
+                    LOGGER.atSevere().withCause(nfe).log("Couldn't parse number!");
                 }
             }
         };

--- a/src/main/java/tfw/tsm/CheckDependencies.java
+++ b/src/main/java/tfw/tsm/CheckDependencies.java
@@ -1,10 +1,9 @@
 package tfw.tsm;
 
 import java.util.List;
-import java.util.logging.Logger;
 
 public interface CheckDependencies {
-    void checkDependencies(List<Processor> processors, List<Processor> delayedProcessors, Logger logger);
+    void checkDependencies(List<Processor> processors, List<Processor> delayedProcessors, boolean logging);
 
     void clearCache();
 }

--- a/src/main/java/tfw/tsm/DefaultCheckDependencies.java
+++ b/src/main/java/tfw/tsm/DefaultCheckDependencies.java
@@ -40,7 +40,7 @@ public class DefaultCheckDependencies implements CheckDependencies {
     }
 
     public void privateCheckDependencies(List<Processor> processors, List<Processor> delayedProcessors) {
-        LOGGER.atInfo().log(
+        LOGGER.atFine().log(
                 "CDN: p.s=%d dp.s=%d c.s=%d", processors.size(), delayedProcessors.size(), processorCache.size());
 
         origProcessorsArraySize = processors.size();

--- a/src/main/java/tfw/tsm/DefaultCheckDependencies.java
+++ b/src/main/java/tfw/tsm/DefaultCheckDependencies.java
@@ -1,5 +1,8 @@
 package tfw.tsm;
 
+import com.google.common.flogger.FluentLogger;
+import com.google.common.flogger.context.LogLevelMap;
+import com.google.common.flogger.context.ScopedLoggingContexts;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -7,9 +10,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class DefaultCheckDependencies implements CheckDependencies {
+    private static final FluentLogger LOGGER = FluentLogger.forEnclosingClass();
+    private static final LogLevelMap DEBUG_LEVELS = LogLevelMap.builder()
+            .setDefault(Level.FINE) // Force all logs at FINE and above
+            .build();
+
     private final Map<Processor, Map<Processor, Boolean>> processorCache = new HashMap<>();
 
     private static int origProcessorsArraySize = 0;
@@ -22,13 +29,19 @@ public class DefaultCheckDependencies implements CheckDependencies {
     private static Set<EventChannel> terminatorCrumbs = new HashSet<>();
 
     @Override
-    public void checkDependencies(List<Processor> processors, List<Processor> delayedProcessors, Logger logger) {
-        if (logger != null) {
-            logger.log(
-                    Level.FINE,
-                    "CDN: p.s=" + processors.size() + " dp.s=" + delayedProcessors.size() + " c.s="
-                            + processorCache.size());
+    public void checkDependencies(List<Processor> processors, List<Processor> delayedProcessors, boolean logging) {
+        if (logging) {
+            ScopedLoggingContexts.newContext()
+                    .withLogLevelMap(DEBUG_LEVELS)
+                    .run(() -> privateCheckDependencies(processors, delayedProcessors));
+        } else {
+            privateCheckDependencies(processors, delayedProcessors);
         }
+    }
+
+    public void privateCheckDependencies(List<Processor> processors, List<Processor> delayedProcessors) {
+        LOGGER.atInfo().log(
+                "CDN: p.s=%d dp.s=%d c.s=%d", processors.size(), delayedProcessors.size(), processorCache.size());
 
         origProcessorsArraySize = processors.size();
         if (origProcessorsArray.length < origProcessorsArraySize) {
@@ -83,8 +96,7 @@ public class DefaultCheckDependencies implements CheckDependencies {
                             terminatorCrumbs,
                             processorCache,
                             2,
-                            null,
-                            logger);
+                            null);
 
                     map = processorCache.get(origProcessor);
 
@@ -119,8 +131,7 @@ public class DefaultCheckDependencies implements CheckDependencies {
             Set<EventChannel> visitedEventChannels,
             Map<Processor, Map<Processor, Boolean>> cache,
             int spaces,
-            List<Processor> dependencyChain,
-            Logger logger) {
+            List<Processor> dependencyChain) {
         if (visitedProcessors.contains(toProcessor)) {
             return;
         }
@@ -141,7 +152,7 @@ public class DefaultCheckDependencies implements CheckDependencies {
                     sb.append(p.getName());
                     sb.append(", ");
                 }
-                logger.log(Level.FINE, sb.toString());
+                LOGGER.atFine().log("%s", sb);
             }
         }
 
@@ -161,8 +172,7 @@ public class DefaultCheckDependencies implements CheckDependencies {
                     visitedEventChannels,
                     cache,
                     spaces + 2,
-                    dependencyChain,
-                    logger);
+                    dependencyChain);
         }
     }
 
@@ -175,8 +185,7 @@ public class DefaultCheckDependencies implements CheckDependencies {
             Set<EventChannel> visitedEventChannels,
             Map<Processor, Map<Processor, Boolean>> cache,
             int spaces,
-            List<Processor> dependencyChain,
-            Logger logger) {
+            List<Processor> dependencyChain) {
         if (visitedEventChannels.contains(eventChannel)) {
             return;
         }
@@ -196,8 +205,7 @@ public class DefaultCheckDependencies implements CheckDependencies {
                     visitedEventChannels,
                     cache,
                     spaces + 2,
-                    dependencyChain,
-                    logger);
+                    dependencyChain);
         }
 
         Terminator terminator = (Terminator) eventChannel;
@@ -219,8 +227,7 @@ public class DefaultCheckDependencies implements CheckDependencies {
                             visitedEventChannels,
                             cache,
                             spaces + 4,
-                            dependencyChain,
-                            logger);
+                            dependencyChain);
                 }
             } else {
                 TreeComponent treeComponent = sinks[i].getTreeComponent();
@@ -239,8 +246,7 @@ public class DefaultCheckDependencies implements CheckDependencies {
                             visitedEventChannels,
                             cache,
                             spaces + 4,
-                            dependencyChain,
-                            logger);
+                            dependencyChain);
 
                     if (dependencyChain != null) {
                         dependencyChain.remove(dependencyChain.size() - 1);

--- a/src/main/java/tfw/tsm/TransactionMgr.java
+++ b/src/main/java/tfw/tsm/TransactionMgr.java
@@ -325,7 +325,7 @@ public final class TransactionMgr {
         }
 
         if (processors.size() > 1) {
-            checkDependencies.checkDependencies(processors, delayedProcessors, null);
+            checkDependencies.checkDependencies(processors, delayedProcessors, logging);
         }
 
         // process the independent processors...


### PR DESCRIPTION
This PR migrates more files to use flogger.

## Summary by Sourcery

Migrate additional components from SLF4J/JUL logging to Flogger and wire build support for the SearchAndReplace utility.

New Features:
- Add exec-maven-plugin configuration to run the SearchAndReplace code generation utility from Maven.

Enhancements:
- Replace SLF4J and java.util.logging usage with FluentLogger-based Flogger logging across several classes, including SearchAndReplace, OctalDump, ByteIlaFromFile, ByteInterleavedImagePanelDemo, and DefaultCheckDependencies.
- Adjust the CheckDependencies interface and its DefaultCheckDependencies implementation to control logging via a boolean flag instead of passing a Logger instance, and update TransactionMgr accordingly.
- Simplify StateMachine action execution by removing internal exception logging and allowing exceptions to propagate or be handled by callers.