### PR TITLE
Add IlmFactory interfaces.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,8 +327,8 @@
                 <configuration>
                     <mainClass>tfw.build.SearchAndReplace</mainClass>
                     <arguments>
-                        <argument>./src/main/template</argument>
-                        <argument>./src/test/template</argument>
+                        <argument>${project.basedir}/src/main/template</argument>
+                        <argument>${project.basedir}/src/test/template</argument>
                     </arguments>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <plugin.error-prone-contrib.version>0.29.0</plugin.error-prone-contrib.version>
         <plugin.error_prone_core.version>2.49.0</plugin.error_prone_core.version>
         <plugin.errorprone-slf4j.version>0.1.29</plugin.errorprone-slf4j.version>
+        <plugin.exec-maven-plugin.version>3.6.3</plugin.exec-maven-plugin.version>
         <plugin.jacoco-maven-plugin.version>0.8.14</plugin.jacoco-maven-plugin.version>
         <plugin.maven-compiler-plugin.version>3.15.0</plugin.maven-compiler-plugin.version>
         <plugin.maven-dependency-plugin.version>3.10.0</plugin.maven-dependency-plugin.version>
@@ -318,6 +319,18 @@
                         <version>${plugin.maven-surefire-junit5-tree-reporter.version}</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${plugin.exec-maven-plugin.version}</version>
+                <configuration>
+                    <mainClass>tfw.build.SearchAndReplace</mainClass>
+                    <arguments>
+                        <argument>./src/main/template</argument>
+                        <argument>./src/test/template</argument>
+                    </arguments>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>

