### PR TITLE
Added CycloneDX maven plugin to create SBOM.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <maven.compiler.release>8</maven.compiler.release>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <plugin.cyclonedx-maven-plugin.version>2.9.2</plugin.cyclonedx-maven-plugin.version>
         <plugin.error-prone-contrib.version>0.30.0</plugin.error-prone-contrib.version>
         <plugin.error_prone_core.version>2.50.0</plugin.error_prone_core.version>
         <plugin.errorprone-slf4j.version>0.1.29</plugin.errorprone-slf4j.version>
@@ -331,6 +332,19 @@
                         <argument>${project.basedir}/src/test/template</argument>
                     </arguments>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${plugin.cyclonedx-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Configure the CycloneDX Maven plugin with a pinned version and bind it to the package phase to generate an aggregate SBOM.