### PR TITLE
Add ComponentEnum, associated classes and tests.

### DIFF
--- a/src/main/java/tfw/tsm/AbstractComponentEnum.java
+++ b/src/main/java/tfw/tsm/AbstractComponentEnum.java
@@ -1,0 +1,31 @@
+package tfw.tsm;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+public abstract class AbstractComponentEnum<T extends TreeComponent> extends DefaultComponentConfig<T>
+        implements ComponentEnum<T> {
+    private static final Map<Class<?>, List<Object>> REGISTRY = new ConcurrentHashMap<>();
+
+    protected AbstractComponentEnum(T component) {
+        super(component);
+
+        REGISTRY.computeIfAbsent(this.getClass(), k -> new CopyOnWriteArrayList<>())
+                .add(this);
+    }
+
+    public static <T extends AbstractComponentEnum<? extends TreeComponent>> List<T> valuesFromClass(
+            Class<T> enumClass) {
+        List<Object> list = REGISTRY.get(enumClass);
+
+        if (list == null) {
+            return Collections.emptyList();
+        }
+
+        return list.stream().map(enumClass::cast).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/tfw/tsm/ComponentConfig.java
+++ b/src/main/java/tfw/tsm/ComponentConfig.java
@@ -1,0 +1,5 @@
+package tfw.tsm;
+
+public interface ComponentConfig<T extends TreeComponent> {
+    T getComponent();
+}

--- a/src/main/java/tfw/tsm/ComponentEnum.java
+++ b/src/main/java/tfw/tsm/ComponentEnum.java
@@ -1,0 +1,3 @@
+package tfw.tsm;
+
+public interface ComponentEnum<T extends TreeComponent> extends ComponentConfig<T> {}

--- a/src/main/java/tfw/tsm/DefaultComponentConfig.java
+++ b/src/main/java/tfw/tsm/DefaultComponentConfig.java
@@ -1,0 +1,18 @@
+package tfw.tsm;
+
+import tfw.check.Arguments;
+
+public class DefaultComponentConfig<T extends TreeComponent> implements ComponentConfig<T> {
+    public final T component;
+
+    public DefaultComponentConfig(final T component) {
+        Arguments.checkNotNull(component, "component");
+
+        this.component = component;
+    }
+
+    @Override
+    public T getComponent() {
+        return component;
+    }
+}

--- a/src/test/java/tfw/tsm/AbstractComponentEnumTest.java
+++ b/src/test/java/tfw/tsm/AbstractComponentEnumTest.java
@@ -1,0 +1,59 @@
+package tfw.tsm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tfw.tsm.ecd.ObjectECD;
+
+class AbstractComponentEnumTest {
+    @Test
+    void testValues() {
+        List<ComponentEnum<?>> channels = TestComponentEnum.values();
+
+        assertThat(channels).hasSize(2);
+        assertThat(channels.get(0)).isEqualTo(TestComponentEnum.INITIATOR1);
+        assertThat(channels.get(1)).isEqualTo(TestComponentEnum.INITIATOR2);
+    }
+
+    static class TestComponentEnum<T extends TreeComponent> extends AbstractComponentEnum<T> {
+        public static final TestComponentEnum<Initiator> INITIATOR1 = new TestComponentEnum<>(Initiator.builder()
+                .setName("test1")
+                .addEventChannelDescription(new ObjectECD("test1"))
+                .build());
+        public static final TestComponentEnum<Initiator> INITIATOR2 = new TestComponentEnum<>(Initiator.builder()
+                .setName("test2")
+                .addEventChannelDescription(new ObjectECD("test2"))
+                .build());
+
+        public TestComponentEnum(T component) {
+            super(component);
+        }
+
+        @SuppressWarnings("unchecked")
+        public static List<ComponentEnum<?>> values() {
+            return valuesFromClass(TestComponentEnum.class);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testValuesFromClassWhenNoInstances() {
+        // Call valuesFromClass on a class that has no instances registered
+        List<UnregisteredComponentEnum<?>> result =
+                AbstractComponentEnum.valuesFromClass(UnregisteredComponentEnum.class);
+
+        assertThat(result).isEmpty();
+    }
+
+    static class UnregisteredComponentEnum<T extends TreeComponent> extends AbstractComponentEnum<T> {
+        public UnregisteredComponentEnum(T component) {
+            super(component);
+        }
+
+        @SuppressWarnings("unchecked")
+        public static List<EventChannelEnum<?>> values() {
+            return valuesFromClass(UnregisteredComponentEnum.class);
+        }
+    }
+}

--- a/src/test/java/tfw/tsm/DefaultComponentConfigTest.java
+++ b/src/test/java/tfw/tsm/DefaultComponentConfigTest.java
@@ -1,0 +1,29 @@
+package tfw.tsm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tfw.tsm.ecd.ObjectECD;
+
+class DefaultComponentConfigTest {
+    @Test
+    void testDefaultComponentConfig() {
+        final ObjectECD ecd = new ObjectECD("testECD");
+        final Initiator initiator = Initiator.builder()
+                .setName("testInitiator")
+                .addEventChannelDescription(ecd)
+                .build();
+
+        DefaultComponentConfig<Initiator> config = new DefaultComponentConfig<>(initiator);
+
+        assertThat(initiator).isEqualTo(config.getComponent());
+    }
+
+    @Test
+    void testValidation() {
+        assertThatThrownBy(() -> new DefaultComponentConfig<>(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("component");
+    }
+}

--- a/src/test/java/tfw/tsm/DefaultComponentConfigTest.java
+++ b/src/test/java/tfw/tsm/DefaultComponentConfigTest.java
@@ -17,7 +17,7 @@ class DefaultComponentConfigTest {
 
         DefaultComponentConfig<Initiator> config = new DefaultComponentConfig<>(initiator);
 
-        assertThat(initiator).isEqualTo(config.getComponent());
+        assertThat(config.getComponent()).isSameAs(initiator);
     }
 
     @Test


### PR DESCRIPTION
## Summary by Sourcery

Introduce a configurable component enumeration abstraction with shared configuration support.

New Features:
- Add ComponentConfig and DefaultComponentConfig to wrap and validate TreeComponent instances.
- Add ComponentEnum and AbstractComponentEnum to provide an enum-like registry for TreeComponent-based components.

Tests:
- Add tests for DefaultComponentConfig validation and component access.
- Add tests verifying AbstractComponentEnum registration, value retrieval, and behavior when no instances are registered.