### PR TITLE
Restrict top-level permissions in security-scan.yml.

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   security-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set explicit read-only contents permissions for the security-scan GitHub Actions workflow.