### PR TITLE
Fix Scorecard.yml read-all permissions warning.

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,7 +15,8 @@ on:
     branches: [ "master" ]
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:
@@ -29,8 +30,8 @@ jobs:
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
       # Uncomment the permissions below if installing in a private repository.
-      # contents: read
-      # actions: read
+      contents: read
+      actions: read
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
## Summary by Sourcery

Update the Scorecard GitHub Actions workflow permissions to satisfy the latest security and configuration requirements.

CI:
- Replace the deprecated top-level read-all permission with explicit contents: read in the Scorecard workflow.
- Grant explicit contents: read and actions: read permissions to the analysis job to support publishing results and badges.