### PR TITLE
Fix CodeQL build-mode to avoid "undefined" warning.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
         # queries: security-extended,security-and-quality
 
         # Explicitly set build-mode to avoid 'undefined' warning
-        build-mode: none 
+        build-mode: none
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,6 +60,8 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
+        # Explicitly set build-mode to avoid 'undefined' warning
+        build-mode: none 
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure CodeQL workflow to use an explicit `build-mode: none` to prevent undefined build-mode warnings during analysis.