--- a/src/main/java/tfw/immutable/ilmf/booleanilmf/BooleanIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/booleanilmf/BooleanIlmFactory.java
@@ -1,0 +1,16 @@
+package tfw.immutable.ilmf.booleanilmf;
+
+import tfw.immutable.ilm.booleanilm.BooleanIlm;
+
+/**
+ * This interface defines a factory that creates BooleanIla objects.
+ */
+public interface BooleanIlmFactory {
+    /**
+     * Create a BooleanIlm object.
+     *
+     * @return the BooleanIlm object.
+     */
+    BooleanIlm create();
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilmf/booleanilmf/BooleanIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/booleanilmf/BooleanIlmFactory.java
@@ -3,7 +3,7 @@ package tfw.immutable.ilmf.booleanilmf;
 import tfw.immutable.ilm.booleanilm.BooleanIlm;
 
 /**
- * This interface defines a factory that creates BooleanIla objects.
+ * This interface defines a factory that creates BooleanIlm objects.
  */
 public interface BooleanIlmFactory {
     /**

--- a/src/main/java/tfw/immutable/ilmf/byteilmf/ByteIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/byteilmf/ByteIlmFactory.java
@@ -3,7 +3,7 @@ package tfw.immutable.ilmf.byteilmf;
 import tfw.immutable.ilm.byteilm.ByteIlm;
 
 /**
- * This interface defines a factory that creates ByteIla objects.
+ * This interface defines a factory that creates ByteIlm objects.
  */
 public interface ByteIlmFactory {
     /**

--- a/src/main/java/tfw/immutable/ilmf/byteilmf/ByteIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/byteilmf/ByteIlmFactory.java
@@ -1,0 +1,16 @@
+package tfw.immutable.ilmf.byteilmf;
+
+import tfw.immutable.ilm.byteilm.ByteIlm;
+
+/**
+ * This interface defines a factory that creates ByteIla objects.
+ */
+public interface ByteIlmFactory {
+    /**
+     * Create a ByteIlm object.
+     *
+     * @return the ByteIlm object.
+     */
+    ByteIlm create();
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilmf/charilmf/CharIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/charilmf/CharIlmFactory.java
@@ -1,0 +1,16 @@
+package tfw.immutable.ilmf.charilmf;
+
+import tfw.immutable.ilm.charilm.CharIlm;
+
+/**
+ * This interface defines a factory that creates CharIla objects.
+ */
+public interface CharIlmFactory {
+    /**
+     * Create a CharIlm object.
+     *
+     * @return the CharIlm object.
+     */
+    CharIlm create();
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilmf/charilmf/CharIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/charilmf/CharIlmFactory.java
@@ -3,7 +3,7 @@ package tfw.immutable.ilmf.charilmf;
 import tfw.immutable.ilm.charilm.CharIlm;
 
 /**
- * This interface defines a factory that creates CharIla objects.
+ * This interface defines a factory that creates CharIlm objects.
  */
 public interface CharIlmFactory {
     /**

--- a/src/main/java/tfw/immutable/ilmf/doubleilmf/DoubleIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/doubleilmf/DoubleIlmFactory.java
@@ -1,0 +1,16 @@
+package tfw.immutable.ilmf.doubleilmf;
+
+import tfw.immutable.ilm.doubleilm.DoubleIlm;
+
+/**
+ * This interface defines a factory that creates DoubleIla objects.
+ */
+public interface DoubleIlmFactory {
+    /**
+     * Create a DoubleIlm object.
+     *
+     * @return the DoubleIlm object.
+     */
+    DoubleIlm create();
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilmf/doubleilmf/DoubleIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/doubleilmf/DoubleIlmFactory.java
@@ -3,7 +3,7 @@ package tfw.immutable.ilmf.doubleilmf;
 import tfw.immutable.ilm.doubleilm.DoubleIlm;
 
 /**
- * This interface defines a factory that creates DoubleIla objects.
+ * This interface defines a factory that creates DoubleIlm objects.
  */
 public interface DoubleIlmFactory {
     /**

--- a/src/main/java/tfw/immutable/ilmf/floatilmf/FloatIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/floatilmf/FloatIlmFactory.java
@@ -3,7 +3,7 @@ package tfw.immutable.ilmf.floatilmf;
 import tfw.immutable.ilm.floatilm.FloatIlm;
 
 /**
- * This interface defines a factory that creates FloatIla objects.
+ * This interface defines a factory that creates FloatIlm objects.
  */
 public interface FloatIlmFactory {
     /**

--- a/src/main/java/tfw/immutable/ilmf/floatilmf/FloatIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/floatilmf/FloatIlmFactory.java
@@ -1,0 +1,16 @@
+package tfw.immutable.ilmf.floatilmf;
+
+import tfw.immutable.ilm.floatilm.FloatIlm;
+
+/**
+ * This interface defines a factory that creates FloatIla objects.
+ */
+public interface FloatIlmFactory {
+    /**
+     * Create a FloatIlm object.
+     *
+     * @return the FloatIlm object.
+     */
+    FloatIlm create();
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilmf/intilmf/IntIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/intilmf/IntIlmFactory.java
@@ -3,7 +3,7 @@ package tfw.immutable.ilmf.intilmf;
 import tfw.immutable.ilm.intilm.IntIlm;
 
 /**
- * This interface defines a factory that creates IntIla objects.
+ * This interface defines a factory that creates IntIlm objects.
  */
 public interface IntIlmFactory {
     /**

--- a/src/main/java/tfw/immutable/ilmf/intilmf/IntIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/intilmf/IntIlmFactory.java
@@ -1,0 +1,16 @@
+package tfw.immutable.ilmf.intilmf;
+
+import tfw.immutable.ilm.intilm.IntIlm;
+
+/**
+ * This interface defines a factory that creates IntIla objects.
+ */
+public interface IntIlmFactory {
+    /**
+     * Create a IntIlm object.
+     *
+     * @return the IntIlm object.
+     */
+    IntIlm create();
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilmf/longilmf/LongIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/longilmf/LongIlmFactory.java
@@ -1,0 +1,16 @@
+package tfw.immutable.ilmf.longilmf;
+
+import tfw.immutable.ilm.longilm.LongIlm;
+
+/**
+ * This interface defines a factory that creates LongIla objects.
+ */
+public interface LongIlmFactory {
+    /**
+     * Create a LongIlm object.
+     *
+     * @return the LongIlm object.
+     */
+    LongIlm create();
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilmf/longilmf/LongIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/longilmf/LongIlmFactory.java
@@ -3,7 +3,7 @@ package tfw.immutable.ilmf.longilmf;
 import tfw.immutable.ilm.longilm.LongIlm;
 
 /**
- * This interface defines a factory that creates LongIla objects.
+ * This interface defines a factory that creates LongIlm objects.
  */
 public interface LongIlmFactory {
     /**

--- a/src/main/java/tfw/immutable/ilmf/objectilmf/ObjectIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/objectilmf/ObjectIlmFactory.java
@@ -3,7 +3,7 @@ package tfw.immutable.ilmf.objectilmf;
 import tfw.immutable.ilm.objectilm.ObjectIlm;
 
 /**
- * This interface defines a factory that creates ObjectIla objects.
+ * This interface defines a factory that creates ObjectIlm objects.
  */
 public interface ObjectIlmFactory<T> {
     /**

--- a/src/main/java/tfw/immutable/ilmf/objectilmf/ObjectIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/objectilmf/ObjectIlmFactory.java
@@ -1,0 +1,16 @@
+package tfw.immutable.ilmf.objectilmf;
+
+import tfw.immutable.ilm.objectilm.ObjectIlm;
+
+/**
+ * This interface defines a factory that creates ObjectIla objects.
+ */
+public interface ObjectIlmFactory<T> {
+    /**
+     * Create a ObjectIlm object.
+     *
+     * @return the ObjectIlm object.
+     */
+    ObjectIlm<T> create();
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilmf/shortilmf/ShortIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/shortilmf/ShortIlmFactory.java
@@ -1,0 +1,16 @@
+package tfw.immutable.ilmf.shortilmf;
+
+import tfw.immutable.ilm.shortilm.ShortIlm;
+
+/**
+ * This interface defines a factory that creates ShortIla objects.
+ */
+public interface ShortIlmFactory {
+    /**
+     * Create a ShortIlm object.
+     *
+     * @return the ShortIlm object.
+     */
+    ShortIlm create();
+}
+// AUTO GENERATED FROM TEMPLATE

--- a/src/main/java/tfw/immutable/ilmf/shortilmf/ShortIlmFactory.java
+++ b/src/main/java/tfw/immutable/ilmf/shortilmf/ShortIlmFactory.java
@@ -3,7 +3,7 @@ package tfw.immutable.ilmf.shortilmf;
 import tfw.immutable.ilm.shortilm.ShortIlm;
 
 /**
- * This interface defines a factory that creates ShortIla objects.
+ * This interface defines a factory that creates ShortIlm objects.
  */
 public interface ShortIlmFactory {
     /**

--- a/src/main/template/tfw/immutable/ilmf/__IlmFactory.template
+++ b/src/main/template/tfw/immutable/ilmf/__IlmFactory.template
@@ -4,7 +4,7 @@ package %%PACKAGE%%;
 import tfw.immutable.ilm.%%LOWER_NAME%%ilm.%%NAME%%Ilm;
 
 /**
- * This interface defines a factory that creates %%NAME%%Ila objects.
+ * This interface defines a factory that creates %%NAME%%Ilm objects.
  */
 public interface %%NAME%%IlmFactory%%TEMPLATE%% {
     /**

--- a/src/main/template/tfw/immutable/ilmf/__IlmFactory.template
+++ b/src/main/template/tfw/immutable/ilmf/__IlmFactory.template
@@ -1,0 +1,16 @@
+// booleanilmf,byteilmf,charilmf,doubleilmf,floatilmf,intilmf,longilmf,objectilmf,shortilmf
+package %%PACKAGE%%;
+
+import tfw.immutable.ilm.%%LOWER_NAME%%ilm.%%NAME%%Ilm;
+
+/**
+ * This interface defines a factory that creates %%NAME%%Ila objects.
+ */
+public interface %%NAME%%IlmFactory%%TEMPLATE%% {
+    /**
+     * Create a %%NAME%%Ilm object.
+     *
+     * @return the %%NAME%%Ilm object.
+     */
+    %%NAME%%Ilm%%TEMPLATE%% create();
+}

--- a/src/main/template/tfw/immutable/ilmf/booleanilmf.mapping
+++ b/src/main/template/tfw/immutable/ilmf/booleanilmf.mapping
@@ -1,0 +1,12 @@
+%%TYPE%% = boolean
+%%NAME%% = Boolean
+%%PACKAGE%% = tfw.immutable.ilmf.booleanilmf
+%%RANDOM_VALUE%% = random.nextBoolean()
+%%ASSERT_EQUALS_DELTA%% =
+%%CREATE_IMMUTABLE_START%% = new Boolean(
+%%CREATE_IMMUTABLE_END%% = )
+%%DIAMOND%% = 
+%%TEMPLATE%% =
+%%TEMPLATE_SPACE%% =
+%%TYPE_OR_TEMPLATE%% = boolean
+%%LOWER_NAME%% = boolean

--- a/src/main/template/tfw/immutable/ilmf/byteilmf.mapping
+++ b/src/main/template/tfw/immutable/ilmf/byteilmf.mapping
@@ -1,0 +1,12 @@
+%%TYPE%% = byte
+%%NAME%% = Byte
+%%PACKAGE%% = tfw.immutable.ilmf.byteilmf
+%%RANDOM_VALUE%% = (byte)random.nextInt()
+%%ASSERT_EQUALS_DELTA%% =
+%%CREATE_IMMUTABLE_START%% = new Byte(
+%%CREATE_IMMUTABLE_END%% = )
+%%DIAMOND%% = 
+%%TEMPLATE%% =
+%%TEMPLATE_SPACE%% =
+%%TYPE_OR_TEMPLATE%% = byte
+%%LOWER_NAME%% = byte

--- a/src/main/template/tfw/immutable/ilmf/charilmf.mapping
+++ b/src/main/template/tfw/immutable/ilmf/charilmf.mapping
@@ -1,0 +1,12 @@
+%%TYPE%% = char
+%%NAME%% = Char
+%%PACKAGE%% = tfw.immutable.ilmf.charilmf
+%%RANDOM_VALUE%% = (char)random.nextInt()
+%%ASSERT_EQUALS_DELTA%% =
+%%CREATE_IMMUTABLE_START%% = new Character(
+%%CREATE_IMMUTABLE_END%% = )
+%%DIAMOND%% = 
+%%TEMPLATE%% =
+%%TEMPLATE_SPACE%% =
+%%TYPE_OR_TEMPLATE%% = char
+%%LOWER_NAME%% = char

--- a/src/main/template/tfw/immutable/ilmf/doubleilmf.mapping
+++ b/src/main/template/tfw/immutable/ilmf/doubleilmf.mapping
@@ -1,0 +1,12 @@
+%%TYPE%% = double
+%%NAME%% = Double
+%%PACKAGE%% = tfw.immutable.ilmf.doubleilmf
+%%RANDOM_VALUE%% = random.nextDouble()
+%%ASSERT_EQUALS_DELTA%% = , 0
+%%CREATE_IMMUTABLE_START%% = new Double(
+%%CREATE_IMMUTABLE_END%% = )
+%%DIAMOND%% = 
+%%TEMPLATE%% =
+%%TEMPLATE_SPACE%% =
+%%TYPE_OR_TEMPLATE%% = double
+%%LOWER_NAME%% = double

--- a/src/main/template/tfw/immutable/ilmf/floatilmf.mapping
+++ b/src/main/template/tfw/immutable/ilmf/floatilmf.mapping
@@ -1,0 +1,12 @@
+%%TYPE%% = float
+%%NAME%% = Float
+%%PACKAGE%% = tfw.immutable.ilmf.floatilmf
+%%RANDOM_VALUE%% = random.nextFloat()
+%%ASSERT_EQUALS_DELTA%% = , 0f
+%%CREATE_IMMUTABLE_START%% = new Float(
+%%CREATE_IMMUTABLE_END%% = )
+%%DIAMOND%% = 
+%%TEMPLATE%% =
+%%TEMPLATE_SPACE%% =
+%%TYPE_OR_TEMPLATE%% = float
+%%LOWER_NAME%% = float

--- a/src/main/template/tfw/immutable/ilmf/intilmf.mapping
+++ b/src/main/template/tfw/immutable/ilmf/intilmf.mapping
@@ -1,0 +1,12 @@
+%%TYPE%% = int
+%%NAME%% = Int
+%%PACKAGE%% = tfw.immutable.ilmf.intilmf
+%%RANDOM_VALUE%% = random.nextInt()
+%%ASSERT_EQUALS_DELTA%% =
+%%CREATE_IMMUTABLE_START%% = new Integer(
+%%CREATE_IMMUTABLE_END%% = )
+%%DIAMOND%% = 
+%%TEMPLATE%% =
+%%TEMPLATE_SPACE%% =
+%%TYPE_OR_TEMPLATE%% = int
+%%LOWER_NAME%% = int

--- a/src/main/template/tfw/immutable/ilmf/longilmf.mapping
+++ b/src/main/template/tfw/immutable/ilmf/longilmf.mapping
@@ -1,0 +1,12 @@
+%%TYPE%% = long
+%%NAME%% = Long
+%%PACKAGE%% = tfw.immutable.ilmf.longilmf
+%%RANDOM_VALUE%% = random.nextLong()
+%%ASSERT_EQUALS_DELTA%% =
+%%CREATE_IMMUTABLE_START%% = new Long(
+%%CREATE_IMMUTABLE_END%% = )
+%%DIAMOND%% = 
+%%TEMPLATE%% =
+%%TEMPLATE_SPACE%% =
+%%TYPE_OR_TEMPLATE%% = long
+%%LOWER_NAME%% = long

--- a/src/main/template/tfw/immutable/ilmf/objectilmf.mapping
+++ b/src/main/template/tfw/immutable/ilmf/objectilmf.mapping
@@ -1,0 +1,12 @@
+%%TYPE%% = Object
+%%NAME%% = Object
+%%PACKAGE%% = tfw.immutable.ilmf.objectilmf
+%%RANDOM_VALUE%% = new Object()
+%%ASSERT_EQUALS_DELTA%% =
+%%CREATE_IMMUTABLE_START%% =
+%%CREATE_IMMUTABLE_END%% =
+%%DIAMOND%% = <>
+%%TEMPLATE%% = <T>
+%%TEMPLATE_SPACE%% = <T>\ 
+%%TYPE_OR_TEMPLATE%% = T
+%%LOWER_NAME%% = object

--- a/src/main/template/tfw/immutable/ilmf/shortilmf.mapping
+++ b/src/main/template/tfw/immutable/ilmf/shortilmf.mapping
@@ -1,0 +1,12 @@
+%%TYPE%% = short
+%%NAME%% = Short
+%%PACKAGE%% = tfw.immutable.ilmf.shortilmf
+%%RANDOM_VALUE%% = (short)random.nextInt()
+%%ASSERT_EQUALS_DELTA%% =
+%%CREATE_IMMUTABLE_START%% = new Short(
+%%CREATE_IMMUTABLE_END%% = )
+%%DIAMOND%% = 
+%%TEMPLATE%% =
+%%TEMPLATE_SPACE%% =
+%%TYPE_OR_TEMPLATE%% = short
+%%LOWER_NAME%% = short


### PR DESCRIPTION
This PR adds IlmFactory interfaces.

## Summary by Sourcery

Introduce Ilm factory interfaces for all supported primitive and object types and wire up template-based code generation in the build.

New Features:
- Add BooleanIlmFactory, ByteIlmFactory, CharIlmFactory, DoubleIlmFactory, FloatIlmFactory, IntIlmFactory, LongIlmFactory, ShortIlmFactory, and generic ObjectIlmFactory interfaces for creating corresponding Ilm instances.

Build:
- Configure exec-maven-plugin to run the SearchAndReplace code generation utility over IlmFactory templates and mappings.
- Add IlmFactory template and mapping files to support generation of the various typed IlmFactory interfaces.