### PR TITLE
Enable dependency check.

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           # Fail the build if a vulnerability is moderate, high, or critical
-          fail-on-severity: moderate
+          # fail-on-severity: moderate
           # warn-only: true 
          
           # Optional: Prevent merging unapproved licenses

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,8 +18,8 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           # Fail the build if a vulnerability is moderate, high, or critical
-          # fail-on-severity: moderate
-          warn-only: true 
+          fail-on-severity: moderate
+          # warn-only: true 
          
           # Optional: Prevent merging unapproved licenses
           allow-licenses: MIT


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure dependency-review GitHub Action to fail the workflow on moderate or higher vulnerabilities instead of only warning.