### PR TITLE
Restrict top permissions in sonar.yml.

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Set top-level workflow permissions in sonar.yml to contents: read for GitHub Actions.