### PR TITLE
Restrict top-level permissions in codeql.yml.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '29 15 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set explicit read-only contents permissions for the CodeQL GitHub Actions workflow.