### PR TITLE
Update github workflow actions to latest versions.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,17 +40,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: 21
         distribution: corretto
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -64,7 +64,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -77,6 +77,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Java ${{ matrix.java }}-${{ matrix.distribution }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: ${{ matrix.java }}
         distribution: ${{ matrix.distribution }}
@@ -29,14 +29,14 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ${{ github.workspace }}/execute-on-vnc.sh mvn -B verify
     - name: Update dependency graph when on master
-      uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 #v5.0.0
+      uses: advanced-security/maven-dependency-submission-action@v5
       if: ${{ github.ref == 'refs/heads/master' }}
     - name: Get changed files
-      uses: tj-actions/verify-changed-files@4616eed12cee617b16fa9d0ef524f883d2a48a48 #20.0.4
+      uses: tj-actions/verify-changed-files@v20
       id: verify-changed-files
     - name: Run step only when files change
       if: steps.verify-changed-files.outputs.files_changed == 'true'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
             core.setFailed('Changed files found: ${{ steps.verify-changed-files.outputs.changed_files }}')

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,10 +29,10 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ${{ github.workspace }}/execute-on-vnc.sh mvn -B verify
     - name: Update dependency graph when on master
-      uses: advanced-security/maven-dependency-submission-action@v5
+      uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 #v5.0.0
       if: ${{ github.ref == 'refs/heads/master' }}
     - name: Get changed files
-      uses: tj-actions/verify-changed-files@v20
+      uses: tj-actions/verify-changed-files@4616eed12cee617b16fa9d0ef524f883d2a48a48 #v20.0.4
       id: verify-changed-files
     - name: Run step only when files change
       if: steps.verify-changed-files.outputs.files_changed == 'true'

--- a/.github/workflows/pitest-pr.yml
+++ b/.github/workflows/pitest-pr.yml
@@ -25,18 +25,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # important to set a fetch depth of 2. By default the checkout action make no history available
           fetch-depth: 2
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: corretto

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Configure java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: corretto

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,17 +12,17 @@ jobs:
     # Don't run for dependabot PRs
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
     - name: Set up Java ${{ matrix.java }}-${{ matrix.distribution }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: 21
         distribution: corretto
         cache: maven
     - name: Cache SonarCloud packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar

--- a/pom.xml
+++ b/pom.xml
@@ -61,20 +61,21 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${dependency.slf4j-api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.flogger</groupId>
             <artifactId>flogger-grpc-context</artifactId>
             <version>0.9</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.flogger</groupId>
             <artifactId>flogger-system-backend</artifactId>
             <version>0.9</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${dependency.slf4j-api.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>net.goui.flogger.testing</groupId>


### PR DESCRIPTION
This PR updates all of the github actions to their latest versions.

## Summary by Sourcery

Update GitHub workflows to use newer major versions of core actions and security tools.

Build:
- Bump actions/checkout to v6 across all workflows.
- Upgrade actions/setup-java to v5 in CodeQL, Maven, Pitest, Sonar, and release workflows.
- Update GitHub CodeQL actions (init, autobuild, analyze) to v4 in the CodeQL workflow.
- Upgrade caching-related actions (actions/cache to v5 and Sonar cache) in relevant workflows.
- Switch maven-dependency-submission and verify-changed-files actions to their latest v5 and v20 tags and bump actions/github-script to v9.