### PR TITLE
Restrict top-level permissions for release.yml.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: Release to Maven Central
 on:
   release:
     types: [created]
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -23,4 +27,3 @@ jobs:
           MVN_USERNAME: ${{ secrets.MVN_USERNAME }}
           MVN_PASSWORD: ${{ secrets.MVN_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Limit the release workflow's top-level permissions to read-only access on repository contents.