### PR TITLE
Add List, Map and Set ECD's

### DIFF
--- a/src/main/java/tfw/tsm/ecd/ListECD.java
+++ b/src/main/java/tfw/tsm/ecd/ListECD.java
@@ -1,0 +1,10 @@
+package tfw.tsm.ecd;
+
+import java.util.List;
+import tfw.value.ClassValueConstraint;
+
+public class ListECD extends ObjectECD {
+    public ListECD(String name) {
+        super(name, ClassValueConstraint.getInstance(List.class));
+    }
+}

--- a/src/main/java/tfw/tsm/ecd/MapECD.java
+++ b/src/main/java/tfw/tsm/ecd/MapECD.java
@@ -3,8 +3,8 @@ package tfw.tsm.ecd;
 import java.util.Map;
 import tfw.value.ClassValueConstraint;
 
-public class MapEcd extends ObjectECD {
-    public MapEcd(String name) {
+public class MapECD extends ObjectECD {
+    public MapECD(String name) {
         super(name, ClassValueConstraint.getInstance(Map.class));
     }
 }

--- a/src/main/java/tfw/tsm/ecd/MapEcd.java
+++ b/src/main/java/tfw/tsm/ecd/MapEcd.java
@@ -1,0 +1,10 @@
+package tfw.tsm.ecd;
+
+import java.util.Map;
+import tfw.value.ClassValueConstraint;
+
+public class MapEcd extends ObjectECD {
+    public MapEcd(String name) {
+        super(name, ClassValueConstraint.getInstance(Map.class));
+    }
+}

--- a/src/main/java/tfw/tsm/ecd/SetECD.java
+++ b/src/main/java/tfw/tsm/ecd/SetECD.java
@@ -1,0 +1,10 @@
+package tfw.tsm.ecd;
+
+import java.util.Set;
+import tfw.value.ClassValueConstraint;
+
+public class SetECD extends ObjectECD {
+    public SetECD(String name) {
+        super(name, ClassValueConstraint.getInstance(Set.class));
+    }
+}

--- a/src/test/java/tfw/tsm/ecd/ListECDTest.java
+++ b/src/test/java/tfw/tsm/ecd/ListECDTest.java
@@ -1,0 +1,20 @@
+package tfw.tsm.ecd;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class ListECDTest {
+    @Test
+    void constructionTest() {
+        assertThatThrownBy(() -> new ListECD(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("eventChannelName == null not allowed!");
+
+        final String testName = "testName";
+        final ListECD listECD = new ListECD(testName);
+
+        assertThat(listECD.getEventChannelName()).isEqualTo(testName);
+    }
+}

--- a/src/test/java/tfw/tsm/ecd/MapECDTest.java
+++ b/src/test/java/tfw/tsm/ecd/MapECDTest.java
@@ -1,0 +1,20 @@
+package tfw.tsm.ecd;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class MapECDTest {
+    @Test
+    void constructionTest() {
+        assertThatThrownBy(() -> new MapECD(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("eventChannelName == null not allowed!");
+
+        final String testName = "testName";
+        final MapECD mapECD = new MapECD(testName);
+
+        assertThat(mapECD.getEventChannelName()).isEqualTo(testName);
+    }
+}

--- a/src/test/java/tfw/tsm/ecd/SetECDTest.java
+++ b/src/test/java/tfw/tsm/ecd/SetECDTest.java
@@ -1,0 +1,20 @@
+package tfw.tsm.ecd;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class SetECDTest {
+    @Test
+    void constructionTest() {
+        assertThatThrownBy(() -> new SetECD(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("eventChannelName == null not allowed!");
+
+        final String testName = "testName";
+        final SetECD setECD = new SetECD(testName);
+
+        assertThat(setECD.getEventChannelName()).isEqualTo(testName);
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Add new entity coordinate definitions for standard Java collection types.

New Features:
- Introduce ListECD for List-typed object coordinates.
- Introduce MapEcd for Map-typed object coordinates.
- Introduce SetECD for Set-typed object coordinates.