### PR TITLE
Add top-level permissions to maven.yml.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Declare read-only contents permission at the workflow level for the Maven CI pipeline.