### PR TITLE
Add github-actions to what dependabot checks.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Extend Dependabot configuration to include weekly update checks for the github-actions ecosystem.